### PR TITLE
fix(resume): detect conversation UUID via path fallback when tmux is dead

### DIFF
--- a/session/history_detector.go
+++ b/session/history_detector.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/tstapler/stapler-squad/session/procinfo"
@@ -26,11 +27,27 @@ type ProcessFileInspector interface {
 // HistoryFileDetector detects Claude JSONL history files for a given process.
 type HistoryFileDetector struct {
 	inspector ProcessFileInspector
+	// homeDir overrides os.UserHomeDir() when set. Used in tests.
+	homeDir string
 }
 
 // NewHistoryFileDetector creates a new HistoryFileDetector.
 func NewHistoryFileDetector(inspector ProcessFileInspector) *HistoryFileDetector {
 	return &HistoryFileDetector{inspector: inspector}
+}
+
+// NewHistoryFileDetectorWithHomeDir creates a HistoryFileDetector with a fixed
+// home directory. Use this in tests to avoid writing to the real home dir.
+func NewHistoryFileDetectorWithHomeDir(inspector ProcessFileInspector, homeDir string) *HistoryFileDetector {
+	return &HistoryFileDetector{inspector: inspector, homeDir: homeDir}
+}
+
+// resolveHomeDir returns homeDir if set, otherwise os.UserHomeDir().
+func (d *HistoryFileDetector) resolveHomeDir() (string, error) {
+	if d.homeDir != "" {
+		return d.homeDir, nil
+	}
+	return os.UserHomeDir()
 }
 
 // claudeProjectsPattern matches ~/.claude/projects/<projectDir>/<uuid>.jsonl
@@ -46,7 +63,7 @@ func (d *HistoryFileDetector) Detect(pid int32) (*HistoryFileInfo, error) {
 		return nil, nil //nolint:nilnil
 	}
 
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := d.resolveHomeDir()
 	if err != nil {
 		return nil, err
 	}
@@ -91,6 +108,83 @@ func (d *HistoryFileDetector) Detect(pid int32) (*HistoryFileInfo, error) {
 	}
 
 	return nil, nil //nolint:nilnil
+}
+
+// ClaudeProjectDirName returns the directory name Claude uses for a given
+// absolute project path. Claude encodes the path by replacing every '/' with '-'.
+// Example: "/Users/alice/myproject" → "-Users-alice-myproject"
+func ClaudeProjectDirName(projectPath string) string {
+	return strings.ReplaceAll(projectPath, "/", "-")
+}
+
+// DetectByPath scans ~/.claude/projects/<encoded-path>/ for the most recently
+// modified conversation JSONL file. It does NOT require a live process, making
+// it suitable for sessions whose tmux session is dead (e.g. after a reboot).
+//
+// Returns nil, nil if the project directory does not exist or contains no
+// valid conversation files.
+func (d *HistoryFileDetector) DetectByPath(projectPath string) (*HistoryFileInfo, error) {
+	homeDir, err := d.resolveHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	projectDir := ClaudeProjectDirName(projectPath)
+	dir := filepath.Join(homeDir, ".claude", "projects", projectDir)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Directory doesn't exist — not an error.
+		return nil, nil //nolint:nilnil
+	}
+
+	type candidate struct {
+		uuid    string
+		path    string
+		modTime int64
+	}
+	var candidates []candidate
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		basename := strings.TrimSuffix(name, ".jsonl")
+		if strings.HasPrefix(basename, "agent-") {
+			continue
+		}
+		if !isValidUUID(basename) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			uuid:    basename,
+			path:    filepath.Join(dir, name),
+			modTime: info.ModTime().UnixNano(),
+		})
+	}
+
+	if len(candidates) == 0 {
+		return nil, nil //nolint:nilnil
+	}
+
+	// Pick the most recently modified file — that's the active conversation.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].modTime > candidates[j].modTime
+	})
+	best := candidates[0]
+	return &HistoryFileInfo{
+		ConversationUUID: best.uuid,
+		HistoryFilePath:  best.path,
+		ProjectDir:       projectDir,
+	}, nil
 }
 
 // NewHistoryFileDetectorWithRealInspector creates a HistoryFileDetector using

--- a/session/history_detector_test.go
+++ b/session/history_detector_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -149,6 +150,74 @@ func TestHistoryFileDetector_ProcessDeadReturnsNilNil(t *testing.T) {
 	// Dead process: no error propagated, nil info
 	require.NoError(t, err)
 	assert.Nil(t, info)
+}
+
+func TestClaudeProjectDirName(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/Users/alice/myproject", "-Users-alice-myproject"},
+		{"/Users/alice/my-project", "-Users-alice-my-project"},
+		{"/home/bob/work/stapler", "-home-bob-work-stapler"},
+	}
+	for _, c := range cases {
+		got := ClaudeProjectDirName(c.path)
+		assert.Equal(t, c.want, got, "path: %s", c.path)
+	}
+}
+
+func TestHistoryFileDetector_DetectByPath_MissingDirReturnsNil(t *testing.T) {
+	tmpHome := t.TempDir()
+	detector := NewHistoryFileDetectorWithHomeDir(nil, tmpHome)
+	info, err := detector.DetectByPath("/nonexistent/path/xyz123abc")
+	require.NoError(t, err)
+	assert.Nil(t, info)
+}
+
+func TestHistoryFileDetector_DetectByPath_FiltersAgentFiles(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectPath := "/Users/alice/agenttest"
+	projectDir := ClaudeProjectDirName(projectPath)
+	dir := filepath.Join(tmpHome, ".claude", "projects", projectDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	// Only an agent file — should be filtered.
+	agentFile := filepath.Join(dir, "agent-abc123.jsonl")
+	require.NoError(t, os.WriteFile(agentFile, []byte("{}"), 0o644))
+
+	detector := NewHistoryFileDetectorWithHomeDir(nil, tmpHome)
+	info, err := detector.DetectByPath(projectPath)
+	require.NoError(t, err)
+	assert.Nil(t, info, "agent-*.jsonl files should be excluded")
+}
+
+func TestHistoryFileDetector_DetectByPath_PicksMostRecentWhenMultiple(t *testing.T) {
+	tmpHome := t.TempDir()
+	projectPath := "/Users/alice/multitest"
+	projectDir := ClaudeProjectDirName(projectPath)
+	dir := filepath.Join(tmpHome, ".claude", "projects", projectDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	uuid1 := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	uuid2 := "11111111-2222-3333-4444-555555555555"
+	p1 := filepath.Join(dir, uuid1+".jsonl")
+	p2 := filepath.Join(dir, uuid2+".jsonl")
+
+	require.NoError(t, os.WriteFile(p1, []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(p2, []byte("{}"), 0o644))
+
+	// Make p2 strictly newer using os.Chtimes with explicit times.
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now()
+	require.NoError(t, os.Chtimes(p1, past, past))
+	require.NoError(t, os.Chtimes(p2, future, future))
+
+	detector := NewHistoryFileDetectorWithHomeDir(nil, tmpHome)
+	info, err := detector.DetectByPath(projectPath)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, uuid2, info.ConversationUUID, "should return most recently modified file")
 }
 
 func TestHistoryFileDetector_Detect_ReturnsFirstMatch(t *testing.T) {

--- a/session/history_linker.go
+++ b/session/history_linker.go
@@ -159,20 +159,27 @@ func (hl *HistoryLinker) correlateSession(inst *Instance) {
 		return
 	}
 
-	// Need an alive tmux session to inspect its foreground process.
+	var info *HistoryFileInfo
+
+	// Fast path: inspect open files of the live tmux pane process.
 	pid, err := inst.GetPanePID()
-	if err != nil {
-		// Session dead or not started yet — normal, not an error.
-		return
+	if err == nil {
+		info, err = hl.detector.Detect(pid)
+		if err != nil {
+			log.WarningLog.Printf("HistoryLinker: detect error for '%s' (pid=%d): %v", inst.Title, pid, err)
+		}
 	}
 
-	info, err := hl.detector.Detect(pid)
-	if err != nil {
-		log.WarningLog.Printf("HistoryLinker: detect error for '%s' (pid=%d): %v", inst.Title, pid, err)
-		return
+	// Fallback: scan the project directory by path (works after reboot / tmux kill).
+	if info == nil && inst.Path != "" {
+		info, err = hl.detector.DetectByPath(inst.Path)
+		if err != nil {
+			log.WarningLog.Printf("HistoryLinker: path-based detect error for '%s': %v", inst.Title, err)
+		}
 	}
+
 	if info == nil {
-		return // No JSONL open yet.
+		return // No JSONL found yet.
 	}
 
 	log.InfoLog.Printf("HistoryLinker: linked '%s' → conv UUID %s", inst.Title, info.ConversationUUID)

--- a/session/instance.go
+++ b/session/instance.go
@@ -158,6 +158,10 @@ type Instance struct {
 	// Set by HistoryLinker when it correlates this session to an open JSONL file.
 	HistoryFilePath string
 
+	// historyDetector is used by tryExtractConversationUUID. When nil the
+	// production inspector is used. Set in tests to inject a fake home dir.
+	historyDetector *HistoryFileDetector
+
 	// Claude Code session information for persistence and re-attachment
 	claudeSession *ClaudeSessionData
 
@@ -1921,26 +1925,39 @@ func (i *Instance) tryExtractConversationUUID() {
 		return
 	}
 
-	// Need an alive tmux session to get the pane PID.
-	if !i.tmuxManager.DoesSessionExist() {
-		log.DebugLog.Printf("tryExtractConversationUUID: tmux session not alive for '%s'", i.Title)
-		return
+	detector := i.historyDetector
+	if detector == nil {
+		detector = NewHistoryFileDetectorWithRealInspector()
+	}
+	var info *HistoryFileInfo
+
+	// Fast path: inspect open files of the live tmux pane process.
+	if i.tmuxManager.DoesSessionExist() {
+		pid, err := i.tmuxManager.GetPanePID()
+		if err != nil {
+			log.DebugLog.Printf("tryExtractConversationUUID: could not get pane PID for '%s': %v", i.Title, err)
+		} else {
+			info, err = detector.Detect(pid)
+			if err != nil {
+				log.WarningLog.Printf("tryExtractConversationUUID: detect error for '%s' (pid=%d): %v", i.Title, pid, err)
+			}
+		}
 	}
 
-	pid, err := i.tmuxManager.GetPanePID()
-	if err != nil {
-		log.DebugLog.Printf("tryExtractConversationUUID: could not get pane PID for '%s': %v", i.Title, err)
-		return
+	// Fallback: scan the project directory by path (works after reboot / tmux kill).
+	if info == nil && i.Path != "" {
+		var err error
+		info, err = detector.DetectByPath(i.Path)
+		if err != nil {
+			log.WarningLog.Printf("tryExtractConversationUUID: path-based detect error for '%s': %v", i.Title, err)
+		}
+		if info != nil {
+			log.InfoLog.Printf("tryExtractConversationUUID: found conversation via path fallback for '%s'", i.Title)
+		}
 	}
 
-	detector := NewHistoryFileDetectorWithRealInspector()
-	info, err := detector.Detect(pid)
-	if err != nil {
-		log.WarningLog.Printf("tryExtractConversationUUID: detect error for '%s' (pid=%d): %v", i.Title, pid, err)
-		return
-	}
 	if info == nil {
-		log.DebugLog.Printf("tryExtractConversationUUID: no JSONL file found for '%s' (pid=%d)", i.Title, pid)
+		log.DebugLog.Printf("tryExtractConversationUUID: no JSONL file found for '%s'", i.Title)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Sessions that have been paused or survive a reboot lose their tmux pane, so the previous PID-based history detection silently skipped UUID extraction. This meant `--resume` was never passed on restart. The fix adds a filesystem fallback that scans `~/.claude/projects/<encoded-path>/` directly, no live process required.

## Changes

- **`session/history_detector.go`** — Added `DetectByPath(projectPath)`: scans the Claude projects directory for the most recently modified conversation JSONL without needing a live PID. Added `ClaudeProjectDirName` helper and `NewHistoryFileDetectorWithHomeDir` for test injection.
- **`session/history_linker.go`** — `linkHistory` now tries PID detection first, then falls back to `DetectByPath` when no result.
- **`session/instance.go`** — `tryExtractConversationUUID` follows the same two-path logic. Added `historyDetector` field for test injection.
- **`session/history_detector_test.go`** — New tests covering `DetectByPath` and `ClaudeProjectDirName`.

## Test plan

- [x] `go test ./session/...` — all 1421 tests pass
- [x] Manual: pause a session, kill tmux manually, restart stapler-squad → session resumes with `--resume <uuid>`
