### PR TITLE
fix(resume): persist Claude session IDs across restarts

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -44,9 +44,9 @@ func NewBridge() *Bridge {
 	log.InfoLog.Printf("Navigation commands - up: %v, down: %v", upCmd != nil, downCmd != nil)
 
 	bridge := &Bridge{
-		registry:           registry,
-		config:             cfg,
-		contextStack:       []ContextID{ContextGlobal}, // Start with global context
+		registry:     registry,
+		config:       cfg,
+		contextStack: []ContextID{ContextGlobal}, // Start with global context
 
 		keyCategoriesCache: make(map[ContextID]map[string][]string),
 	}

--- a/main.go
+++ b/main.go
@@ -49,7 +49,21 @@ var (
 		Use:   "stapler-squad",
 		Short: "Stapler Squad - Manage multiple AI agents like Claude Code, Aider, Codex, and Amp (Web Mode)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// Graceful shutdown on SIGTERM (pkill from Makefile) and SIGINT (Ctrl+C).
+			// cancel() triggers srv.Shutdown() which runs the shutdown hooks that persist
+			// session state (including Claude session IDs for --resume on next start).
+			sigChan := make(chan os.Signal, 1)
+			signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
+			defer signal.Stop(sigChan)
+			go func() {
+				sig := <-sigChan
+				log.InfoLog.Printf("Received signal %v, initiating graceful shutdown", sig)
+				log.LogSessionPathsToStderr()
+				cancel()
+			}()
 
 			// Enable test mode if flag is set
 			if testModeFlag {
@@ -878,18 +892,6 @@ func startRemoteAccess(ctx context.Context, srv *server.Server, localAddr string
 }
 
 func main() {
-	// Set up signal handling for SIGTERM only (not SIGINT/Ctrl+C)
-	// We only intercept SIGTERM for forced termination (e.g., systemd, docker)
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGTERM) // Only SIGTERM, not os.Interrupt
-
-	go func() {
-		<-c
-		log.InfoLog.Printf("Received SIGTERM, forcing exit")
-		log.LogSessionPathsToStderr()
-		os.Exit(1)
-	}()
-
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 	}

--- a/session/detection/ratelimit/detector_test.go
+++ b/session/detection/ratelimit/detector_test.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -170,9 +171,9 @@ func TestScheduler_ScheduleRecovery(t *testing.T) {
 	scheduler := NewScheduler("test-session")
 	scheduler.SetBuffer(1)
 
-	var executed bool
+	var executed atomic.Bool
 	scheduler.SetRecoveryCallback(func() error {
-		executed = true
+		executed.Store(true)
 		return nil
 	})
 
@@ -185,7 +186,7 @@ func TestScheduler_ScheduleRecovery(t *testing.T) {
 
 	time.Sleep(1500 * time.Millisecond)
 
-	if !executed {
+	if !executed.Load() {
 		t.Error("expected recovery callback to be executed")
 	}
 }

--- a/session/history_detector.go
+++ b/session/history_detector.go
@@ -111,10 +111,21 @@ func (d *HistoryFileDetector) Detect(pid int32) (*HistoryFileInfo, error) {
 }
 
 // ClaudeProjectDirName returns the directory name Claude uses for a given
-// absolute project path. Claude encodes the path by replacing every '/' with '-'.
-// Example: "/Users/alice/myproject" → "-Users-alice-myproject"
+// absolute project path. Claude encodes the path by replacing every non-alphanumeric
+// character with '-'. This includes '/', '.', '_', and any other non-word characters.
+// Example: "/Users/alice/myproject"          → "-Users-alice-myproject"
+// Example: "/Users/alice/.hidden/my_project" → "-Users-alice--hidden-my-project"
 func ClaudeProjectDirName(projectPath string) string {
-	return strings.ReplaceAll(projectPath, "/", "-")
+	result := make([]byte, len(projectPath))
+	for i := 0; i < len(projectPath); i++ {
+		c := projectPath[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			result[i] = c
+		} else {
+			result[i] = '-'
+		}
+	}
+	return string(result)
 }
 
 // DetectByPath scans ~/.claude/projects/<encoded-path>/ for the most recently

--- a/session/history_detector_test.go
+++ b/session/history_detector_test.go
@@ -160,6 +160,13 @@ func TestClaudeProjectDirName(t *testing.T) {
 		{"/Users/alice/myproject", "-Users-alice-myproject"},
 		{"/Users/alice/my-project", "-Users-alice-my-project"},
 		{"/home/bob/work/stapler", "-home-bob-work-stapler"},
+		// Dots must be replaced (e.g. hidden dirs like .stapler-squad)
+		{"/Users/alice/.hidden/project", "-Users-alice--hidden-project"},
+		// Underscores must be replaced (e.g. worktree suffix like _18a6509d1eaa86b8)
+		{"/Users/alice/my_project", "-Users-alice-my-project"},
+		// Real-world worktree path: both dot and underscore in same path
+		{"/Users/tylerstapler/.stapler-squad/workspaces/a21d754799a5c839/worktrees/claude-squad-resume-not-working_18a6509d1eaa86b8",
+			"-Users-tylerstapler--stapler-squad-workspaces-a21d754799a5c839-worktrees-claude-squad-resume-not-working-18a6509d1eaa86b8"},
 	}
 	for _, c := range cases {
 		got := ClaudeProjectDirName(c.path)

--- a/session/history_linker.go
+++ b/session/history_linker.go
@@ -182,7 +182,8 @@ func (hl *HistoryLinker) correlateSession(inst *Instance) {
 	}
 
 	if info == nil {
-		return // No JSONL found yet.
+		log.DebugLog.Printf("HistoryLinker: no JSONL found for '%s' (path=%q)", inst.Title, inst.Path)
+		return
 	}
 
 	log.InfoLog.Printf("HistoryLinker: linked '%s' → conv UUID %s", inst.Title, info.ConversationUUID)


### PR DESCRIPTION
## Summary

Sessions never resumed their prior Claude conversation because session state (including Claude conversation UUIDs needed for `--resume`) was never persisted to disk. Three independent root causes combined to produce the failure.

## Changes

**`main.go`** — SIGTERM handler called `os.Exit(1)`, bypassing shutdown hooks entirely. The server context was `context.Background()` (non-cancellable), so `srv.Shutdown()` and its `SaveInstances` hook never ran. `make restart-web` uses `pkill` which sends SIGTERM → hard exit → all in-memory session state lost.

Fix: make context cancellable; signal goroutine calls `cancel()` instead of `os.Exit(1)`, triggering graceful shutdown → `SaveInstances` persists session state including Claude UUIDs.

**`session/history_detector.go`** — `ClaudeProjectDirName()` only replaced `/` → `-`, but Claude CLI replaces **all non-alphanumeric characters** with `-`. Paths with `.` (e.g. `.stapler-squad`) or `_` (e.g. worktree suffix `_18a6509d1eaa86b8`) produced wrong directory names. `DetectByPath()` silently looked in a non-existent directory and returned nil on every 5s poll — UUID never detected, never saved.

Fix: replace any non-alphanumeric byte with `-`, matching Claude's actual encoding. Verified against real `~/.claude/projects/` directory names on disk.

**`session/history_detector_test.go`** — Tests only covered paths with no dots or underscores, so the encoding bug had zero test coverage. Added three new cases including the exact real-world worktree path.

**`session/history_linker.go`** — `correlateSession()` logged nothing when detection found nothing, making the failure completely invisible. Added debug-level log showing instance name and path on miss.

## Test plan

- [x] `TestClaudeProjectDirName` passes with new cases covering `.` and `_` in paths
- [x] Verified encoded path matches actual `~/.claude/projects/` directory name on disk
- [x] `make quick-check` passes (22 session tests green)
- [ ] Deploy and confirm `HistoryLinker: linked '<session>' → conv UUID <uuid>` appears in logs
- [ ] Restart server via `make restart-web` and confirm sessions start with `--resume <uuid>` flag