### PR TITLE
feat(omnibar): two-phase fuzzy search — session discovery + DirCache

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -44,9 +44,9 @@ func NewBridge() *Bridge {
 	log.InfoLog.Printf("Navigation commands - up: %v, down: %v", upCmd != nil, downCmd != nil)
 
 	bridge := &Bridge{
-		registry:           registry,
-		config:             cfg,
-		contextStack:       []ContextID{ContextGlobal}, // Start with global context
+		registry:     registry,
+		config:       cfg,
+		contextStack: []ContextID{ContextGlobal}, // Start with global context
 
 		keyCategoriesCache: make(map[ContextID]map[string][]string),
 	}

--- a/docs/tasks/omni-bar-session-search.md
+++ b/docs/tasks/omni-bar-session-search.md
@@ -1,0 +1,1102 @@
+# Implementation Plan: Omni Bar Session Search
+
+Status: Ready for Implementation
+Created: 2026-04-14
+Branch: claude-squad-better-search-fuzzy
+MDD Spec: `project_plans/omni-bar-session-search/`
+
+---
+
+## Epic Overview
+
+**User value:** Reach any existing session via the Omnibar in 3 keystrokes or fewer after Cmd+K; start a new session on any previously-used repo in 5 keystrokes or fewer.
+
+**Success metrics:**
+- Path completion results appear in <100ms on cache hit (repeated open); <500ms cold
+- Session search results update on every keypress with no perceptible delay (<16ms)
+- Zero new RPC endpoints for session search (client-side only)
+- Zero proto changes
+
+**Scope — Must Have:**
+1. Session navigation — fuzzy search existing sessions from Omnibar; selecting navigates to that session
+2. Recent repos quick-pick — frecent paths shown in empty state; selecting pre-fills path for new session creation
+3. Fuzzy matching quality — Fuse.js multi-field weighted session search
+4. Directory tree cache — stateful `DirCache` in `PathCompletionService` with mtime + TTL invalidation
+
+**Out of scope:**
+- Global OS-level hotkey (system-wide Cmd+K)
+- AI/LLM suggestions
+- Non-session navigation (Settings, Help, etc.)
+- Mobile/responsive layout
+- Remote path support (SSH, network mounts)
+- Disk-backed cache persistence
+- Worktree list caching (lower priority; separate follow-up)
+
+---
+
+## Dependency Diagram
+
+```
+Story 1: Go Directory Cache (backend)
+    |
+    | (independent — ship any time)
+    |
+Story 2: Detector + usePathHistory Fixes (frontend plumbing)
+    |
+    +---> Story 3: useSessionSearch hook
+              |
+              +---> Story 4: OmnibarResultList UI components
+                        |
+                        +---> Story 5: Omnibar Two-Phase Integration (wires everything)
+```
+
+Stories 1 and 2 are fully independent and can be worked in parallel. Story 3 depends on Story 2 (needs `InputType.SessionSearch`). Story 4 depends on Story 3 (needs the hook's return type to define component props). Story 5 depends on Stories 2, 3, and 4.
+
+---
+
+## Story 1: Go Directory Cache
+
+**Value:** Eliminates redundant `os.ReadDir` calls on every Omnibar open. Meets the <100ms repeated-open requirement.
+
+**Files:**
+- `server/services/dir_cache.go` — new file, `DirCache` struct
+- `server/services/path_completion_service.go` — add `cache *DirCache` field, wrap ReadDir call
+
+### Task 1.1 — Implement DirCache
+
+**File:** `server/services/dir_cache.go` (new)
+
+**What to build:**
+
+```go
+package services
+
+import (
+    "os"
+    "sync"
+    "time"
+)
+
+type dirCacheEntry struct {
+    entries  []os.DirEntry
+    dirMtime time.Time
+    cachedAt time.Time
+}
+
+type DirCache struct {
+    mu      sync.RWMutex
+    entries map[string]*dirCacheEntry
+    maxSize int
+    ttl     time.Duration
+}
+
+func NewDirCache(maxSize int, ttl time.Duration) *DirCache {
+    return &DirCache{
+        entries: make(map[string]*dirCacheEntry, maxSize),
+        maxSize: maxSize,
+        ttl:     ttl,
+    }
+}
+
+// Get returns cached DirEntry slice for path if it is still valid.
+// Validity: cachedAt within TTL AND directory mtime unchanged.
+// Returns (nil, false) on miss, stale TTL, or changed mtime.
+func (c *DirCache) Get(path string) ([]os.DirEntry, bool) { ... }
+
+// Put stores entries for path. Evicts oldest entry when at maxSize.
+func (c *DirCache) Put(path string, entries []os.DirEntry, dirMtime time.Time) { ... }
+
+// evictOldest removes the entry with the oldest cachedAt. Caller holds write lock.
+func (c *DirCache) evictOldest() { ... }
+```
+
+**Implementation notes:**
+- `Get`: acquire read lock, check entry exists; if not, return miss. Check `time.Since(entry.cachedAt) > c.ttl` — return miss if expired. Call `os.Stat(path)` to get current mtime; if `info.ModTime().After(entry.dirMtime)` return miss (delete entry under write lock). Otherwise return entries.
+- `Put`: acquire write lock, if `len(c.entries) >= c.maxSize` call `evictOldest()`. Store new entry.
+- `evictOldest`: O(n) scan to find entry with smallest `cachedAt`. Acceptable at n=256.
+- No goroutines; no background cleanup; all operations are on-demand.
+
+**Tests to write** (`server/services/dir_cache_test.go`):
+1. `TestDirCache_Hit` — Put then Get returns same entries
+2. `TestDirCache_MissOnMtimeChange` — Put, then simulate mtime change via temp dir, Get returns miss
+3. `TestDirCache_MissOnTTLExpiry` — Put with 1ms TTL, sleep, Get returns miss
+4. `TestDirCache_Eviction` — Fill to maxSize, add one more, total entries stays at maxSize
+5. `TestDirCache_ConcurrentReads` — 10 goroutines Get simultaneously after one Put, no data race (run with `-race`)
+
+**INVEST:** Independent (no frontend dependency), Negotiable (eviction policy), Valuable (hits <100ms target), Estimable (1-2 hours), Small (single file + test file), Testable (all behaviors have unit tests).
+
+---
+
+### Task 1.2 — Wire DirCache into PathCompletionService
+
+**File:** `server/services/path_completion_service.go`
+
+**Changes:**
+
+1. Change struct definition:
+```go
+// Before
+type PathCompletionService struct{}
+
+// After
+type PathCompletionService struct {
+    cache *DirCache
+}
+```
+
+2. Change constructor:
+```go
+// Before
+func NewPathCompletionService() *PathCompletionService {
+    return &PathCompletionService{}
+}
+
+// After
+func NewPathCompletionService() *PathCompletionService {
+    return &PathCompletionService{
+        cache: NewDirCache(256, 60*time.Second),
+    }
+}
+```
+
+3. In `ListPathCompletions`, after the `baseDirExists` check (line 76), capture mtime from the existing `baseDirInfo`:
+```go
+// baseDirInfo is already computed above (line 67-68)
+dirMtime := baseDirInfo.ModTime()
+```
+
+4. Replace the goroutine+channel ReadDir block (lines 78-112) with a cache-aware wrapper:
+```go
+// Check cache first
+var dirEntries []os.DirEntry
+if cached, ok := p.cache.Get(baseDir); ok {
+    dirEntries = cached
+} else {
+    // existing goroutine+channel ReadDir logic producing dirEntries
+    // ... (unchanged from current implementation)
+    if readErr == nil {
+        p.cache.Put(baseDir, dirEntries, dirMtime)
+    }
+}
+```
+
+**No other changes.** Filtering, pagination, and response construction are unchanged.
+
+**Tests to write** (`server/services/path_completion_service_test.go` — extend existing):
+1. `TestListPathCompletions_CacheHit` — call twice for same path, second call returns same entries without new ReadDir
+2. `TestListPathCompletions_CacheMissAfterMtimeChange` — call once, modify directory, call again, gets fresh entries
+
+**INVEST:** Depends only on Task 1.1, small change to one function, testable via integration test.
+
+---
+
+## Story 2: Detector + usePathHistory Fixes
+
+**Value:** Makes bare-text queries (e.g., "squad", "my-feature") route to session-search mode instead of `InputType.Unknown`. Adds `getAll()` to expose recent repos without prefix filtering. Fixes the `dropdownDismissed` stickiness bug between mode transitions.
+
+**Files:**
+- `web-app/src/lib/omnibar/types.ts` — add `InputType.SessionSearch`
+- `web-app/src/lib/omnibar/detector.ts` — add `SessionSearchDetector`, register at priority 200
+- `web-app/src/lib/hooks/usePathHistory.ts` — add `getAll(limit)` method, expose from hook return
+
+### Task 2.1 — Add InputType.SessionSearch
+
+**File:** `web-app/src/lib/omnibar/types.ts`
+
+Add to `InputType` enum:
+```typescript
+SessionSearch = "session_search",
+```
+
+Add to `INPUT_TYPE_INFO`:
+```typescript
+[InputType.SessionSearch]: {
+  label: "Search Sessions",
+  icon: "🔍",
+  description: "Search existing sessions",
+},
+```
+
+**File:** `web-app/src/lib/omnibar/detector.ts`
+
+Add new detector class after `LocalPathDetector`:
+```typescript
+/**
+ * Session Search detector — catch-all for bare-text queries.
+ * Fires for any non-empty input that no other detector claimed.
+ * Priority 200 ensures it runs last (after LocalPath at priority 100).
+ */
+class SessionSearchDetector implements Detector {
+  name = "SessionSearch";
+  priority = 200;
+
+  detect(input: string): DetectionResult | null {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+    // All inputs that reach this point have already been rejected by
+    // GitHub URL detectors (priorities 10-40), PathWithBranch (50),
+    // and LocalPath (100). They are bare-text session search queries.
+    return {
+      type: InputType.SessionSearch,
+      confidence: 0.5,
+      parsedValue: trimmed,
+      suggestedName: "",
+    };
+  }
+}
+```
+
+Register in `createDefaultRegistry()`:
+```typescript
+registry.register(new SessionSearchDetector());
+```
+
+**Critical:** The empty-input case (`input === ""`) is handled by `Omnibar.tsx` which sets `detection = null` when input is empty (line 171-173). The `SessionSearchDetector` must return `null` for empty input to preserve this behavior.
+
+**Pitfall addressed:** P1 — Detector mode conflict. Without this, bare-text queries resolve to `InputType.Unknown`, blocking session result display and flagging `canSubmit = false`.
+
+**Tests:** Add to existing detector tests:
+1. `"squad"` → `InputType.SessionSearch`
+2. `"my-feature"` → `InputType.SessionSearch`
+3. `""` → falls through to `InputType.Unknown` (the registry default)
+4. `"~/projects"` → still `InputType.LocalPath` (not hijacked by SessionSearch)
+5. `"org/repo"` → still `InputType.GitHubShorthand`
+
+---
+
+### Task 2.2 — Add getAll() to usePathHistory
+
+**File:** `web-app/src/lib/hooks/usePathHistory.ts`
+
+Add `getAll` alongside `getMatching`:
+```typescript
+/**
+ * Return all stored paths sorted by score desc, limited to `limit` entries.
+ * Used for "Recent Repos" empty-state display when no query is active.
+ */
+const getAll = useCallback(
+  (limit: number = MAX_RESULTS): PathHistoryEntry[] => {
+    return [...entries]
+      .sort((a, b) => entryScore(b) - entryScore(a))
+      .slice(0, limit);
+  },
+  [entries]
+);
+```
+
+Update hook return value:
+```typescript
+// Before
+return { getMatching, save };
+
+// After
+return { getMatching, getAll, save };
+```
+
+**No other changes.** The `entryScore` function and storage logic are unchanged.
+
+**Pitfall addressed:** P3 — `getMatching` is prefix-only; `getAll` is needed for the empty-state recent repos list.
+
+**Tests:** Add to `usePathHistory` tests:
+1. `getAll(5)` returns top 5 by score when more than 5 entries exist
+2. `getAll()` returns all entries sorted by score when fewer than limit
+3. After `save(path)`, `getAll()` includes the newly saved path
+4. Score ordering: entry used 2 hours ago > entry used 3 weeks ago
+
+---
+
+### Task 2.3 — Fix dropdownDismissed stickiness on mode transition
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+In the detection `useEffect` (lines 146-181), after `setDetection(result)`, add:
+```typescript
+// Reset dropdown dismissed state when input type changes modes.
+// Prevents session results from being suppressed after user dismisses
+// path completion dropdown then backspaces to bare text.
+setDropdownDismissed(false);
+```
+
+This reset must happen on every detection type change, not just on character input (which already resets it). The detection runs 150ms debounced, so the reset happens at most 150ms after the mode switch — acceptable UX.
+
+**Pitfall addressed:** P2 — `dropdownDismissed` stickiness. If user types a path, presses Escape to dismiss path completions (sets `dropdownDismissed = true`), then backspaces to bare text, session results would be suppressed without this fix.
+
+**Tests:** Verify in OmnibarResultList integration test that session results appear after: type path → press Escape → backspace to bare text → type session query.
+
+**INVEST:** All three tasks in Story 2 are small, independently testable changes to separate files. Together they form a coherent plumbing story required before Stories 3-5.
+
+---
+
+## Story 3: useSessionSearch Hook
+
+**Value:** Client-side fuzzy session search using Fuse.js. Powers the sessions section of the result list.
+
+**Prerequisite:** Story 2 (needs `InputType.SessionSearch` to know when to show results).
+
+**Files:**
+- `web-app/package.json` — add `fuse.js` dependency
+- `web-app/src/lib/hooks/useSessionSearch.ts` — new file
+
+### Task 3.1 — Install fuse.js
+
+```bash
+cd web-app && npm install fuse.js
+```
+
+Verify `"fuse.js"` appears in `web-app/package.json` dependencies. No other configuration changes.
+
+**Version note:** Use fuse.js v7.x (latest stable). The API used here (`new Fuse(list, options)`, `.search(query)`) is stable since v6.
+
+---
+
+### Task 3.2 — Implement useSessionSearch hook
+
+**File:** `web-app/src/lib/hooks/useSessionSearch.ts` (new)
+
+```typescript
+"use client";
+
+import { useMemo } from "react";
+import Fuse from "fuse.js";
+import { Session, SessionStatus } from "@/gen/session/v1/types_pb";
+import { useAppSelector } from "@/lib/store";
+import { selectAllSessions } from "@/lib/store/sessionsSlice";
+
+export interface SessionSearchResult {
+  session: Session;
+  score: number; // 0.0 = perfect match, 1.0 = no match (Fuse.js convention)
+  matchedFields: string[]; // which fields contributed to the match
+}
+
+// Fuse.js config: multi-field weighted search
+// title:0.5 > branch:0.3 > path:0.15 > tags:0.05
+// threshold:0.4 — allow moderate fuzziness; tighten if too many false positives
+// minMatchCharLength:1 — single character queries return results
+const FUSE_OPTIONS: Fuse.IFuseOptions<Session> = {
+  keys: [
+    { name: "title", weight: 0.5 },
+    { name: "branch", weight: 0.3 },
+    { name: "path", weight: 0.15 },
+    { name: "tags", weight: 0.05 },
+  ],
+  includeScore: true,
+  includeMatches: true,
+  threshold: 0.4,
+  minMatchCharLength: 1,
+  ignoreLocation: true, // don't penalize matches far from string start
+};
+
+// Sessions in these statuses are excluded from results
+const EXCLUDED_STATUSES = new Set([
+  SessionStatus.STOPPED,
+  SessionStatus.UNSPECIFIED,
+]);
+
+/**
+ * Client-side fuzzy session search using Fuse.js.
+ * Returns ranked results for display in the Omnibar session section.
+ * Empty query returns empty array (empty state shows recents instead).
+ */
+export function useSessionSearch(query: string): SessionSearchResult[] {
+  const sessions = useAppSelector(selectAllSessions);
+
+  // Filter to active sessions only
+  const activeSessions = useMemo(
+    () => sessions.filter((s) => !EXCLUDED_STATUSES.has(s.status)),
+    [sessions]
+  );
+
+  // Rebuild Fuse index when active session list changes
+  const fuse = useMemo(
+    () => new Fuse(activeSessions, FUSE_OPTIONS),
+    [activeSessions]
+  );
+
+  return useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    const results = fuse.search(trimmed, { limit: 8 });
+
+    return results.map((r) => ({
+      session: r.item,
+      score: r.score ?? 1.0,
+      matchedFields: r.matches?.map((m) => m.key ?? "") ?? [],
+    }));
+  }, [query, fuse]);
+}
+```
+
+**Implementation notes:**
+- `ignoreLocation: true` — prevents Fuse.js from penalizing matches that appear deep in the path string. Without this, "squad" matching the tail of "stapler-squad" would score lower than if "squad" appeared at position 0.
+- `limit: 8` passed to `fuse.search()` — caps results before any filtering.
+- The Fuse index (`new Fuse(...)`) is rebuilt only when `activeSessions` changes, not on every query. The `.search()` call runs on every query change; this is the fast path (<1ms for hundreds of sessions).
+- `STOPPED` and `UNSPECIFIED` sessions excluded. Navigating to a stopped session is a confusing UX (the terminal is not running).
+
+**Tests** (`web-app/src/lib/hooks/useSessionSearch.test.ts`):
+1. Empty query returns `[]`
+2. Query matching title scores higher than same query matching only path
+3. STOPPED sessions are excluded from results
+4. Results are capped at 8
+5. "squad" matches session with title "stapler-squad" (fuzzy non-prefix match)
+6. "myfeat" matches branch "my-feature-branch" (character-sequence fuzzy)
+7. Title weight dominance: session A with "auth" in title outranks session B with "auth" only in path
+
+**INVEST:** Independent of UI stories, fully testable in isolation, clear acceptance criteria.
+
+---
+
+## Story 4: OmnibarResultList UI Components
+
+**Value:** Renders the two-section result list (sessions + repos) with keyboard navigation. Visually distinguishes session results from repo results.
+
+**Prerequisite:** Story 3 (needs `SessionSearchResult` type). Also needs `PathHistoryEntry` from Story 2's `getAll()`.
+
+**Files:**
+- `web-app/src/components/sessions/OmnibarResultList.tsx` — new
+- `web-app/src/components/sessions/OmnibarResultList.css.ts` — new (vanilla-extract)
+- `web-app/src/components/sessions/OmnibarSessionResult.tsx` — new
+- `web-app/src/components/sessions/OmnibarSessionResult.css.ts` — new
+- `web-app/src/components/sessions/OmnibarRepoResult.tsx` — new
+- `web-app/src/components/sessions/OmnibarRepoResult.css.ts` — new
+
+### Task 4.1 — OmnibarSessionResult row component
+
+**File:** `web-app/src/components/sessions/OmnibarSessionResult.tsx` (new)
+
+Visual layout:
+```
+[status dot]  [session title (bold)]           [branch (muted, right)]
+              [repo path (muted, smaller)]
+```
+
+Props interface:
+```typescript
+interface OmnibarSessionResultProps {
+  session: Session;
+  isHighlighted: boolean;
+  onSelect: (session: Session) => void;
+}
+```
+
+Status dot: colored `<span>` with `aria-label` set to status string.
+- `SessionStatus.RUNNING` → green (#22c55e)
+- `SessionStatus.PAUSED` → yellow (#eab308)
+- `SessionStatus.READY` → blue (#3b82f6)
+- Other → grey (#6b7280)
+
+Path display: show only the last 2 segments of the path to avoid overflow (e.g., `/Users/tyler/projects/auth` → `projects/auth`).
+
+**Accessibility:** The row is a `<li role="option">` inside the `OmnibarResultList`'s `<ul role="listbox">`. `aria-selected` reflects `isHighlighted`. `id` must be `omnibar-result-session-{session.id}` for `aria-activedescendant` on the input.
+
+**CSS** (`OmnibarSessionResult.css.ts`): Use `vars` from `web-app/src/styles/theme.css.ts`. Two-line layout via flex-column. Status dot is a 8px `border-radius: 50%` span with inline color.
+
+---
+
+### Task 4.2 — OmnibarRepoResult row component
+
+**File:** `web-app/src/components/sessions/OmnibarRepoResult.tsx` (new)
+
+Visual layout:
+```
+[folder icon]  [parent/path (muted)] / [repo-name (bold)]    [relative time (muted, right)]
+               [N sessions] (muted, small)
+```
+
+Props interface:
+```typescript
+interface OmnibarRepoResultProps {
+  entry: PathHistoryEntry;
+  sessionCount?: number;
+  isHighlighted: boolean;
+  onSelect: (path: string) => void;
+}
+```
+
+Path splitting: `const parts = path.split('/').filter(Boolean); const repoName = parts[parts.length - 1]; const parent = parts.slice(-3, -1).join('/');`
+
+Relative time: use a simple inline util (no library needed):
+```typescript
+function relativeTime(epochMs: number): string {
+  const diff = Date.now() - epochMs;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+  return `${Math.floor(diff / (7 * 86_400_000))}w ago`;
+}
+```
+
+Accessibility: `<li role="option">`, same `aria-selected` / `id` pattern as `OmnibarSessionResult`. Id format: `omnibar-result-repo-{encodeURIComponent(entry.path)}`.
+
+---
+
+### Task 4.3 — OmnibarResultList container component
+
+**File:** `web-app/src/components/sessions/OmnibarResultList.tsx` (new)
+
+This component owns the keyboard navigation state for the result list and renders both sections.
+
+Props interface:
+```typescript
+interface OmnibarResultListProps {
+  sessionResults: SessionSearchResult[];
+  repoEntries: PathHistoryEntry[];
+  sessionCounts?: Record<string, number>; // path → session count, for repo rows
+  onSessionSelect: (session: Session) => void;
+  onRepoSelect: (path: string) => void;
+  highlightedIndex: number; // controlled from parent (Omnibar)
+  // "Create new session" always-present item at bottom
+  onCreateNew: () => void;
+}
+```
+
+**Rendering logic:**
+- Show "SESSIONS" section header + session rows if `sessionResults.length > 0`
+- Show "REPOS" section header + repo rows if `repoEntries.length > 0`
+- Show "+ New Session" item at bottom with a visual separator (always present)
+- Hide entire component if both sections are empty and no create-new item needed
+
+**Section headers:** `<div role="presentation" aria-hidden="true">` — they are visual only, not keyboard-navigable.
+
+**Flat index management:** The component exposes a `totalItemCount` (sessions + repos + 1 for create-new) so the parent Omnibar can drive arrow-key navigation. The `highlightedIndex` prop maps: 0..sessionResults.length-1 = sessions, sessionResults.length..sessionResults.length+repoEntries.length-1 = repos, last = create-new.
+
+**ARIA:** The list is `<ul role="listbox" id="omnibar-result-listbox">`. The parent input's `aria-controls` points to this id. `aria-activedescendant` on the input tracks the highlighted item's id.
+
+**CSS** (`OmnibarResultList.css.ts`):
+```typescript
+import { style } from '@vanilla-extract/css';
+import { vars } from '../../styles/theme.css';
+
+export const resultList = style({
+  listStyle: 'none',
+  margin: 0,
+  padding: `${vars.space[1]} 0`,
+  maxHeight: '320px',
+  overflowY: 'auto',
+});
+
+export const sectionHeader = style({
+  padding: `${vars.space[1]} ${vars.space[3]}`,
+  fontSize: vars.fontSize.xs,
+  fontWeight: 600,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: vars.color.textMuted,
+  userSelect: 'none',
+});
+
+export const separator = style({
+  height: '1px',
+  background: vars.color.borderDefault,
+  margin: `${vars.space[1]} ${vars.space[3]}`,
+});
+```
+
+**Tests** (`web-app/src/components/sessions/OmnibarResultList.test.tsx`):
+1. Renders session section only when sessionResults non-empty, repoEntries empty
+2. Renders repo section only when repoEntries non-empty, sessionResults empty
+3. Hides empty sections (no "SESSIONS" header when sessionResults is `[]`)
+4. "+ New Session" item always renders
+5. Arrow key down from last session item moves highlight to first repo item (skips section header)
+6. `onSessionSelect` called with correct session on Enter when session highlighted
+7. `onRepoSelect` called with correct path on Enter when repo highlighted
+
+**INVEST:** Depends on Tasks 4.1 and 4.2 for row components, but those can be stubbed for testing. All navigation logic is testable with shallow render.
+
+---
+
+## Story 5: Omnibar Two-Phase Integration
+
+**Value:** Wires session search, recent repos, and the result list into the existing Omnibar component. Implements the two-phase (discovery/creation) mode state. This is the story that delivers the full feature end-to-end.
+
+**Prerequisite:** Stories 2, 3, and 4.
+
+**Files:**
+- `web-app/src/components/sessions/Omnibar.tsx` — significant additions, no deletion of existing form logic
+- `web-app/src/components/sessions/Omnibar.module.css` — minor additions for mode-transition styles
+
+### Task 5.1 — Add mode state and session navigation callback
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+**New prop:**
+```typescript
+interface OmnibarProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreateSession: (data: OmnibarSessionData) => Promise<void>;
+  onNavigateToSession: (sessionId: string) => void; // NEW
+}
+```
+
+**New state:**
+```typescript
+type OmnibarMode = "discovery" | "creation";
+const [mode, setMode] = useState<OmnibarMode>("discovery");
+const [resultHighlightIndex, setResultHighlightIndex] = useState(-1);
+```
+
+**Mode logic:**
+- `mode` starts as `"discovery"` on open
+- Transitions to `"creation"` when:
+  - User selects a repo result (path pre-filled into input)
+  - Input is detected as `InputType.LocalPath` or `InputType.PathWithBranch` (existing path detection)
+- Transitions back to `"discovery"` when:
+  - Input is detected as `InputType.SessionSearch`
+  - Input is cleared (empty)
+
+Add to the detection `useEffect`, after `setDetection(result)`:
+```typescript
+if (
+  result.type === InputType.LocalPath ||
+  result.type === InputType.PathWithBranch ||
+  result.type === InputType.GitHubPR ||
+  result.type === InputType.GitHubBranch ||
+  result.type === InputType.GitHubRepo ||
+  result.type === InputType.GitHubShorthand
+) {
+  setMode("creation");
+} else if (result.type === InputType.SessionSearch) {
+  setMode("discovery");
+}
+```
+
+When input is cleared:
+```typescript
+// In the else branch (empty input, line 171-173):
+setDetection(null);
+setMode("discovery");
+```
+
+---
+
+### Task 5.2 — Wire session search and recent repos hooks
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+Add hooks at the top of the component body:
+
+```typescript
+import Fuse from "fuse.js";
+
+// Session search (only active in discovery mode)
+const sessionSearchQuery =
+  detection?.type === InputType.SessionSearch ? input : "";
+const sessionResults = useSessionSearch(sessionSearchQuery);
+
+// Recent repos for empty-state discovery
+const { getAll: getAllHistory } = usePathHistory();
+// useRepositorySuggestions for frecency-ranked paths from existing sessions
+const { suggestions: repoSuggestions } = useRepositorySuggestions();
+
+// What to show in the result list
+const isDiscoveryMode = mode === "discovery" || !input.trim();
+
+// Stable snapshot of recent repo entries — rebuilt only when history changes.
+// Capped at 50 so Fuse index stays small.
+const allRepoEntries = useMemo(() => getAllHistory(50), [getAllHistory]);
+
+// Fuse instance over repo paths — same threshold/ignoreLocation as session search
+// for consistent match quality. Rebuilt only when allRepoEntries changes.
+const repoFuse = useMemo(
+  () =>
+    new Fuse(allRepoEntries, {
+      keys: [{ name: "path", weight: 1.0 }],
+      threshold: 0.4,
+      ignoreLocation: true,
+      minMatchCharLength: 1,
+    }),
+  [allRepoEntries]
+);
+
+// Empty state: show top-5 recent sessions + top-5 repo suggestions
+// Active search: show session results + fuzzy-filtered repo suggestions
+const displayedSessionResults = useMemo(() => {
+  if (!input.trim()) {
+    // Empty state — not yet implemented here; sessions come from Redux
+    // selectAllSessions sorted by updatedAt, top 5
+    return []; // populated in Task 5.3
+  }
+  return sessionResults;
+}, [input, sessionResults]);
+
+const displayedRepoEntries = useMemo(() => {
+  if (!input.trim()) {
+    // Empty state — top 5 by frecency score
+    return allRepoEntries.slice(0, 5);
+  }
+  // Active search — fuzzy match against path (same quality as session search)
+  return repoFuse.search(input).map((r) => r.item).slice(0, 8);
+}, [input, allRepoEntries, repoFuse]);
+```
+
+**Why fuse.js here too:** The requirements specify fuzzy search for previously-used repos ("create a new session based on a repo I've already used before based on fuzzy search"). Substring `.includes()` would miss "squad" → "stapler-squad". Since fuse.js is already installed for session search (Story 3), there is no additional dependency cost. The same `threshold: 0.4` and `ignoreLocation: true` settings are used for consistency.
+
+**Fuse instance stability:** `allRepoEntries` is memoized from `getAllHistory(50)`. `getAllHistory` is a `useCallback` inside `usePathHistory` — it only changes reference when the stored entries change (i.e. when `save()` is called). In practice the Fuse index rebuilds only when the user creates a new session or uses a new path, not on every keystroke.
+
+---
+
+### Task 5.3 — Empty state: recent sessions from Redux
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+For the empty-state session list, select top-5 sessions from Redux sorted by `updatedAt` desc:
+
+```typescript
+// At hook level (outside useMemo, to get selector):
+const allSessions = useAppSelector(selectAllSessions);
+
+// Inside displayedSessionResults useMemo, empty-state branch:
+if (!input.trim()) {
+  const active = allSessions
+    .filter((s) => s.status !== SessionStatus.STOPPED && s.status !== SessionStatus.UNSPECIFIED)
+    .sort((a, b) => {
+      const aTime = a.updatedAt ? Number(a.updatedAt.seconds) : 0;
+      const bTime = b.updatedAt ? Number(b.updatedAt.seconds) : 0;
+      return bTime - aTime;
+    })
+    .slice(0, 5);
+  return active.map((s) => ({ session: s, score: 0, matchedFields: [] }));
+}
+```
+
+---
+
+### Task 5.4 — Handle session result selection
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+Add handler:
+```typescript
+const handleSessionSelect = useCallback(
+  (session: Session) => {
+    onNavigateToSession(session.id);
+    onClose();
+  },
+  [onNavigateToSession, onClose]
+);
+```
+
+**Pitfall addressed (P1):** Enter key ambiguity. The `handleKeyDown` must route Enter by current context:
+- If `isDiscoveryMode` and `resultHighlightIndex >= 0` (a result is highlighted):
+  - If highlighted item is a session → call `handleSessionSelect`
+  - If highlighted item is a repo → call `handleRepoSelect`
+  - If highlighted item is create-new → call `handleCreateNew`
+  - In all cases, `e.preventDefault()` and `return` before the Cmd+Enter check
+- Otherwise, existing Cmd+Enter → `handleSubmit` behavior unchanged
+
+```typescript
+// Inside handleKeyDown, at the top of the function (before isDropdownVisible check):
+if (isDiscoveryMode && resultHighlightIndex >= 0) {
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    setResultHighlightIndex((i) => Math.min(i + 1, totalResultCount - 1));
+    return;
+  }
+  if (e.key === "ArrowUp") {
+    e.preventDefault();
+    setResultHighlightIndex((i) => Math.max(i - 1, -1));
+    return;
+  }
+  if (e.key === "Enter" && !e.metaKey) {
+    e.preventDefault();
+    // dispatch based on which item is highlighted
+    dispatchHighlightedResultAction(resultHighlightIndex);
+    return;
+  }
+  if (e.key === "Escape") {
+    e.nativeEvent.stopImmediatePropagation();
+    setResultHighlightIndex(-1);
+    return; // first Escape clears highlight; second Escape closes (falls through)
+  }
+}
+```
+
+---
+
+### Task 5.5 — Handle repo result selection (pre-fill + mode transition)
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+```typescript
+const handleRepoSelect = useCallback(
+  (path: string) => {
+    setInput(path + "/");
+    setMode("creation");
+    setResultHighlightIndex(-1);
+    setDropdownDismissed(false);
+    inputRef.current?.focus();
+  },
+  []
+);
+```
+
+This pre-fills the input with the repo path, which will trigger path detection on the next debounce cycle (150ms), transitioning the omnibar into creation mode with the path completion dropdown active.
+
+---
+
+### Task 5.6 — Render OmnibarResultList conditionally
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+In the JSX, replace the path completion dropdown block and add discovery mode rendering:
+
+```tsx
+{/* Discovery mode: session results + recent repos */}
+{isDiscoveryMode && (
+  <OmnibarResultList
+    sessionResults={displayedSessionResults}
+    repoEntries={displayedRepoEntries}
+    highlightedIndex={resultHighlightIndex}
+    onSessionSelect={handleSessionSelect}
+    onRepoSelect={handleRepoSelect}
+    onCreateNew={handleCreateNew}
+  />
+)}
+
+{/* Creation mode: existing path completion dropdown (unchanged) */}
+{!isDiscoveryMode && isDropdownVisible && (
+  <PathCompletionDropdown
+    id="path-completion-listbox"
+    entries={mergedEntries}
+    historyCount={historyCount}
+    selectedIndex={dropdownIndex}
+    onSelect={handleCompletionSelect}
+    isLoading={isCompletionLoading}
+  />
+)}
+```
+
+**Conditional form body:** Show `<div className={styles.body}>` only in `creation` mode:
+```tsx
+{mode === "creation" && (
+  <div className={styles.body}>
+    {/* ... existing form fields unchanged ... */}
+  </div>
+)}
+```
+
+**Update footer hints:**
+```tsx
+<div className={styles.shortcuts}>
+  <span className={styles.shortcut}>
+    <span className={styles.shortcutKey}>Esc</span> Close
+  </span>
+  {mode === "creation" && (
+    <span className={styles.shortcut}>
+      <span className={styles.shortcutKey}>⌘↵</span> Create
+    </span>
+  )}
+  {isDiscoveryMode && (
+    <>
+      <span className={styles.shortcut}>
+        <span className={styles.shortcutKey}>↑↓</span> Navigate
+      </span>
+      <span className={styles.shortcut}>
+        <span className={styles.shortcutKey}>↵</span> Jump
+      </span>
+    </>
+  )}
+</div>
+```
+
+**Update placeholder text:**
+```tsx
+placeholder={
+  mode === "creation"
+    ? "Enter path, GitHub URL, or owner/repo..."
+    : "Jump to session or search repos..."
+}
+```
+
+**Update canSubmit:** Add `InputType.SessionSearch` to the block list:
+```typescript
+if (!detection || detection.type === InputType.Unknown || detection.type === InputType.SessionSearch) return false;
+```
+
+**INVEST:** All tasks in Story 5 modify a single file. Each task is independently reviewable. The story is complete when all six tasks pass their respective tests.
+
+---
+
+## Quality Gates
+
+### Go cache unit tests
+
+Location: `server/services/dir_cache_test.go`
+
+| Test | Scenario |
+|---|---|
+| `TestDirCache_Hit` | Put entries, Get returns same slice |
+| `TestDirCache_MissOnMtimeChange` | Create temp dir, Put, modify dir contents, Get returns miss |
+| `TestDirCache_MissOnTTLExpiry` | Put with 1ms TTL, sleep 5ms, Get returns miss |
+| `TestDirCache_NoEvictionBelowMax` | Fill to maxSize-1, verify no eviction |
+| `TestDirCache_EvictsOldestAtMax` | Fill to maxSize, add one more, oldest entry is gone |
+| `TestDirCache_ConcurrentReads` | 50 goroutines Get after one Put, run with `-race` |
+| `TestListPathCompletions_CacheHit` | Call twice, second call does not invoke ReadDir |
+| `TestListPathCompletions_CacheMissAfterMtimeChange` | Verify fresh entries after directory mutation |
+
+### useSessionSearch unit tests
+
+Location: `web-app/src/lib/hooks/useSessionSearch.test.ts`
+
+| Test | Scenario |
+|---|---|
+| Empty query | Returns `[]` |
+| Title match beats path match | "auth" in title outranks "auth" only in path |
+| STOPPED sessions excluded | Sessions with `status === STOPPED` never in results |
+| Result cap | At most 8 results even with 100 matching sessions |
+| Fuzzy non-prefix match | "squad" matches "stapler-squad" |
+| Consecutive char match | "myfeat" matches "my-feature-branch" |
+| Multi-field | Session matching title AND branch scores higher than session matching only one field |
+
+### OmnibarResultList keyboard navigation tests
+
+Location: `web-app/src/components/sessions/OmnibarResultList.test.tsx`
+
+| Test | Scenario |
+|---|---|
+| Empty sections hidden | `sessionResults=[]` → no SESSIONS header |
+| Create-new always visible | Renders even with both sections empty |
+| Arrow down skips headers | Down from last session item → first repo item (not header) |
+| Enter dispatches session action | `onSessionSelect` called with correct session |
+| Enter dispatches repo action | `onRepoSelect` called with correct path |
+| ARIA activedescendant | Highlighted item id matches input's aria-activedescendant |
+
+### Integration acceptance tests
+
+| Scenario | Expected |
+|---|---|
+| Omnibar opens empty | Both sections visible with recents |
+| User types "auth" | Session results update, repo results update, form body hidden |
+| User types "~/" | Session results hidden, path completion dropdown appears |
+| Enter on session result | Omnibar closes, `onNavigateToSession` called |
+| Enter on repo result | Input pre-filled with path, creation form appears |
+| Escape on highlighted result | Highlight cleared, results still visible |
+| Second Escape | Omnibar closes |
+
+---
+
+## Known Issues
+
+### Bug 1 — GitHubShorthand fires on branch-style session searches [SEVERITY: Medium]
+
+**Description:** The `GitHubShorthandDetector` (priority 40) matches `^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)`. A user searching for a session with title `feature/auth-overhaul` will trigger GitHub detection instead of session search, showing a GitHub icon and blocking session results.
+
+**Mitigation in this plan:** `SessionSearchDetector` has priority 200, so it only fires after all GitHub detectors. The user's query `feature/auth-overhaul` will be classified as `InputType.GitHubShorthand`, not `InputType.SessionSearch`. The session result for that session title will not appear.
+
+**Workaround:** Search for `auth-overhaul` (the branch suffix) instead. The Fuse.js search will still find it via the `branch` field.
+
+**Future fix:** Add an active-session-title check to `GitHubShorthandDetector`: if the input exactly matches an existing session title, prefer `SessionSearch` over `GitHubShorthand`. This requires passing the session list into the detector, which is a bigger architectural change. Deferred to a follow-up.
+
+**Files likely affected:** `web-app/src/lib/omnibar/detector.ts`
+
+---
+
+### Bug 2 — Recent repos list shows deleted paths [SEVERITY: Medium]
+
+**Description:** `usePathHistory` stores paths in `localStorage` without existence checks. A repo that was moved or deleted appears in the Recent Repos empty-state list. Selecting it pre-fills a non-existent path, which fails at session creation.
+
+**Mitigation in this plan:** The path existence check (`✓`/`✗`) in the input indicator will show `✗` after the user selects a deleted path and the detection runs. The user sees immediate feedback before attempting to create the session.
+
+**Future fix:** On each Omnibar open, call the `pathExists` check for each recent repo entry and filter out non-existent paths. This adds one RPC per recent repo but could be batched. Deferred because the `✓`/`✗` indicator provides sufficient feedback for now.
+
+**Files likely affected:** `web-app/src/lib/hooks/usePathHistory.ts`, `web-app/src/components/sessions/OmnibarRepoResult.tsx`
+
+---
+
+### Bug 3 — ConnectRPC transport created per-render in usePathCompletions [SEVERITY: Low]
+
+**Description:** `usePathCompletions.ts` creates a new `createConnectTransport` and `createClient` inside the debounce callback (inside a `useEffect`). This means a new HTTP transport object is created on every debounce firing, which has small but real memory overhead.
+
+**Mitigation in this plan:** Not fixed in this plan. The issue predates this feature. Adding session search (a second async hook) makes the impact slightly larger but does not introduce the root cause.
+
+**Future fix:** Lift transport/client creation to module level, matching the pattern used by `completionCache` in the same file.
+
+**Files likely affected:** `web-app/src/lib/hooks/usePathCompletions.ts`
+
+---
+
+### Bug 4 — Fuse.js threshold may over-match on short queries [SEVERITY: Low]
+
+**Description:** With `threshold: 0.4`, a 1-2 character query like "a" will match most sessions. The result list will be populated with low-relevance results ranked by score, but the user will see up to 8 results for a single character, all with mediocre scores.
+
+**Mitigation:** `minMatchCharLength: 1` is set intentionally for the "3 keystroke" requirement (Cmd+K, type one char, arrow, Enter). The user expects results on a single character. If relevance drift becomes an issue, raise `minMatchCharLength` to 2 or increase `threshold` to 0.3 (stricter) in follow-up.
+
+**Files likely affected:** `web-app/src/lib/hooks/useSessionSearch.ts`
+
+---
+
+### Bug 5 — DirCache mtime invalidation unreliable on network filesystems [SEVERITY: Low]
+
+**Description:** On NFS or SMB mounts, mtime may not update synchronously when directory contents change. The 60s hard TTL is the backstop, but users on network filesystems could see stale path completions for up to 60 seconds after a directory change.
+
+**Mitigation:** The 60s TTL is the fallback. For a solo-practitioner tool primarily used on local filesystems, this is acceptable. Document as a known limitation.
+
+**Files likely affected:** `server/services/dir_cache.go`
+
+---
+
+### Bug 6 — useRepositorySuggestions makes a listSessions RPC on every Omnibar open [SEVERITY: Low]
+
+**Description:** `useRepositorySuggestions` calls `client.listSessions({})` inside a `useEffect` that runs when `baseUrl` changes. Since the hook is instantiated inside `Omnibar.tsx` (which mounts/unmounts on each open/close), it fires an RPC on every Omnibar open.
+
+**Mitigation in this plan:** The session data from `useRepositorySuggestions` is redundant with the Redux store (`selectAllSessions`). The empty-state recent session list (Task 5.3) uses Redux directly (zero RPCs). The `useRepositorySuggestions` hook provides frecency-ranked paths from session `path` fields, which is complementary to `usePathHistory` (user-typed paths).
+
+**Future fix:** Replace `useRepositorySuggestions` with a `useMemo` over `selectAllSessions` for the repo paths section. The `rankPathsByFrecency` util can run client-side against the Redux store. This eliminates the redundant RPC.
+
+**Files likely affected:** `web-app/src/lib/hooks/useRepositorySuggestions.ts`, `web-app/src/components/sessions/Omnibar.tsx`
+
+---
+
+## Implementation Sequence
+
+1. **Task 1.1** — `dir_cache.go` (backend, independent)
+2. **Task 1.2** — Wire cache into `path_completion_service.go`
+3. **Task 2.1** — `InputType.SessionSearch` in `types.ts` + `SessionSearchDetector` in `detector.ts`
+4. **Task 2.2** — `getAll()` in `usePathHistory.ts`
+5. **Task 2.3** — `dropdownDismissed` reset in `Omnibar.tsx`
+6. **Task 3.1** — Install fuse.js
+7. **Task 3.2** — `useSessionSearch.ts` hook
+8. **Task 4.1** — `OmnibarSessionResult.tsx`
+9. **Task 4.2** — `OmnibarRepoResult.tsx`
+10. **Task 4.3** — `OmnibarResultList.tsx`
+11. **Task 5.1** — Mode state + `onNavigateToSession` prop in `Omnibar.tsx`
+12. **Task 5.2** — Hook wiring in `Omnibar.tsx`
+13. **Task 5.3** — Empty-state recent sessions from Redux
+14. **Task 5.4** — Session result selection handler + Enter key routing
+15. **Task 5.5** — Repo result selection + pre-fill
+16. **Task 5.6** — Conditional render of result list vs form body
+
+Tasks 1.1-1.2 and 2.1-2.3 can be started simultaneously in separate commits. Tasks 3-5 must follow in sequence.
+
+---
+
+## File Reference
+
+| File | Action | Story |
+|---|---|---|
+| `server/services/dir_cache.go` | CREATE | 1 |
+| `server/services/dir_cache_test.go` | CREATE | 1 |
+| `server/services/path_completion_service.go` | MODIFY | 1 |
+| `web-app/src/lib/omnibar/types.ts` | MODIFY | 2 |
+| `web-app/src/lib/omnibar/detector.ts` | MODIFY | 2 |
+| `web-app/src/lib/hooks/usePathHistory.ts` | MODIFY | 2 |
+| `web-app/src/components/sessions/Omnibar.tsx` | MODIFY | 2, 5 |
+| `web-app/package.json` | MODIFY | 3 |
+| `web-app/src/lib/hooks/useSessionSearch.ts` | CREATE | 3 |
+| `web-app/src/lib/hooks/useSessionSearch.test.ts` | CREATE | 3 |
+| `web-app/src/components/sessions/OmnibarSessionResult.tsx` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarSessionResult.css.ts` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarRepoResult.tsx` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarRepoResult.css.ts` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarResultList.tsx` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarResultList.css.ts` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarResultList.test.tsx` | CREATE | 4 |
+
+---
+
+## ADR References
+
+- `project_plans/omni-bar-session-search/decisions/ADR-001-client-side-session-search.md` — why no SearchSessions RPC
+- `project_plans/omni-bar-session-search/decisions/ADR-002-fusejs-typescript-fuzzy.md` — why Fuse.js over fzf-for-js or match-sorter
+- `project_plans/omni-bar-session-search/decisions/ADR-003-go-sync-map-dir-cache.md` — why DirCache over sync.Map

--- a/project_plans/omni-bar-session-search/decisions/ADR-001-client-side-session-search.md
+++ b/project_plans/omni-bar-session-search/decisions/ADR-001-client-side-session-search.md
@@ -1,0 +1,34 @@
+# ADR-001: Client-Side Session Search (No New RPCs)
+
+Status: Accepted
+Date: 2026-04-14
+Deciders: Tyler Stapler
+
+## Context
+
+Session search in the Omnibar needs a data source for existing sessions. Two architectural options exist:
+1. Client-side filtering of the Redux session store
+2. A new `SearchSessions` RPC endpoint on the backend
+
+The full session list is already loaded into the Redux entity adapter (`sessionsSlice`) via `useSessionService`'s `listSessions` call and `WatchSessions` streaming. The `selectAllSessions` selector gives zero-latency O(1) access to the complete session list.
+
+The existing `session/search/` package is a BM25 engine over Claude _conversation history_ (JSONL files in `~/.claude/`). It is architecturally separate from the live session metadata store and unsuitable for this use case: BM25 requires exact token matches, has no consecutive-character or word-boundary bonuses, and would need server-side index maintenance for live session metadata. "squad" does not match "stapler-squad" through BM25 because the IDF weighting on short corpora produces near-identical scores.
+
+## Decision
+
+Session search operates entirely client-side, filtering the Redux session store with a fuzzy algorithm (Fuse.js). No new RPC endpoints, no proto changes.
+
+## Rationale
+
+1. **Zero additional latency.** The data is already in memory. A round-trip RPC adds 5-20ms per keystroke even on localhost. Client-side is synchronous and updates on every keypress.
+2. **Data is already fresh.** The `WatchSessions` stream keeps Redux up to date in real time. A server search would be operating on the same data with an unnecessary network round trip.
+3. **Scale is bounded.** Even at 500 sessions, Fuse.js Bitap runs in under 1ms. The worst-case scale for a solo-practitioner tool is well within JavaScript budget.
+4. **No coupling to backend.** Session search is a UI navigation concern — which sessions the user wants to jump to is a function of what they see on screen, not what the server computes.
+5. **Resilient during reconnect.** Client-side filtering continues working during brief WebSocket reconnects; server search would degrade silently.
+6. **Consistent with existing pattern.** `SessionList.tsx` already does client-side filtering via a `filteredSessions` useMemo. This is an upgrade of that established pattern.
+
+## Consequences
+
+- `useSessionSearch(query)` is a pure frontend addition in `web-app/src/lib/hooks/useSessionSearch.ts`.
+- Zero changes to proto files, server handlers, or the ConnectRPC layer.
+- If session count grows to 10,000+ in a multi-user deployment, this decision should be revisited. The `ListSessionsRequest.search_query` field (proto field 4) exists as a future hook for a server-side `SearchSessions` upgrade path.

--- a/project_plans/omni-bar-session-search/decisions/ADR-002-fusejs-fuzzy-library.md
+++ b/project_plans/omni-bar-session-search/decisions/ADR-002-fusejs-fuzzy-library.md
@@ -1,0 +1,36 @@
+# ADR-002: Fuse.js for TypeScript Fuzzy Session Search
+
+Status: Accepted
+Date: 2026-04-14
+Deciders: Tyler Stapler
+
+## Context
+
+Session search requires multi-field fuzzy matching across `title`, `branch`, `path`, and `tags` with field-specific weights (title matches matter more than path matches). Three TypeScript candidates were evaluated:
+
+| Library | Algorithm | Multi-field | Bundle |
+|---|---|---|---|
+| `fuse.js` | Bitap | First-class, weighted | ~8 kB gzip |
+| `match-sorter` | Tiered ranking | Yes | ~3-4 kB gzip |
+| `fzf` (fzf-for-js) | Smith-Waterman | Single-field only | ~10 kB est. |
+
+## Decision
+
+Use `fuse.js` for client-side session fuzzy search.
+
+## Rationale
+
+1. **Multi-field weighted keys are first-class.** Fuse.js accepts a `keys` array with per-field `weight` values. This is the primary requirement — title match (weight 0.5) must rank above path match (weight 0.1).
+2. **TypeScript types included.** No `@types/` package needed.
+3. **`includeScore` and `includeMatches`.** Score is returned per result for post-ranking with status boost and recency decay. Match indices are available for future highlight rendering.
+4. **Threshold tuning.** The `threshold` parameter controls sensitivity. Starting at 0.4 covers the "myfeat" → "my-feature-branch" case.
+5. **`match-sorter` rejected** because its tier-based ranking does not handle non-contiguous character patterns ("myfeat" never matches "my-feature-branch" — fails the ≤3 keystrokes requirement).
+6. **`fzf-for-js` rejected** because it lacks first-class multi-field support; composite-string workaround loses per-field weight control.
+
+## Consequences
+
+- Add `fuse.js` to `web-app/package.json` dependencies (not already present).
+- Create `web-app/src/lib/fuzzy.ts` as the Fuse.js integration layer with session-specific field configuration.
+- Fuse.js instance is created once per query batch (or memoized) — not on every keystroke render.
+- Threshold and field weights are tunable constants in `fuzzy.ts`, not scattered across call sites.
+- If scoring quality is insufficient after implementation, `fzf-for-js` can be swapped into the same `fuzzy.ts` interface without changing callers.

--- a/project_plans/omni-bar-session-search/decisions/ADR-002-fusejs-typescript-fuzzy.md
+++ b/project_plans/omni-bar-session-search/decisions/ADR-002-fusejs-typescript-fuzzy.md
@@ -1,0 +1,57 @@
+# ADR-002: Fuse.js for TypeScript Client-Side Fuzzy Search
+
+Status: Accepted
+Date: 2026-04-14
+Deciders: Tyler Stapler
+
+## Context
+
+Session search in the Omnibar must match short, imprecise queries (1-4 characters) against multiple fields: session title, branch name, working directory path, and tags. The fields have different relevance weights (title matters most, tags least). The requirements specify that "myfeat" should match "my-feature-branch" and "squad" should match "stapler-squad".
+
+Three TypeScript fuzzy libraries were evaluated:
+
+**fuse.js** — Bitap (Shift-or) approximate string matching algorithm. Multi-field weighted `keys` config is first-class. Returns scores 0.0-1.0 with optional match position highlights. ~8kB gzip. Zero dependencies. Full TypeScript types. No word-boundary or consecutive-character bonus.
+
+**fzf-for-js** (`fzf` on npm) — Port of the fzf CLI's Smith-Waterman-like algorithm. Best single-field fuzzy quality (consecutive-char and word-boundary bonuses). Multi-field search is not first-class: requires building a composite string or running multiple searches and merging. No built-in per-field weighting.
+
+**match-sorter** — Seven-tier ranking (exact → starts-with → word-starts-with → contains → acronym → fuzzy). Multi-field support via `keys` array. Not true fuzzy: "myfeat" will not match "my-feature-branch" because none of the tiers handle non-contiguous character patterns. Fails the key requirement.
+
+## Decision
+
+Use **fuse.js** for session search in the Omnibar.
+
+Configuration:
+```typescript
+{
+  keys: [
+    { name: "title",  weight: 0.5 },
+    { name: "branch", weight: 0.3 },
+    { name: "path",   weight: 0.15 },
+    { name: "tags",   weight: 0.05 },
+  ],
+  includeScore: true,
+  includeMatches: true,
+  threshold: 0.4,
+  minMatchCharLength: 1,
+  ignoreLocation: true,
+}
+```
+
+## Rationale
+
+1. **Multi-field weighted keys is the core requirement.** The session search problem is inherently multi-field: a match on `title` is more valuable than a match on `path`. Fuse.js handles this natively through its `keys` weight configuration. fzf-for-js requires a composite string workaround that loses per-field weight control.
+
+2. **Bitap quality is sufficient.** While fzf-for-js would produce marginally better ranking for single-field queries (consecutive-char bonuses), the difference is imperceptible for a session list of ≤100 items where all above-threshold results appear in the 8-item list.
+
+3. **`ignoreLocation: true` fixes the path-match penalty.** Without this, Fuse.js penalizes matches that appear far from position 0 in the string. "squad" at position 8 in "stapler-squad" would score worse than "squad" at position 0. `ignoreLocation` removes this bias, treating all positions equally — correct for path and branch names.
+
+4. **match-sorter is disqualified.** It cannot match non-contiguous character patterns. "myfeat" not matching "my-feature-branch" is a hard failure against the requirements.
+
+5. **Bundle size is acceptable.** ~8kB gzip is trivial against the existing ~5MB application bundle.
+
+## Consequences
+
+- `fuse.js` is added to `web-app/package.json` dependencies.
+- `web-app/src/lib/hooks/useSessionSearch.ts` is the only consumer.
+- The Fuse index is rebuilt when the active session list changes (memoized). The `.search()` call runs synchronously on every keypress — the expected hot path.
+- If the threshold proves too permissive (too many low-relevance matches), tighten to `0.3`. If too strict (real matches missed), loosen to `0.5`. The threshold is the primary tuning knob.

--- a/project_plans/omni-bar-session-search/decisions/ADR-003-go-sync-map-dir-cache.md
+++ b/project_plans/omni-bar-session-search/decisions/ADR-003-go-sync-map-dir-cache.md
@@ -1,0 +1,58 @@
+# ADR-003: Go DirCache with sync.RWMutex, mtime Invalidation, and 60s TTL
+
+Status: Accepted
+Date: 2026-04-14
+Deciders: Tyler Stapler
+
+## Context
+
+`PathCompletionService` in `server/services/path_completion_service.go` is stateless. Every `ListPathCompletions` RPC call performs a fresh `os.ReadDir(baseDir)` with a 2-second timeout goroutine. The client has a 30-second TTL LRU cache in `usePathCompletions.ts`, but this is lost on page reload and not shared across browser sessions.
+
+The requirement is: path completion results must appear in <100ms on repeated opens (cache hit) and <500ms cold (first open after server restart).
+
+Four caching patterns were evaluated:
+
+| Pattern | Pros | Cons |
+|---|---|---|
+| In-memory map + mtime check | Correct invalidation, no background goroutine | One `os.Stat` per Get call (~1µs) |
+| TTL-only expiry | Simpler code | May show stale results up to TTL after directory change |
+| `sync.Map` (built-in) | Optimized for read-heavy | Less explicit control; no capacity limit built-in |
+| Disk-backed JSON | Survives server restart | High complexity; cold start budget <500ms is already met without it |
+
+Two thread-safety mechanisms were evaluated for the in-memory map:
+- `sync.Map`: built-in, optimized for append-once workloads (many readers, rare writes). No LRU/capacity limit built-in.
+- `sync.RWMutex` + `map[string]*dirCacheEntry`: explicit, allows capacity check and O(n) eviction on write.
+
+## Decision
+
+Implement `DirCache` in `server/services/dir_cache.go` using:
+- `sync.RWMutex` + `map[string]*dirCacheEntry` (not `sync.Map`)
+- Primary invalidation: mtime comparison via `os.Stat(baseDir)` on each `Get`
+- Fallback invalidation: 60-second hard TTL (handles network filesystems where mtime is unreliable)
+- Max capacity: 256 entries with O(n) oldest-cachedAt eviction
+- No disk persistence
+
+`PathCompletionService` becomes stateful with a `cache *DirCache` field. The `NewPathCompletionService()` constructor signature is unchanged.
+
+## Rationale
+
+1. **mtime-based invalidation is correct for single-level reads.** On macOS APFS/HFS+ and Linux ext4, adding or removing a direct child of a directory updates that directory's mtime. Since `os.ReadDir` operates on one directory level (not recursive), mtime change in `baseDir` means the cache entry is stale. The `os.Stat` overhead is ~1µs per Get call — negligible against the <100ms target.
+
+2. **60s TTL is the right backstop.** Network filesystems (NFS, SMB) may not update mtime synchronously. A 60-second backstop ensures cache entries never go stale for more than 1 minute in the worst case. The pitfalls research confirmed that for single-level caching (the only case here), mtime is reliable on local filesystems; the TTL handles the edge case.
+
+3. **`sync.RWMutex` over `sync.Map`.** The cache profile is read-heavy (many path completion calls for the same prefix burst) with rare writes (cache misses). Both provide safe concurrent reads. `sync.RWMutex` was chosen because it allows explicit capacity management (check `len(c.entries)` under write lock, evict before inserting) and produces clearer code for the Get/Put/evict pattern. `sync.Map` would also work but lacks built-in LRU capacity enforcement.
+
+4. **256 entries capacity.** A typical home directory traversal with 2-3 levels covers 20-50 unique `baseDir` values. 256 provides 5-10x headroom. O(n) eviction at n=256 is a scan of 256 pointers — sub-microsecond.
+
+5. **No disk persistence.** The cold-start budget is <500ms. The client's existing 30s cache covers most realistic page reloads. Disk persistence would add startup I/O, a serialization layer, and stale-on-restart risk (cached mtime may not match actual mtime after unmount/remount). The complexity is not justified until profiling shows the cold-start budget is violated.
+
+6. **Filtering runs per-request.** The cache stores raw `[]os.DirEntry` for the full base directory. Filtering by `filterPrefix`, `directoriesOnly`, and `showHidden` runs on every request. These are cheap CPU operations that depend on per-request parameters the cache cannot key on without significantly more complexity.
+
+## Consequences
+
+- New file: `server/services/dir_cache.go` implementing `DirCache` struct with `Get`, `Put`, `evictOldest`.
+- New file: `server/services/dir_cache_test.go` with tests for hit, mtime-miss, TTL-miss, eviction, concurrent safety.
+- `PathCompletionService.cache *DirCache` field added; zero callers need updating (constructor unchanged).
+- The existing `os.Stat(baseDir)` call at line 67 in `ListPathCompletions` now serves dual purpose: directory existence check + mtime capture for cache invalidation.
+- The goroutine+channel ReadDir block (lines 78-112) is wrapped with a cache lookup before and a cache store after on success.
+- Known limitation: mtime invalidation is unreliable on network filesystems. The 60s TTL is the backstop. Document as expected behavior.

--- a/project_plans/omni-bar-session-search/decisions/ADR-003-two-phase-omnibar-model.md
+++ b/project_plans/omni-bar-session-search/decisions/ADR-003-two-phase-omnibar-model.md
@@ -1,0 +1,40 @@
+# ADR-003: Two-Phase Omnibar Model (Discovery + Creation)
+
+Status: Accepted
+Date: 2026-04-14
+Deciders: Tyler Stapler
+
+## Context
+
+The Omnibar currently operates in a single mode: session creation. Adding session navigation (jump to existing session) and recent-repo quick-pick requires deciding how to blend two fundamentally different intent models in one input:
+
+- **Navigate intent**: user wants to jump to an existing session
+- **Create intent**: user wants to start a new session (existing behavior)
+
+Three interaction models were considered:
+1. Sigil-based mode switching (e.g., `>` for navigation, no prefix for creation) — VS Code pattern
+2. Two-phase sequential model (discovery list → creation form)
+3. Single merged result list with action labels
+
+## Decision
+
+Implement a two-phase Omnibar model:
+- **Phase 1 (Discovery)**: Input drives a fuzzy result list (sessions + recent repos). No form visible.
+- **Phase 2 (Creation)**: The existing session creation form. Entered when a repo result is selected or when input is detected as a local path or GitHub URL.
+
+## Rationale
+
+1. **Sigil-based switching rejected.** VS Code uses sigils because it has 8+ intent modes. Two modes do not justify learned syntax. Visual grouping achieves the same disambiguation with no cognitive overhead.
+2. **Single merged list rejected.** Session results (navigate → close omnibar) and repo results (fill form → stay in omnibar) have different primary actions. Interleaving them creates ambiguity for keyboard users. Research evidence: Linear, Raycast both use sections with headers for distinct action types.
+3. **Two-phase sequential is the Linear model.** Empty state shows recent sessions + recent repos. Selecting a session closes the omnibar. Selecting a repo transitions to Phase 2 with the path pre-filled.
+4. **Phase 2 is unchanged.** The existing creation form requires zero modification. The boundary between Phase 1 and Phase 2 is a mode state variable in `Omnibar.tsx`. This minimizes regression risk.
+5. **Path and GitHub URL inputs bypass Phase 1.** When the detector identifies a local path or GitHub URL, the omnibar jumps directly to Phase 2. This preserves all existing creation flows.
+
+## Consequences
+
+- `Omnibar.tsx` gains `omnibarMode: 'discovery' | 'creation'` state variable.
+- New components: `OmnibarResultList`, `OmnibarSessionResult`, `OmnibarRepoResult`.
+- Phase 2 (the existing form body and submit logic) is untouched.
+- Enter key behavior splits: Enter on session result → navigate; Enter on repo result → fill path + transition to creation; Cmd+Enter → submit form (only valid in Phase 2).
+- The `canSubmit` gate must exclude `InputType.SessionSearch` mode (no form to submit).
+- Escape from Phase 1 result list → dismiss list (first press); Escape again → close omnibar (second press). Same contract as path completion dropdown.

--- a/project_plans/omni-bar-session-search/decisions/ADR-004-dir-cache-design.md
+++ b/project_plans/omni-bar-session-search/decisions/ADR-004-dir-cache-design.md
@@ -1,0 +1,49 @@
+# ADR-004: Server-Side Directory Tree Cache Design
+
+Status: Accepted
+Date: 2026-04-14
+Deciders: Tyler Stapler
+
+## Context
+
+`PathCompletionService` in `server/services/path_completion_service.go` is currently stateless (comment at line 25: "It is stateless; each call performs a fresh directory listing"). Every `ListPathCompletions` RPC call executes a full `os.ReadDir(baseDir)` with a 2-second timeout.
+
+The client already has a 30s TTL LRU cache in `usePathCompletions.ts` (module-level `completionCache` at lines 27-55). This protects against burst typing but not against page reloads or cold server starts.
+
+Requirement 3 specifies: path completion results must appear in <100ms on repeated opens (cache hit) and <500ms cold.
+
+Four caching patterns were evaluated:
+1. In-memory map + mtime check (primary invalidation)
+2. TTL-only expiry (simpler, slightly less correct)
+3. `sync.Map` vs custom `sync.RWMutex` map
+4. Disk-backed JSON persistence
+
+## Decision
+
+Implement a server-side in-memory `DirCache` in a new file `server/services/dir_cache.go` with:
+- Key: absolute `baseDir` path (after tilde expansion)
+- Invalidation: mtime comparison on `os.Stat(baseDir)` — if directory mtime changed, cache entry is invalid
+- Fallback TTL: 60 seconds (handles network filesystems where mtime updates are unreliable)
+- Max size: 256 entries with LRU eviction (O(n) scan acceptable at this scale)
+- Thread safety: `sync.RWMutex` with read-lock for Get, write-lock for Put/eviction
+- No disk persistence initially
+
+`PathCompletionService` becomes stateful by adding a `*DirCache` field. The `NewPathCompletionService()` constructor signature is unchanged — it allocates the cache internally.
+
+## Rationale
+
+1. **mtime-based invalidation is correct for single-level reads.** On macOS (APFS/HFS+), adding or removing a direct child of a directory updates that directory's mtime. `os.ReadDir` operates on one directory level. The pitfalls research confirms this is sufficient for the use case.
+2. **60s TTL as safety net.** Network filesystems and some edge cases may not update mtime reliably. The TTL backstop catches these without sacrificing correctness in the common case.
+3. **256 entries.** A typical home directory traversal with 2-3 levels of drilling covers ~20-50 unique `baseDir` values. 256 provides generous headroom.
+4. **`sync.RWMutex` over `sync.Map`.** The cache profile is read-heavy (many path completion calls) with rare writes (cache miss). `sync.RWMutex` allows concurrent reads; `sync.Map` would also work but `RWMutex` gives explicit control and clarity.
+5. **No disk persistence.** Cold-start budget is <500ms. The client's existing 30s cache covers most realistic reloads. Disk persistence adds complexity for marginal gain at the current scale.
+6. **Filtering still runs per-request.** The cache stores raw `[]os.DirEntry` for the base directory. Filtering by `filterPrefix`, `directoriesOnly`, and `showHidden` continues to run on every request (cheap CPU operations that depend on per-request parameters).
+
+## Consequences
+
+- New file: `server/services/dir_cache.go` with `DirCache` struct.
+- `PathCompletionService` struct gains `cache *DirCache` field.
+- `NewPathCompletionService()` allocates `NewDirCache(256, 60*time.Second)` internally — no caller changes required.
+- The `os.ReadDir` goroutine in `ListPathCompletions` (lines 88-91) is wrapped with a cache check before and a cache store after.
+- `os.Stat(baseDir)` at line 67 now serves double duty: existence check + mtime capture for cache invalidation.
+- Tests required: cache hit, mtime invalidation, TTL expiry, concurrent read safety.

--- a/project_plans/omni-bar-session-search/implementation/plan.md
+++ b/project_plans/omni-bar-session-search/implementation/plan.md
@@ -1,0 +1,1102 @@
+# Implementation Plan: Omni Bar Session Search
+
+Status: Ready for Implementation
+Created: 2026-04-14
+Branch: claude-squad-better-search-fuzzy
+MDD Spec: `project_plans/omni-bar-session-search/`
+
+---
+
+## Epic Overview
+
+**User value:** Reach any existing session via the Omnibar in 3 keystrokes or fewer after Cmd+K; start a new session on any previously-used repo in 5 keystrokes or fewer.
+
+**Success metrics:**
+- Path completion results appear in <100ms on cache hit (repeated open); <500ms cold
+- Session search results update on every keypress with no perceptible delay (<16ms)
+- Zero new RPC endpoints for session search (client-side only)
+- Zero proto changes
+
+**Scope — Must Have:**
+1. Session navigation — fuzzy search existing sessions from Omnibar; selecting navigates to that session
+2. Recent repos quick-pick — frecent paths shown in empty state; selecting pre-fills path for new session creation
+3. Fuzzy matching quality — Fuse.js multi-field weighted session search
+4. Directory tree cache — stateful `DirCache` in `PathCompletionService` with mtime + TTL invalidation
+
+**Out of scope:**
+- Global OS-level hotkey (system-wide Cmd+K)
+- AI/LLM suggestions
+- Non-session navigation (Settings, Help, etc.)
+- Mobile/responsive layout
+- Remote path support (SSH, network mounts)
+- Disk-backed cache persistence
+- Worktree list caching (lower priority; separate follow-up)
+
+---
+
+## Dependency Diagram
+
+```
+Story 1: Go Directory Cache (backend)
+    |
+    | (independent — ship any time)
+    |
+Story 2: Detector + usePathHistory Fixes (frontend plumbing)
+    |
+    +---> Story 3: useSessionSearch hook
+              |
+              +---> Story 4: OmnibarResultList UI components
+                        |
+                        +---> Story 5: Omnibar Two-Phase Integration (wires everything)
+```
+
+Stories 1 and 2 are fully independent and can be worked in parallel. Story 3 depends on Story 2 (needs `InputType.SessionSearch`). Story 4 depends on Story 3 (needs the hook's return type to define component props). Story 5 depends on Stories 2, 3, and 4.
+
+---
+
+## Story 1: Go Directory Cache
+
+**Value:** Eliminates redundant `os.ReadDir` calls on every Omnibar open. Meets the <100ms repeated-open requirement.
+
+**Files:**
+- `server/services/dir_cache.go` — new file, `DirCache` struct
+- `server/services/path_completion_service.go` — add `cache *DirCache` field, wrap ReadDir call
+
+### Task 1.1 — Implement DirCache
+
+**File:** `server/services/dir_cache.go` (new)
+
+**What to build:**
+
+```go
+package services
+
+import (
+    "os"
+    "sync"
+    "time"
+)
+
+type dirCacheEntry struct {
+    entries  []os.DirEntry
+    dirMtime time.Time
+    cachedAt time.Time
+}
+
+type DirCache struct {
+    mu      sync.RWMutex
+    entries map[string]*dirCacheEntry
+    maxSize int
+    ttl     time.Duration
+}
+
+func NewDirCache(maxSize int, ttl time.Duration) *DirCache {
+    return &DirCache{
+        entries: make(map[string]*dirCacheEntry, maxSize),
+        maxSize: maxSize,
+        ttl:     ttl,
+    }
+}
+
+// Get returns cached DirEntry slice for path if it is still valid.
+// Validity: cachedAt within TTL AND directory mtime unchanged.
+// Returns (nil, false) on miss, stale TTL, or changed mtime.
+func (c *DirCache) Get(path string) ([]os.DirEntry, bool) { ... }
+
+// Put stores entries for path. Evicts oldest entry when at maxSize.
+func (c *DirCache) Put(path string, entries []os.DirEntry, dirMtime time.Time) { ... }
+
+// evictOldest removes the entry with the oldest cachedAt. Caller holds write lock.
+func (c *DirCache) evictOldest() { ... }
+```
+
+**Implementation notes:**
+- `Get`: acquire read lock, check entry exists; if not, return miss. Check `time.Since(entry.cachedAt) > c.ttl` — return miss if expired. Call `os.Stat(path)` to get current mtime; if `info.ModTime().After(entry.dirMtime)` return miss (delete entry under write lock). Otherwise return entries.
+- `Put`: acquire write lock, if `len(c.entries) >= c.maxSize` call `evictOldest()`. Store new entry.
+- `evictOldest`: O(n) scan to find entry with smallest `cachedAt`. Acceptable at n=256.
+- No goroutines; no background cleanup; all operations are on-demand.
+
+**Tests to write** (`server/services/dir_cache_test.go`):
+1. `TestDirCache_Hit` — Put then Get returns same entries
+2. `TestDirCache_MissOnMtimeChange` — Put, then simulate mtime change via temp dir, Get returns miss
+3. `TestDirCache_MissOnTTLExpiry` — Put with 1ms TTL, sleep, Get returns miss
+4. `TestDirCache_Eviction` — Fill to maxSize, add one more, total entries stays at maxSize
+5. `TestDirCache_ConcurrentReads` — 10 goroutines Get simultaneously after one Put, no data race (run with `-race`)
+
+**INVEST:** Independent (no frontend dependency), Negotiable (eviction policy), Valuable (hits <100ms target), Estimable (1-2 hours), Small (single file + test file), Testable (all behaviors have unit tests).
+
+---
+
+### Task 1.2 — Wire DirCache into PathCompletionService
+
+**File:** `server/services/path_completion_service.go`
+
+**Changes:**
+
+1. Change struct definition:
+```go
+// Before
+type PathCompletionService struct{}
+
+// After
+type PathCompletionService struct {
+    cache *DirCache
+}
+```
+
+2. Change constructor:
+```go
+// Before
+func NewPathCompletionService() *PathCompletionService {
+    return &PathCompletionService{}
+}
+
+// After
+func NewPathCompletionService() *PathCompletionService {
+    return &PathCompletionService{
+        cache: NewDirCache(256, 60*time.Second),
+    }
+}
+```
+
+3. In `ListPathCompletions`, after the `baseDirExists` check (line 76), capture mtime from the existing `baseDirInfo`:
+```go
+// baseDirInfo is already computed above (line 67-68)
+dirMtime := baseDirInfo.ModTime()
+```
+
+4. Replace the goroutine+channel ReadDir block (lines 78-112) with a cache-aware wrapper:
+```go
+// Check cache first
+var dirEntries []os.DirEntry
+if cached, ok := p.cache.Get(baseDir); ok {
+    dirEntries = cached
+} else {
+    // existing goroutine+channel ReadDir logic producing dirEntries
+    // ... (unchanged from current implementation)
+    if readErr == nil {
+        p.cache.Put(baseDir, dirEntries, dirMtime)
+    }
+}
+```
+
+**No other changes.** Filtering, pagination, and response construction are unchanged.
+
+**Tests to write** (`server/services/path_completion_service_test.go` — extend existing):
+1. `TestListPathCompletions_CacheHit` — call twice for same path, second call returns same entries without new ReadDir
+2. `TestListPathCompletions_CacheMissAfterMtimeChange` — call once, modify directory, call again, gets fresh entries
+
+**INVEST:** Depends only on Task 1.1, small change to one function, testable via integration test.
+
+---
+
+## Story 2: Detector + usePathHistory Fixes
+
+**Value:** Makes bare-text queries (e.g., "squad", "my-feature") route to session-search mode instead of `InputType.Unknown`. Adds `getAll()` to expose recent repos without prefix filtering. Fixes the `dropdownDismissed` stickiness bug between mode transitions.
+
+**Files:**
+- `web-app/src/lib/omnibar/types.ts` — add `InputType.SessionSearch`
+- `web-app/src/lib/omnibar/detector.ts` — add `SessionSearchDetector`, register at priority 200
+- `web-app/src/lib/hooks/usePathHistory.ts` — add `getAll(limit)` method, expose from hook return
+
+### Task 2.1 — Add InputType.SessionSearch
+
+**File:** `web-app/src/lib/omnibar/types.ts`
+
+Add to `InputType` enum:
+```typescript
+SessionSearch = "session_search",
+```
+
+Add to `INPUT_TYPE_INFO`:
+```typescript
+[InputType.SessionSearch]: {
+  label: "Search Sessions",
+  icon: "🔍",
+  description: "Search existing sessions",
+},
+```
+
+**File:** `web-app/src/lib/omnibar/detector.ts`
+
+Add new detector class after `LocalPathDetector`:
+```typescript
+/**
+ * Session Search detector — catch-all for bare-text queries.
+ * Fires for any non-empty input that no other detector claimed.
+ * Priority 200 ensures it runs last (after LocalPath at priority 100).
+ */
+class SessionSearchDetector implements Detector {
+  name = "SessionSearch";
+  priority = 200;
+
+  detect(input: string): DetectionResult | null {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+    // All inputs that reach this point have already been rejected by
+    // GitHub URL detectors (priorities 10-40), PathWithBranch (50),
+    // and LocalPath (100). They are bare-text session search queries.
+    return {
+      type: InputType.SessionSearch,
+      confidence: 0.5,
+      parsedValue: trimmed,
+      suggestedName: "",
+    };
+  }
+}
+```
+
+Register in `createDefaultRegistry()`:
+```typescript
+registry.register(new SessionSearchDetector());
+```
+
+**Critical:** The empty-input case (`input === ""`) is handled by `Omnibar.tsx` which sets `detection = null` when input is empty (line 171-173). The `SessionSearchDetector` must return `null` for empty input to preserve this behavior.
+
+**Pitfall addressed:** P1 — Detector mode conflict. Without this, bare-text queries resolve to `InputType.Unknown`, blocking session result display and flagging `canSubmit = false`.
+
+**Tests:** Add to existing detector tests:
+1. `"squad"` → `InputType.SessionSearch`
+2. `"my-feature"` → `InputType.SessionSearch`
+3. `""` → falls through to `InputType.Unknown` (the registry default)
+4. `"~/projects"` → still `InputType.LocalPath` (not hijacked by SessionSearch)
+5. `"org/repo"` → still `InputType.GitHubShorthand`
+
+---
+
+### Task 2.2 — Add getAll() to usePathHistory
+
+**File:** `web-app/src/lib/hooks/usePathHistory.ts`
+
+Add `getAll` alongside `getMatching`:
+```typescript
+/**
+ * Return all stored paths sorted by score desc, limited to `limit` entries.
+ * Used for "Recent Repos" empty-state display when no query is active.
+ */
+const getAll = useCallback(
+  (limit: number = MAX_RESULTS): PathHistoryEntry[] => {
+    return [...entries]
+      .sort((a, b) => entryScore(b) - entryScore(a))
+      .slice(0, limit);
+  },
+  [entries]
+);
+```
+
+Update hook return value:
+```typescript
+// Before
+return { getMatching, save };
+
+// After
+return { getMatching, getAll, save };
+```
+
+**No other changes.** The `entryScore` function and storage logic are unchanged.
+
+**Pitfall addressed:** P3 — `getMatching` is prefix-only; `getAll` is needed for the empty-state recent repos list.
+
+**Tests:** Add to `usePathHistory` tests:
+1. `getAll(5)` returns top 5 by score when more than 5 entries exist
+2. `getAll()` returns all entries sorted by score when fewer than limit
+3. After `save(path)`, `getAll()` includes the newly saved path
+4. Score ordering: entry used 2 hours ago > entry used 3 weeks ago
+
+---
+
+### Task 2.3 — Fix dropdownDismissed stickiness on mode transition
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+In the detection `useEffect` (lines 146-181), after `setDetection(result)`, add:
+```typescript
+// Reset dropdown dismissed state when input type changes modes.
+// Prevents session results from being suppressed after user dismisses
+// path completion dropdown then backspaces to bare text.
+setDropdownDismissed(false);
+```
+
+This reset must happen on every detection type change, not just on character input (which already resets it). The detection runs 150ms debounced, so the reset happens at most 150ms after the mode switch — acceptable UX.
+
+**Pitfall addressed:** P2 — `dropdownDismissed` stickiness. If user types a path, presses Escape to dismiss path completions (sets `dropdownDismissed = true`), then backspaces to bare text, session results would be suppressed without this fix.
+
+**Tests:** Verify in OmnibarResultList integration test that session results appear after: type path → press Escape → backspace to bare text → type session query.
+
+**INVEST:** All three tasks in Story 2 are small, independently testable changes to separate files. Together they form a coherent plumbing story required before Stories 3-5.
+
+---
+
+## Story 3: useSessionSearch Hook
+
+**Value:** Client-side fuzzy session search using Fuse.js. Powers the sessions section of the result list.
+
+**Prerequisite:** Story 2 (needs `InputType.SessionSearch` to know when to show results).
+
+**Files:**
+- `web-app/package.json` — add `fuse.js` dependency
+- `web-app/src/lib/hooks/useSessionSearch.ts` — new file
+
+### Task 3.1 — Install fuse.js
+
+```bash
+cd web-app && npm install fuse.js
+```
+
+Verify `"fuse.js"` appears in `web-app/package.json` dependencies. No other configuration changes.
+
+**Version note:** Use fuse.js v7.x (latest stable). The API used here (`new Fuse(list, options)`, `.search(query)`) is stable since v6.
+
+---
+
+### Task 3.2 — Implement useSessionSearch hook
+
+**File:** `web-app/src/lib/hooks/useSessionSearch.ts` (new)
+
+```typescript
+"use client";
+
+import { useMemo } from "react";
+import Fuse from "fuse.js";
+import { Session, SessionStatus } from "@/gen/session/v1/types_pb";
+import { useAppSelector } from "@/lib/store";
+import { selectAllSessions } from "@/lib/store/sessionsSlice";
+
+export interface SessionSearchResult {
+  session: Session;
+  score: number; // 0.0 = perfect match, 1.0 = no match (Fuse.js convention)
+  matchedFields: string[]; // which fields contributed to the match
+}
+
+// Fuse.js config: multi-field weighted search
+// title:0.5 > branch:0.3 > path:0.15 > tags:0.05
+// threshold:0.4 — allow moderate fuzziness; tighten if too many false positives
+// minMatchCharLength:1 — single character queries return results
+const FUSE_OPTIONS: Fuse.IFuseOptions<Session> = {
+  keys: [
+    { name: "title", weight: 0.5 },
+    { name: "branch", weight: 0.3 },
+    { name: "path", weight: 0.15 },
+    { name: "tags", weight: 0.05 },
+  ],
+  includeScore: true,
+  includeMatches: true,
+  threshold: 0.4,
+  minMatchCharLength: 1,
+  ignoreLocation: true, // don't penalize matches far from string start
+};
+
+// Sessions in these statuses are excluded from results
+const EXCLUDED_STATUSES = new Set([
+  SessionStatus.STOPPED,
+  SessionStatus.UNSPECIFIED,
+]);
+
+/**
+ * Client-side fuzzy session search using Fuse.js.
+ * Returns ranked results for display in the Omnibar session section.
+ * Empty query returns empty array (empty state shows recents instead).
+ */
+export function useSessionSearch(query: string): SessionSearchResult[] {
+  const sessions = useAppSelector(selectAllSessions);
+
+  // Filter to active sessions only
+  const activeSessions = useMemo(
+    () => sessions.filter((s) => !EXCLUDED_STATUSES.has(s.status)),
+    [sessions]
+  );
+
+  // Rebuild Fuse index when active session list changes
+  const fuse = useMemo(
+    () => new Fuse(activeSessions, FUSE_OPTIONS),
+    [activeSessions]
+  );
+
+  return useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    const results = fuse.search(trimmed, { limit: 8 });
+
+    return results.map((r) => ({
+      session: r.item,
+      score: r.score ?? 1.0,
+      matchedFields: r.matches?.map((m) => m.key ?? "") ?? [],
+    }));
+  }, [query, fuse]);
+}
+```
+
+**Implementation notes:**
+- `ignoreLocation: true` — prevents Fuse.js from penalizing matches that appear deep in the path string. Without this, "squad" matching the tail of "stapler-squad" would score lower than if "squad" appeared at position 0.
+- `limit: 8` passed to `fuse.search()` — caps results before any filtering.
+- The Fuse index (`new Fuse(...)`) is rebuilt only when `activeSessions` changes, not on every query. The `.search()` call runs on every query change; this is the fast path (<1ms for hundreds of sessions).
+- `STOPPED` and `UNSPECIFIED` sessions excluded. Navigating to a stopped session is a confusing UX (the terminal is not running).
+
+**Tests** (`web-app/src/lib/hooks/useSessionSearch.test.ts`):
+1. Empty query returns `[]`
+2. Query matching title scores higher than same query matching only path
+3. STOPPED sessions are excluded from results
+4. Results are capped at 8
+5. "squad" matches session with title "stapler-squad" (fuzzy non-prefix match)
+6. "myfeat" matches branch "my-feature-branch" (character-sequence fuzzy)
+7. Title weight dominance: session A with "auth" in title outranks session B with "auth" only in path
+
+**INVEST:** Independent of UI stories, fully testable in isolation, clear acceptance criteria.
+
+---
+
+## Story 4: OmnibarResultList UI Components
+
+**Value:** Renders the two-section result list (sessions + repos) with keyboard navigation. Visually distinguishes session results from repo results.
+
+**Prerequisite:** Story 3 (needs `SessionSearchResult` type). Also needs `PathHistoryEntry` from Story 2's `getAll()`.
+
+**Files:**
+- `web-app/src/components/sessions/OmnibarResultList.tsx` — new
+- `web-app/src/components/sessions/OmnibarResultList.css.ts` — new (vanilla-extract)
+- `web-app/src/components/sessions/OmnibarSessionResult.tsx` — new
+- `web-app/src/components/sessions/OmnibarSessionResult.css.ts` — new
+- `web-app/src/components/sessions/OmnibarRepoResult.tsx` — new
+- `web-app/src/components/sessions/OmnibarRepoResult.css.ts` — new
+
+### Task 4.1 — OmnibarSessionResult row component
+
+**File:** `web-app/src/components/sessions/OmnibarSessionResult.tsx` (new)
+
+Visual layout:
+```
+[status dot]  [session title (bold)]           [branch (muted, right)]
+              [repo path (muted, smaller)]
+```
+
+Props interface:
+```typescript
+interface OmnibarSessionResultProps {
+  session: Session;
+  isHighlighted: boolean;
+  onSelect: (session: Session) => void;
+}
+```
+
+Status dot: colored `<span>` with `aria-label` set to status string.
+- `SessionStatus.RUNNING` → green (#22c55e)
+- `SessionStatus.PAUSED` → yellow (#eab308)
+- `SessionStatus.READY` → blue (#3b82f6)
+- Other → grey (#6b7280)
+
+Path display: show only the last 2 segments of the path to avoid overflow (e.g., `/Users/tyler/projects/auth` → `projects/auth`).
+
+**Accessibility:** The row is a `<li role="option">` inside the `OmnibarResultList`'s `<ul role="listbox">`. `aria-selected` reflects `isHighlighted`. `id` must be `omnibar-result-session-{session.id}` for `aria-activedescendant` on the input.
+
+**CSS** (`OmnibarSessionResult.css.ts`): Use `vars` from `web-app/src/styles/theme.css.ts`. Two-line layout via flex-column. Status dot is a 8px `border-radius: 50%` span with inline color.
+
+---
+
+### Task 4.2 — OmnibarRepoResult row component
+
+**File:** `web-app/src/components/sessions/OmnibarRepoResult.tsx` (new)
+
+Visual layout:
+```
+[folder icon]  [parent/path (muted)] / [repo-name (bold)]    [relative time (muted, right)]
+               [N sessions] (muted, small)
+```
+
+Props interface:
+```typescript
+interface OmnibarRepoResultProps {
+  entry: PathHistoryEntry;
+  sessionCount?: number;
+  isHighlighted: boolean;
+  onSelect: (path: string) => void;
+}
+```
+
+Path splitting: `const parts = path.split('/').filter(Boolean); const repoName = parts[parts.length - 1]; const parent = parts.slice(-3, -1).join('/');`
+
+Relative time: use a simple inline util (no library needed):
+```typescript
+function relativeTime(epochMs: number): string {
+  const diff = Date.now() - epochMs;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+  return `${Math.floor(diff / (7 * 86_400_000))}w ago`;
+}
+```
+
+Accessibility: `<li role="option">`, same `aria-selected` / `id` pattern as `OmnibarSessionResult`. Id format: `omnibar-result-repo-{encodeURIComponent(entry.path)}`.
+
+---
+
+### Task 4.3 — OmnibarResultList container component
+
+**File:** `web-app/src/components/sessions/OmnibarResultList.tsx` (new)
+
+This component owns the keyboard navigation state for the result list and renders both sections.
+
+Props interface:
+```typescript
+interface OmnibarResultListProps {
+  sessionResults: SessionSearchResult[];
+  repoEntries: PathHistoryEntry[];
+  sessionCounts?: Record<string, number>; // path → session count, for repo rows
+  onSessionSelect: (session: Session) => void;
+  onRepoSelect: (path: string) => void;
+  highlightedIndex: number; // controlled from parent (Omnibar)
+  // "Create new session" always-present item at bottom
+  onCreateNew: () => void;
+}
+```
+
+**Rendering logic:**
+- Show "SESSIONS" section header + session rows if `sessionResults.length > 0`
+- Show "REPOS" section header + repo rows if `repoEntries.length > 0`
+- Show "+ New Session" item at bottom with a visual separator (always present)
+- Hide entire component if both sections are empty and no create-new item needed
+
+**Section headers:** `<div role="presentation" aria-hidden="true">` — they are visual only, not keyboard-navigable.
+
+**Flat index management:** The component exposes a `totalItemCount` (sessions + repos + 1 for create-new) so the parent Omnibar can drive arrow-key navigation. The `highlightedIndex` prop maps: 0..sessionResults.length-1 = sessions, sessionResults.length..sessionResults.length+repoEntries.length-1 = repos, last = create-new.
+
+**ARIA:** The list is `<ul role="listbox" id="omnibar-result-listbox">`. The parent input's `aria-controls` points to this id. `aria-activedescendant` on the input tracks the highlighted item's id.
+
+**CSS** (`OmnibarResultList.css.ts`):
+```typescript
+import { style } from '@vanilla-extract/css';
+import { vars } from '../../styles/theme.css';
+
+export const resultList = style({
+  listStyle: 'none',
+  margin: 0,
+  padding: `${vars.space[1]} 0`,
+  maxHeight: '320px',
+  overflowY: 'auto',
+});
+
+export const sectionHeader = style({
+  padding: `${vars.space[1]} ${vars.space[3]}`,
+  fontSize: vars.fontSize.xs,
+  fontWeight: 600,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: vars.color.textMuted,
+  userSelect: 'none',
+});
+
+export const separator = style({
+  height: '1px',
+  background: vars.color.borderDefault,
+  margin: `${vars.space[1]} ${vars.space[3]}`,
+});
+```
+
+**Tests** (`web-app/src/components/sessions/OmnibarResultList.test.tsx`):
+1. Renders session section only when sessionResults non-empty, repoEntries empty
+2. Renders repo section only when repoEntries non-empty, sessionResults empty
+3. Hides empty sections (no "SESSIONS" header when sessionResults is `[]`)
+4. "+ New Session" item always renders
+5. Arrow key down from last session item moves highlight to first repo item (skips section header)
+6. `onSessionSelect` called with correct session on Enter when session highlighted
+7. `onRepoSelect` called with correct path on Enter when repo highlighted
+
+**INVEST:** Depends on Tasks 4.1 and 4.2 for row components, but those can be stubbed for testing. All navigation logic is testable with shallow render.
+
+---
+
+## Story 5: Omnibar Two-Phase Integration
+
+**Value:** Wires session search, recent repos, and the result list into the existing Omnibar component. Implements the two-phase (discovery/creation) mode state. This is the story that delivers the full feature end-to-end.
+
+**Prerequisite:** Stories 2, 3, and 4.
+
+**Files:**
+- `web-app/src/components/sessions/Omnibar.tsx` — significant additions, no deletion of existing form logic
+- `web-app/src/components/sessions/Omnibar.module.css` — minor additions for mode-transition styles
+
+### Task 5.1 — Add mode state and session navigation callback
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+**New prop:**
+```typescript
+interface OmnibarProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreateSession: (data: OmnibarSessionData) => Promise<void>;
+  onNavigateToSession: (sessionId: string) => void; // NEW
+}
+```
+
+**New state:**
+```typescript
+type OmnibarMode = "discovery" | "creation";
+const [mode, setMode] = useState<OmnibarMode>("discovery");
+const [resultHighlightIndex, setResultHighlightIndex] = useState(-1);
+```
+
+**Mode logic:**
+- `mode` starts as `"discovery"` on open
+- Transitions to `"creation"` when:
+  - User selects a repo result (path pre-filled into input)
+  - Input is detected as `InputType.LocalPath` or `InputType.PathWithBranch` (existing path detection)
+- Transitions back to `"discovery"` when:
+  - Input is detected as `InputType.SessionSearch`
+  - Input is cleared (empty)
+
+Add to the detection `useEffect`, after `setDetection(result)`:
+```typescript
+if (
+  result.type === InputType.LocalPath ||
+  result.type === InputType.PathWithBranch ||
+  result.type === InputType.GitHubPR ||
+  result.type === InputType.GitHubBranch ||
+  result.type === InputType.GitHubRepo ||
+  result.type === InputType.GitHubShorthand
+) {
+  setMode("creation");
+} else if (result.type === InputType.SessionSearch) {
+  setMode("discovery");
+}
+```
+
+When input is cleared:
+```typescript
+// In the else branch (empty input, line 171-173):
+setDetection(null);
+setMode("discovery");
+```
+
+---
+
+### Task 5.2 — Wire session search and recent repos hooks
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+Add hooks at the top of the component body:
+
+```typescript
+import Fuse from "fuse.js";
+
+// Session search (only active in discovery mode)
+const sessionSearchQuery =
+  detection?.type === InputType.SessionSearch ? input : "";
+const sessionResults = useSessionSearch(sessionSearchQuery);
+
+// Recent repos for empty-state discovery
+const { getAll: getAllHistory } = usePathHistory();
+// useRepositorySuggestions for frecency-ranked paths from existing sessions
+const { suggestions: repoSuggestions } = useRepositorySuggestions();
+
+// What to show in the result list
+const isDiscoveryMode = mode === "discovery" || !input.trim();
+
+// Stable snapshot of recent repo entries — rebuilt only when history changes.
+// Capped at 50 so Fuse index stays small.
+const allRepoEntries = useMemo(() => getAllHistory(50), [getAllHistory]);
+
+// Fuse instance over repo paths — same threshold/ignoreLocation as session search
+// for consistent match quality. Rebuilt only when allRepoEntries changes.
+const repoFuse = useMemo(
+  () =>
+    new Fuse(allRepoEntries, {
+      keys: [{ name: "path", weight: 1.0 }],
+      threshold: 0.4,
+      ignoreLocation: true,
+      minMatchCharLength: 1,
+    }),
+  [allRepoEntries]
+);
+
+// Empty state: show top-5 recent sessions + top-5 repo suggestions
+// Active search: show session results + fuzzy-filtered repo suggestions
+const displayedSessionResults = useMemo(() => {
+  if (!input.trim()) {
+    // Empty state — not yet implemented here; sessions come from Redux
+    // selectAllSessions sorted by updatedAt, top 5
+    return []; // populated in Task 5.3
+  }
+  return sessionResults;
+}, [input, sessionResults]);
+
+const displayedRepoEntries = useMemo(() => {
+  if (!input.trim()) {
+    // Empty state — top 5 by frecency score
+    return allRepoEntries.slice(0, 5);
+  }
+  // Active search — fuzzy match against path (same quality as session search)
+  return repoFuse.search(input).map((r) => r.item).slice(0, 8);
+}, [input, allRepoEntries, repoFuse]);
+```
+
+**Why fuse.js here too:** The requirements specify fuzzy search for previously-used repos ("create a new session based on a repo I've already used before based on fuzzy search"). Substring `.includes()` would miss "squad" → "stapler-squad". Since fuse.js is already installed for session search (Story 3), there is no additional dependency cost. The same `threshold: 0.4` and `ignoreLocation: true` settings are used for consistency.
+
+**Fuse instance stability:** `allRepoEntries` is memoized from `getAllHistory(50)`. `getAllHistory` is a `useCallback` inside `usePathHistory` — it only changes reference when the stored entries change (i.e. when `save()` is called). In practice the Fuse index rebuilds only when the user creates a new session or uses a new path, not on every keystroke.
+
+---
+
+### Task 5.3 — Empty state: recent sessions from Redux
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+For the empty-state session list, select top-5 sessions from Redux sorted by `updatedAt` desc:
+
+```typescript
+// At hook level (outside useMemo, to get selector):
+const allSessions = useAppSelector(selectAllSessions);
+
+// Inside displayedSessionResults useMemo, empty-state branch:
+if (!input.trim()) {
+  const active = allSessions
+    .filter((s) => s.status !== SessionStatus.STOPPED && s.status !== SessionStatus.UNSPECIFIED)
+    .sort((a, b) => {
+      const aTime = a.updatedAt ? Number(a.updatedAt.seconds) : 0;
+      const bTime = b.updatedAt ? Number(b.updatedAt.seconds) : 0;
+      return bTime - aTime;
+    })
+    .slice(0, 5);
+  return active.map((s) => ({ session: s, score: 0, matchedFields: [] }));
+}
+```
+
+---
+
+### Task 5.4 — Handle session result selection
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+Add handler:
+```typescript
+const handleSessionSelect = useCallback(
+  (session: Session) => {
+    onNavigateToSession(session.id);
+    onClose();
+  },
+  [onNavigateToSession, onClose]
+);
+```
+
+**Pitfall addressed (P1):** Enter key ambiguity. The `handleKeyDown` must route Enter by current context:
+- If `isDiscoveryMode` and `resultHighlightIndex >= 0` (a result is highlighted):
+  - If highlighted item is a session → call `handleSessionSelect`
+  - If highlighted item is a repo → call `handleRepoSelect`
+  - If highlighted item is create-new → call `handleCreateNew`
+  - In all cases, `e.preventDefault()` and `return` before the Cmd+Enter check
+- Otherwise, existing Cmd+Enter → `handleSubmit` behavior unchanged
+
+```typescript
+// Inside handleKeyDown, at the top of the function (before isDropdownVisible check):
+if (isDiscoveryMode && resultHighlightIndex >= 0) {
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    setResultHighlightIndex((i) => Math.min(i + 1, totalResultCount - 1));
+    return;
+  }
+  if (e.key === "ArrowUp") {
+    e.preventDefault();
+    setResultHighlightIndex((i) => Math.max(i - 1, -1));
+    return;
+  }
+  if (e.key === "Enter" && !e.metaKey) {
+    e.preventDefault();
+    // dispatch based on which item is highlighted
+    dispatchHighlightedResultAction(resultHighlightIndex);
+    return;
+  }
+  if (e.key === "Escape") {
+    e.nativeEvent.stopImmediatePropagation();
+    setResultHighlightIndex(-1);
+    return; // first Escape clears highlight; second Escape closes (falls through)
+  }
+}
+```
+
+---
+
+### Task 5.5 — Handle repo result selection (pre-fill + mode transition)
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+```typescript
+const handleRepoSelect = useCallback(
+  (path: string) => {
+    setInput(path + "/");
+    setMode("creation");
+    setResultHighlightIndex(-1);
+    setDropdownDismissed(false);
+    inputRef.current?.focus();
+  },
+  []
+);
+```
+
+This pre-fills the input with the repo path, which will trigger path detection on the next debounce cycle (150ms), transitioning the omnibar into creation mode with the path completion dropdown active.
+
+---
+
+### Task 5.6 — Render OmnibarResultList conditionally
+
+**File:** `web-app/src/components/sessions/Omnibar.tsx`
+
+In the JSX, replace the path completion dropdown block and add discovery mode rendering:
+
+```tsx
+{/* Discovery mode: session results + recent repos */}
+{isDiscoveryMode && (
+  <OmnibarResultList
+    sessionResults={displayedSessionResults}
+    repoEntries={displayedRepoEntries}
+    highlightedIndex={resultHighlightIndex}
+    onSessionSelect={handleSessionSelect}
+    onRepoSelect={handleRepoSelect}
+    onCreateNew={handleCreateNew}
+  />
+)}
+
+{/* Creation mode: existing path completion dropdown (unchanged) */}
+{!isDiscoveryMode && isDropdownVisible && (
+  <PathCompletionDropdown
+    id="path-completion-listbox"
+    entries={mergedEntries}
+    historyCount={historyCount}
+    selectedIndex={dropdownIndex}
+    onSelect={handleCompletionSelect}
+    isLoading={isCompletionLoading}
+  />
+)}
+```
+
+**Conditional form body:** Show `<div className={styles.body}>` only in `creation` mode:
+```tsx
+{mode === "creation" && (
+  <div className={styles.body}>
+    {/* ... existing form fields unchanged ... */}
+  </div>
+)}
+```
+
+**Update footer hints:**
+```tsx
+<div className={styles.shortcuts}>
+  <span className={styles.shortcut}>
+    <span className={styles.shortcutKey}>Esc</span> Close
+  </span>
+  {mode === "creation" && (
+    <span className={styles.shortcut}>
+      <span className={styles.shortcutKey}>⌘↵</span> Create
+    </span>
+  )}
+  {isDiscoveryMode && (
+    <>
+      <span className={styles.shortcut}>
+        <span className={styles.shortcutKey}>↑↓</span> Navigate
+      </span>
+      <span className={styles.shortcut}>
+        <span className={styles.shortcutKey}>↵</span> Jump
+      </span>
+    </>
+  )}
+</div>
+```
+
+**Update placeholder text:**
+```tsx
+placeholder={
+  mode === "creation"
+    ? "Enter path, GitHub URL, or owner/repo..."
+    : "Jump to session or search repos..."
+}
+```
+
+**Update canSubmit:** Add `InputType.SessionSearch` to the block list:
+```typescript
+if (!detection || detection.type === InputType.Unknown || detection.type === InputType.SessionSearch) return false;
+```
+
+**INVEST:** All tasks in Story 5 modify a single file. Each task is independently reviewable. The story is complete when all six tasks pass their respective tests.
+
+---
+
+## Quality Gates
+
+### Go cache unit tests
+
+Location: `server/services/dir_cache_test.go`
+
+| Test | Scenario |
+|---|---|
+| `TestDirCache_Hit` | Put entries, Get returns same slice |
+| `TestDirCache_MissOnMtimeChange` | Create temp dir, Put, modify dir contents, Get returns miss |
+| `TestDirCache_MissOnTTLExpiry` | Put with 1ms TTL, sleep 5ms, Get returns miss |
+| `TestDirCache_NoEvictionBelowMax` | Fill to maxSize-1, verify no eviction |
+| `TestDirCache_EvictsOldestAtMax` | Fill to maxSize, add one more, oldest entry is gone |
+| `TestDirCache_ConcurrentReads` | 50 goroutines Get after one Put, run with `-race` |
+| `TestListPathCompletions_CacheHit` | Call twice, second call does not invoke ReadDir |
+| `TestListPathCompletions_CacheMissAfterMtimeChange` | Verify fresh entries after directory mutation |
+
+### useSessionSearch unit tests
+
+Location: `web-app/src/lib/hooks/useSessionSearch.test.ts`
+
+| Test | Scenario |
+|---|---|
+| Empty query | Returns `[]` |
+| Title match beats path match | "auth" in title outranks "auth" only in path |
+| STOPPED sessions excluded | Sessions with `status === STOPPED` never in results |
+| Result cap | At most 8 results even with 100 matching sessions |
+| Fuzzy non-prefix match | "squad" matches "stapler-squad" |
+| Consecutive char match | "myfeat" matches "my-feature-branch" |
+| Multi-field | Session matching title AND branch scores higher than session matching only one field |
+
+### OmnibarResultList keyboard navigation tests
+
+Location: `web-app/src/components/sessions/OmnibarResultList.test.tsx`
+
+| Test | Scenario |
+|---|---|
+| Empty sections hidden | `sessionResults=[]` → no SESSIONS header |
+| Create-new always visible | Renders even with both sections empty |
+| Arrow down skips headers | Down from last session item → first repo item (not header) |
+| Enter dispatches session action | `onSessionSelect` called with correct session |
+| Enter dispatches repo action | `onRepoSelect` called with correct path |
+| ARIA activedescendant | Highlighted item id matches input's aria-activedescendant |
+
+### Integration acceptance tests
+
+| Scenario | Expected |
+|---|---|
+| Omnibar opens empty | Both sections visible with recents |
+| User types "auth" | Session results update, repo results update, form body hidden |
+| User types "~/" | Session results hidden, path completion dropdown appears |
+| Enter on session result | Omnibar closes, `onNavigateToSession` called |
+| Enter on repo result | Input pre-filled with path, creation form appears |
+| Escape on highlighted result | Highlight cleared, results still visible |
+| Second Escape | Omnibar closes |
+
+---
+
+## Known Issues
+
+### Bug 1 — GitHubShorthand fires on branch-style session searches [SEVERITY: Medium]
+
+**Description:** The `GitHubShorthandDetector` (priority 40) matches `^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)`. A user searching for a session with title `feature/auth-overhaul` will trigger GitHub detection instead of session search, showing a GitHub icon and blocking session results.
+
+**Mitigation in this plan:** `SessionSearchDetector` has priority 200, so it only fires after all GitHub detectors. The user's query `feature/auth-overhaul` will be classified as `InputType.GitHubShorthand`, not `InputType.SessionSearch`. The session result for that session title will not appear.
+
+**Workaround:** Search for `auth-overhaul` (the branch suffix) instead. The Fuse.js search will still find it via the `branch` field.
+
+**Future fix:** Add an active-session-title check to `GitHubShorthandDetector`: if the input exactly matches an existing session title, prefer `SessionSearch` over `GitHubShorthand`. This requires passing the session list into the detector, which is a bigger architectural change. Deferred to a follow-up.
+
+**Files likely affected:** `web-app/src/lib/omnibar/detector.ts`
+
+---
+
+### Bug 2 — Recent repos list shows deleted paths [SEVERITY: Medium]
+
+**Description:** `usePathHistory` stores paths in `localStorage` without existence checks. A repo that was moved or deleted appears in the Recent Repos empty-state list. Selecting it pre-fills a non-existent path, which fails at session creation.
+
+**Mitigation in this plan:** The path existence check (`✓`/`✗`) in the input indicator will show `✗` after the user selects a deleted path and the detection runs. The user sees immediate feedback before attempting to create the session.
+
+**Future fix:** On each Omnibar open, call the `pathExists` check for each recent repo entry and filter out non-existent paths. This adds one RPC per recent repo but could be batched. Deferred because the `✓`/`✗` indicator provides sufficient feedback for now.
+
+**Files likely affected:** `web-app/src/lib/hooks/usePathHistory.ts`, `web-app/src/components/sessions/OmnibarRepoResult.tsx`
+
+---
+
+### Bug 3 — ConnectRPC transport created per-render in usePathCompletions [SEVERITY: Low]
+
+**Description:** `usePathCompletions.ts` creates a new `createConnectTransport` and `createClient` inside the debounce callback (inside a `useEffect`). This means a new HTTP transport object is created on every debounce firing, which has small but real memory overhead.
+
+**Mitigation in this plan:** Not fixed in this plan. The issue predates this feature. Adding session search (a second async hook) makes the impact slightly larger but does not introduce the root cause.
+
+**Future fix:** Lift transport/client creation to module level, matching the pattern used by `completionCache` in the same file.
+
+**Files likely affected:** `web-app/src/lib/hooks/usePathCompletions.ts`
+
+---
+
+### Bug 4 — Fuse.js threshold may over-match on short queries [SEVERITY: Low]
+
+**Description:** With `threshold: 0.4`, a 1-2 character query like "a" will match most sessions. The result list will be populated with low-relevance results ranked by score, but the user will see up to 8 results for a single character, all with mediocre scores.
+
+**Mitigation:** `minMatchCharLength: 1` is set intentionally for the "3 keystroke" requirement (Cmd+K, type one char, arrow, Enter). The user expects results on a single character. If relevance drift becomes an issue, raise `minMatchCharLength` to 2 or increase `threshold` to 0.3 (stricter) in follow-up.
+
+**Files likely affected:** `web-app/src/lib/hooks/useSessionSearch.ts`
+
+---
+
+### Bug 5 — DirCache mtime invalidation unreliable on network filesystems [SEVERITY: Low]
+
+**Description:** On NFS or SMB mounts, mtime may not update synchronously when directory contents change. The 60s hard TTL is the backstop, but users on network filesystems could see stale path completions for up to 60 seconds after a directory change.
+
+**Mitigation:** The 60s TTL is the fallback. For a solo-practitioner tool primarily used on local filesystems, this is acceptable. Document as a known limitation.
+
+**Files likely affected:** `server/services/dir_cache.go`
+
+---
+
+### Bug 6 — useRepositorySuggestions makes a listSessions RPC on every Omnibar open [SEVERITY: Low]
+
+**Description:** `useRepositorySuggestions` calls `client.listSessions({})` inside a `useEffect` that runs when `baseUrl` changes. Since the hook is instantiated inside `Omnibar.tsx` (which mounts/unmounts on each open/close), it fires an RPC on every Omnibar open.
+
+**Mitigation in this plan:** The session data from `useRepositorySuggestions` is redundant with the Redux store (`selectAllSessions`). The empty-state recent session list (Task 5.3) uses Redux directly (zero RPCs). The `useRepositorySuggestions` hook provides frecency-ranked paths from session `path` fields, which is complementary to `usePathHistory` (user-typed paths).
+
+**Future fix:** Replace `useRepositorySuggestions` with a `useMemo` over `selectAllSessions` for the repo paths section. The `rankPathsByFrecency` util can run client-side against the Redux store. This eliminates the redundant RPC.
+
+**Files likely affected:** `web-app/src/lib/hooks/useRepositorySuggestions.ts`, `web-app/src/components/sessions/Omnibar.tsx`
+
+---
+
+## Implementation Sequence
+
+1. **Task 1.1** — `dir_cache.go` (backend, independent)
+2. **Task 1.2** — Wire cache into `path_completion_service.go`
+3. **Task 2.1** — `InputType.SessionSearch` in `types.ts` + `SessionSearchDetector` in `detector.ts`
+4. **Task 2.2** — `getAll()` in `usePathHistory.ts`
+5. **Task 2.3** — `dropdownDismissed` reset in `Omnibar.tsx`
+6. **Task 3.1** — Install fuse.js
+7. **Task 3.2** — `useSessionSearch.ts` hook
+8. **Task 4.1** — `OmnibarSessionResult.tsx`
+9. **Task 4.2** — `OmnibarRepoResult.tsx`
+10. **Task 4.3** — `OmnibarResultList.tsx`
+11. **Task 5.1** — Mode state + `onNavigateToSession` prop in `Omnibar.tsx`
+12. **Task 5.2** — Hook wiring in `Omnibar.tsx`
+13. **Task 5.3** — Empty-state recent sessions from Redux
+14. **Task 5.4** — Session result selection handler + Enter key routing
+15. **Task 5.5** — Repo result selection + pre-fill
+16. **Task 5.6** — Conditional render of result list vs form body
+
+Tasks 1.1-1.2 and 2.1-2.3 can be started simultaneously in separate commits. Tasks 3-5 must follow in sequence.
+
+---
+
+## File Reference
+
+| File | Action | Story |
+|---|---|---|
+| `server/services/dir_cache.go` | CREATE | 1 |
+| `server/services/dir_cache_test.go` | CREATE | 1 |
+| `server/services/path_completion_service.go` | MODIFY | 1 |
+| `web-app/src/lib/omnibar/types.ts` | MODIFY | 2 |
+| `web-app/src/lib/omnibar/detector.ts` | MODIFY | 2 |
+| `web-app/src/lib/hooks/usePathHistory.ts` | MODIFY | 2 |
+| `web-app/src/components/sessions/Omnibar.tsx` | MODIFY | 2, 5 |
+| `web-app/package.json` | MODIFY | 3 |
+| `web-app/src/lib/hooks/useSessionSearch.ts` | CREATE | 3 |
+| `web-app/src/lib/hooks/useSessionSearch.test.ts` | CREATE | 3 |
+| `web-app/src/components/sessions/OmnibarSessionResult.tsx` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarSessionResult.css.ts` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarRepoResult.tsx` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarRepoResult.css.ts` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarResultList.tsx` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarResultList.css.ts` | CREATE | 4 |
+| `web-app/src/components/sessions/OmnibarResultList.test.tsx` | CREATE | 4 |
+
+---
+
+## ADR References
+
+- `project_plans/omni-bar-session-search/decisions/ADR-001-client-side-session-search.md` — why no SearchSessions RPC
+- `project_plans/omni-bar-session-search/decisions/ADR-002-fusejs-typescript-fuzzy.md` — why Fuse.js over fzf-for-js or match-sorter
+- `project_plans/omni-bar-session-search/decisions/ADR-003-go-sync-map-dir-cache.md` — why DirCache over sync.Map

--- a/project_plans/omni-bar-session-search/implementation/validation.md
+++ b/project_plans/omni-bar-session-search/implementation/validation.md
@@ -1,0 +1,1265 @@
+# Validation Plan: Omni Bar Session Search
+
+Status: Draft | Phase: 4 - Validation
+Created: 2026-04-15
+
+---
+
+## Requirements Traceability Matrix
+
+| Success Criterion (requirements.md) | Test ID(s) | Layer | Status |
+|---|---|---|---|
+| SC-1: Reach any session in ≤3 keystrokes after Cmd+K | T-E2E-001 | E2E | Pending |
+| SC-2: Start new session on any previously-used repo in ≤5 keystrokes | T-E2E-002 | E2E | Pending |
+| SC-3: Path completion <100ms on cache hit | T-E2E-003, T-UNIT-GO-004 | E2E + Unit | Pending |
+| SC-3: Path completion <500ms cold start | T-E2E-004 | E2E | Pending |
+| SC-4: "myfeat" matches "my-feature-branch" | T-UNIT-TS-004 | Unit | Pending |
+| SC-4: "squad" matches "stapler-squad" | T-UNIT-TS-003 | Unit | Pending |
+| Must Have: Session fuzzy search in Omnibar | T-UNIT-TS-001–007, T-INT-001 | Unit + Integration | Pending |
+| Must Have: Recent repos quick-pick empty state | T-UNIT-TS-012–015, T-INT-002 | Unit + Integration | Pending |
+| Must Have: Proper fuzzy algorithm (not naive substring) | T-UNIT-TS-003, T-UNIT-TS-004, T-UNIT-TS-016 | Unit | Pending |
+| Must Have: Directory tree cache (mtime + TTL) | T-UNIT-GO-001–007, T-INT-GO-001–002 | Unit + Integration | Pending |
+| Constraint: Zero new RPC endpoints for session search | T-ARCH-001 | Architecture | Pending |
+| Constraint: Zero proto changes | T-ARCH-002 | Architecture | Pending |
+| Constraint: Session search results update <16ms per keypress | T-PERF-001 | Performance | Pending |
+
+---
+
+## Story Acceptance Criteria Traceability
+
+| Story | Acceptance Criterion | Test ID(s) |
+|---|---|---|
+| Story 1: DirCache | Cache hit returns entries without ReadDir | T-UNIT-GO-001, T-INT-GO-001 |
+| Story 1: DirCache | Miss on changed mtime | T-UNIT-GO-002 |
+| Story 1: DirCache | Miss on TTL expiry | T-UNIT-GO-003 |
+| Story 1: DirCache | Eviction at maxSize | T-UNIT-GO-005, T-UNIT-GO-006 |
+| Story 1: DirCache | No data race under concurrency | T-UNIT-GO-007 |
+| Story 2: Detector | Bare text routes to SessionSearch, not Unknown | T-UNIT-TS-008 |
+| Story 2: Detector | Path input still routes to LocalPath | T-UNIT-TS-010 |
+| Story 2: Detector | GitHub shorthand still routes correctly | T-UNIT-TS-011 |
+| Story 2: Detector | Empty input does not match SessionSearch | T-UNIT-TS-009 |
+| Story 2: usePathHistory | getAll returns top N by score | T-UNIT-TS-012 |
+| Story 2: usePathHistory | getAll ordering: recent beats stale | T-UNIT-TS-015 |
+| Story 2: dropdownDismissed | Session results appear after Escape + backspace | T-UNIT-TS-020, T-INT-005 |
+| Story 3: useSessionSearch | Empty query returns [] | T-UNIT-TS-001 |
+| Story 3: useSessionSearch | Title weight beats path weight | T-UNIT-TS-002 |
+| Story 3: useSessionSearch | STOPPED sessions excluded | T-UNIT-TS-005 |
+| Story 3: useSessionSearch | Results capped at 8 | T-UNIT-TS-006 |
+| Story 3: useSessionSearch | Fuzzy non-prefix match | T-UNIT-TS-003, T-UNIT-TS-004 |
+| Story 4: OmnibarResultList | Session section hidden when results empty | T-UNIT-TS-017 |
+| Story 4: OmnibarResultList | Repo section hidden when entries empty | T-UNIT-TS-018 |
+| Story 4: OmnibarResultList | Create-new always visible | T-UNIT-TS-019 |
+| Story 4: OmnibarResultList | Arrow down skips section headers | T-UNIT-TS-022 |
+| Story 4: OmnibarResultList | Enter on session calls onSessionSelect | T-UNIT-TS-023 |
+| Story 4: OmnibarResultList | Enter on repo calls onRepoSelect | T-UNIT-TS-024 |
+| Story 4: OmnibarResultList | ARIA activedescendant tracks highlight | T-UNIT-TS-021 |
+| Story 5: Integration | Discovery mode on open | T-INT-001 |
+| Story 5: Integration | Creation mode on path input | T-INT-003 |
+| Story 5: Integration | Session navigate + close | T-INT-004 |
+| Story 5: Integration | Repo select pre-fills path | T-INT-006 |
+| Story 5: Integration | Escape clears highlight; second Escape closes | T-INT-007, T-INT-008 |
+| Story 5: Integration | canSubmit false for SessionSearch type | T-UNIT-TS-025 |
+
+---
+
+## Test Suite Overview
+
+### Layer Distribution
+
+| Layer | Count |
+|---|---|
+| Go unit tests | 9 |
+| Go integration tests | 2 |
+| TypeScript unit tests | 25 |
+| TypeScript integration tests | 8 |
+| E2E tests | 4 |
+| Architecture/constraint tests | 2 |
+| Performance benchmarks | 4 |
+| **Total** | **54** |
+
+Target pyramid: ~60% unit, ~25% integration, ~7% E2E, ~8% performance/architecture.
+
+---
+
+## Go Unit Tests
+
+### DirCache (`server/services/dir_cache_test.go`)
+
+#### T-UNIT-GO-001: Cache hit returns stored entries without re-reading
+
+```
+File: server/services/dir_cache_test.go
+Function: TestDirCache_Hit
+```
+
+Given: A `DirCache` with `maxSize=10, ttl=60s`. A temporary directory has been created with 3 files. `Put` has been called with the directory path, the 3 `os.DirEntry` items, and the directory's current `ModTime()`.
+
+When: `Get` is called for the same path immediately after.
+
+Then: `(entries, true)` is returned. `len(entries) == 3`. The returned slice is the same object (or equal) to what was passed to `Put`.
+
+Pass criteria: `ok == true`, `len(entries) == 3`, no call to `os.ReadDir` (verified by inserting a counter or mock that wraps `os.ReadDir` — alternatively, verify via timing that no syscall happens).
+
+---
+
+#### T-UNIT-GO-002: Cache miss when directory mtime has changed
+
+```
+File: server/services/dir_cache_test.go
+Function: TestDirCache_MissOnMtimeChange
+```
+
+Given: A `DirCache`. A temporary directory has been created. `Put` called with current mtime. A new file is then created inside that directory, advancing the directory's mtime.
+
+When: `Get` is called for the same path after the mtime change.
+
+Then: `(nil, false)` is returned — the cache detects the directory changed and returns a miss.
+
+Pass criteria: `ok == false`, `entries == nil`.
+
+Implementation note: On macOS/Linux, creating a file inside a directory advances the directory's mtime. The test must call `os.Stat(path).ModTime()` after the file creation to confirm mtime advanced before asserting the miss.
+
+---
+
+#### T-UNIT-GO-003: Cache miss after TTL expiry
+
+```
+File: server/services/dir_cache_test.go
+Function: TestDirCache_MissOnTTLExpiry
+```
+
+Given: A `DirCache` with `ttl=1ms`. `Put` called with current mtime.
+
+When: `time.Sleep(5 * time.Millisecond)` passes, then `Get` is called.
+
+Then: `(nil, false)` returned — TTL has expired.
+
+Pass criteria: `ok == false`. The directory mtime has NOT changed (only TTL triggered the miss).
+
+---
+
+#### T-UNIT-GO-004: Cache hit performance — Get completes in <100ms
+
+```
+File: server/services/dir_cache_test.go
+Function: TestDirCache_HitPerformance
+```
+
+Given: A `DirCache` populated with 256 entries (maxSize) covering a typical home directory listing.
+
+When: `Get` is called for one of the cached paths and the call is timed with `time.Since`.
+
+Then: Elapsed time is less than 100ms.
+
+Pass criteria: `elapsed < 100*time.Millisecond`. This test enforces the <100ms cache-hit requirement from SC-3.
+
+---
+
+#### T-UNIT-GO-005: No eviction below maxSize
+
+```
+File: server/services/dir_cache_test.go
+Function: TestDirCache_NoEvictionBelowMax
+```
+
+Given: A `DirCache` with `maxSize=5`. `Put` has been called 4 times with 4 different paths, each with a different `cachedAt` time spaced 1ms apart.
+
+When: The internal `entries` map is inspected.
+
+Then: All 4 paths are still present. No eviction occurred.
+
+Pass criteria: `len(cache.entries) == 4`.
+
+---
+
+#### T-UNIT-GO-006: Evicts oldest entry at maxSize
+
+```
+File: server/services/dir_cache_test.go
+Function: TestDirCache_EvictsOldestAtMax
+```
+
+Given: A `DirCache` with `maxSize=3`. `Put` called 3 times with paths `"/a"`, `"/b"`, `"/c"`, with `cachedAt` at t=0, t=1ms, t=2ms respectively (controlled via a fake clock or by spacing real sleeps).
+
+When: `Put` is called for a fourth path `"/d"`.
+
+Then: Total entries in the map is 3. The entry for `"/a"` (oldest `cachedAt`) is gone. Entries for `"/b"`, `"/c"`, and `"/d"` are present.
+
+Pass criteria: `len(cache.entries) == 3`, `cache.entries["/a"] == nil`, `cache.entries["/d"] != nil`.
+
+---
+
+#### T-UNIT-GO-007: Concurrent reads produce no data race
+
+```
+File: server/services/dir_cache_test.go
+Function: TestDirCache_ConcurrentReads
+Run with: go test -race ./server/services/...
+```
+
+Given: A `DirCache` with one entry populated via `Put`.
+
+When: 50 goroutines each call `Get` simultaneously using `sync.WaitGroup`.
+
+Then: No data race is reported by the race detector. All 50 goroutines receive the same entries.
+
+Pass criteria: Test passes with `go test -race` — zero race conditions reported. `len(results) == 50` with all entries matching.
+
+---
+
+### PathCompletionService Integration (`server/services/path_completion_service_test.go`)
+
+#### T-INT-GO-001: Second call returns cached entries (ReadDir not called twice)
+
+```
+File: server/services/path_completion_service_test.go
+Function: TestListPathCompletions_CacheHit
+```
+
+Given: A `PathCompletionService` with an instrumented `DirCache`. A real temporary directory with 5 subdirectories. `ListPathCompletions` called once, which populates the cache.
+
+When: `ListPathCompletions` is called again with the exact same path prefix before any directory changes.
+
+Then: The same 5 completions are returned. `os.ReadDir` was called exactly once total (verified via a call-count wrapper or by asserting the ReadDir counter incremented only on the first call).
+
+Pass criteria: Both calls return identical results. `readDirCallCount == 1`.
+
+---
+
+#### T-INT-GO-002: Cache miss after directory mutation returns fresh entries
+
+```
+File: server/services/path_completion_service_test.go
+Function: TestListPathCompletions_CacheMissAfterMtimeChange
+```
+
+Given: A `PathCompletionService`. A real temporary directory with 2 subdirectories. `ListPathCompletions` called once — cache populated.
+
+When: A new subdirectory is created inside the temporary directory (advancing its mtime), then `ListPathCompletions` is called again.
+
+Then: 3 completions are returned (the original 2 plus the new one). `readDirCallCount == 2` — the cache invalidated and re-read.
+
+Pass criteria: Second call returns 3 results. `readDirCallCount == 2`.
+
+---
+
+## TypeScript Unit Tests
+
+### useSessionSearch hook (`web-app/src/lib/hooks/useSessionSearch.test.ts`)
+
+#### T-UNIT-TS-001: Empty query returns empty array
+
+```
+File: web-app/src/lib/hooks/useSessionSearch.test.ts
+Function: describe("useSessionSearch") > "returns [] for empty query"
+```
+
+Given: Redux store with 5 active sessions. `useSessionSearch` rendered with `renderHook`.
+
+When: `query = ""`
+
+Then: Hook returns `[]`.
+
+Pass criteria: `result.current.length === 0`.
+
+---
+
+#### T-UNIT-TS-002: Title match ranks above path-only match
+
+```
+File: web-app/src/lib/hooks/useSessionSearch.test.ts
+Function: "title match ranks above path match for same query"
+```
+
+Given: Redux store with two sessions:
+- Session A: `{ title: "auth-service", path: "/home/user/other", branch: "main" }`
+- Session B: `{ title: "other-service", path: "/home/user/auth", branch: "main" }`
+
+When: `query = "auth"`
+
+Then: Session A appears before Session B in results (`results[0].session.title === "auth-service"`).
+
+Pass criteria: `results[0].session.title === "auth-service"`, `results.length >= 2`.
+
+---
+
+#### T-UNIT-TS-003: Fuzzy non-prefix match — "squad" matches "stapler-squad"
+
+```
+File: web-app/src/lib/hooks/useSessionSearch.test.ts
+Function: "matches tail substring via ignoreLocation"
+```
+
+Given: Redux store with one session: `{ title: "stapler-squad", path: "/home/user/stapler-squad" }`.
+
+When: `query = "squad"`
+
+Then: The session is returned in results.
+
+Pass criteria: `results.length === 1`, `results[0].session.title === "stapler-squad"`.
+
+---
+
+#### T-UNIT-TS-004: Character-sequence fuzzy — "myfeat" matches "my-feature-branch"
+
+```
+File: web-app/src/lib/hooks/useSessionSearch.test.ts
+Function: "matches hyphenated branch via character sequence"
+```
+
+Given: Redux store with one session: `{ title: "auth", branch: "my-feature-branch", path: "/x" }`.
+
+When: `query = "myfeat"`
+
+Then: The session is returned in results (Fuse.js `ignoreLocation: true` finds the match across the hyphen).
+
+Pass criteria: `results.length === 1`, `results[0].session.branch === "my-feature-branch"`.
+
+---
+
+#### T-UNIT-TS-005: STOPPED sessions are excluded from results
+
+```
+File: web-app/src/lib/hooks/useSessionSearch.test.ts
+Function: "excludes STOPPED sessions"
+```
+
+Given: Redux store with two sessions:
+- Session A: `{ title: "active-session", status: SessionStatus.RUNNING }`
+- Session B: `{ title: "stopped-session", status: SessionStatus.STOPPED }`
+
+When: `query = "session"` (matches both titles)
+
+Then: Only Session A is returned. Session B is absent.
+
+Pass criteria: `results.length === 1`, `results[0].session.title === "active-session"`.
+
+---
+
+#### T-UNIT-TS-006: Results capped at 8
+
+```
+File: web-app/src/lib/hooks/useSessionSearch.test.ts
+Function: "caps results at 8"
+```
+
+Given: Redux store with 20 active sessions, all with titles matching "proj" (e.g., "proj-1" through "proj-20").
+
+When: `query = "proj"`
+
+Then: At most 8 results are returned.
+
+Pass criteria: `results.length <= 8`.
+
+---
+
+#### T-UNIT-TS-007: Multi-field match scores higher than single-field match
+
+```
+File: web-app/src/lib/hooks/useSessionSearch.test.ts
+Function: "multi-field match ranks above single-field match"
+```
+
+Given: Redux store with two sessions:
+- Session A: `{ title: "auth-service", branch: "auth-feature", path: "/other" }` (matches "auth" in title AND branch)
+- Session B: `{ title: "unrelated", branch: "unrelated", path: "/projects/auth-module" }` (matches "auth" only in path)
+
+When: `query = "auth"`
+
+Then: Session A has a lower score value (better match in Fuse.js convention) and appears first.
+
+Pass criteria: `results[0].session.title === "auth-service"`, `results[0].score < results[1].score`.
+
+---
+
+### Detector (`web-app/src/lib/omnibar/detector.test.ts`)
+
+#### T-UNIT-TS-008: Bare text resolves to InputType.SessionSearch
+
+```
+File: web-app/src/lib/omnibar/detector.test.ts
+Function: "SessionSearchDetector" > "resolves bare word to SessionSearch"
+```
+
+Given: The default detector registry (includes SessionSearchDetector at priority 200).
+
+When: `detect("squad")` is called.
+
+Then: Result has `type === InputType.SessionSearch`.
+
+Pass criteria: `result.type === InputType.SessionSearch`, `result.parsedValue === "squad"`.
+
+---
+
+#### T-UNIT-TS-009: Empty input does not resolve to SessionSearch
+
+```
+File: web-app/src/lib/omnibar/detector.test.ts
+Function: "SessionSearchDetector" > "returns null for empty string"
+```
+
+Given: The default detector registry.
+
+When: `detect("")` is called.
+
+Then: Result does NOT have `type === InputType.SessionSearch`. The registry default (`InputType.Unknown`) applies.
+
+Pass criteria: `result.type !== InputType.SessionSearch`. (The SessionSearchDetector's internal `null` return causes fallthrough to Unknown.)
+
+---
+
+#### T-UNIT-TS-010: Path input still resolves to LocalPath
+
+```
+File: web-app/src/lib/omnibar/detector.test.ts
+Function: "LocalPath not displaced by SessionSearch"
+```
+
+Given: The default detector registry.
+
+When: `detect("~/projects")` is called.
+
+Then: Result has `type === InputType.LocalPath`.
+
+Pass criteria: `result.type === InputType.LocalPath`.
+
+---
+
+#### T-UNIT-TS-011: GitHub shorthand still resolves correctly
+
+```
+File: web-app/src/lib/omnibar/detector.test.ts
+Function: "GitHubShorthand not displaced by SessionSearch"
+```
+
+Given: The default detector registry.
+
+When: `detect("org/repo")` is called.
+
+Then: Result has `type === InputType.GitHubShorthand`.
+
+Pass criteria: `result.type === InputType.GitHubShorthand`.
+
+---
+
+### usePathHistory (`web-app/src/lib/hooks/usePathHistory.test.ts`)
+
+#### T-UNIT-TS-012: getAll returns top N entries by score when more than N exist
+
+```
+File: web-app/src/lib/hooks/usePathHistory.test.ts
+Function: "getAll" > "returns top N by score"
+```
+
+Given: `usePathHistory` with 10 stored entries. The entry at index 3 has the highest score (most recent + most frequent).
+
+When: `getAll(5)` is called.
+
+Then: An array of exactly 5 entries is returned. The highest-scoring entry is at index 0.
+
+Pass criteria: `result.length === 5`, `result[0]` corresponds to the highest-scored entry.
+
+---
+
+#### T-UNIT-TS-013: getAll returns all entries when count < limit
+
+```
+File: web-app/src/lib/hooks/usePathHistory.test.ts
+Function: "getAll" > "returns all when count below limit"
+```
+
+Given: `usePathHistory` with 3 stored entries. Limit is 10.
+
+When: `getAll(10)` is called.
+
+Then: All 3 entries are returned, sorted by score descending.
+
+Pass criteria: `result.length === 3`.
+
+---
+
+#### T-UNIT-TS-014: save then getAll includes the newly saved path
+
+```
+File: web-app/src/lib/hooks/usePathHistory.test.ts
+Function: "getAll" > "includes newly saved path"
+```
+
+Given: `usePathHistory` with 2 stored entries.
+
+When: `save("/home/user/new-repo")` is called, then `getAll(10)`.
+
+Then: `/home/user/new-repo` appears in the returned entries.
+
+Pass criteria: `result.some(e => e.path === "/home/user/new-repo") === true`.
+
+---
+
+#### T-UNIT-TS-015: Score ordering favors recently used over old
+
+```
+File: web-app/src/lib/hooks/usePathHistory.test.ts
+Function: "getAll" > "score ordering: recent beats stale"
+```
+
+Given: Two entries in storage:
+- Entry A: path `/recent`, last accessed 2 hours ago, accessed 1 time
+- Entry B: path `/stale`, last accessed 3 weeks ago, accessed 5 times
+
+When: `getAll(2)` is called.
+
+Then: Entry A ranks higher (recency dominates over raw frequency for old entries).
+
+Pass criteria: `result[0].path === "/recent"`. (Validates that `entryScore` function weights recency sufficiently.)
+
+---
+
+### OmnibarResultList component (`web-app/src/components/sessions/OmnibarResultList.test.tsx`)
+
+#### T-UNIT-TS-016: Repo fuzzy search via Fuse.js matches non-contiguous characters
+
+```
+File: web-app/src/components/sessions/OmnibarResultList.test.tsx
+  OR: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "repo fuzzy search" > "matches non-contiguous characters in path"
+```
+
+Given: A Fuse instance configured with `{ keys: [{ name: "path", weight: 1.0 }], threshold: 0.4, ignoreLocation: true }`. History entries: `[{ path: "/home/user/stapler-squad" }]`.
+
+When: `repoFuse.search("squad")` is called.
+
+Then: The entry is returned.
+
+Pass criteria: `results.length > 0`, `results[0].item.path` contains `"stapler-squad"`.
+
+---
+
+#### T-UNIT-TS-017: Session section hidden when sessionResults is empty
+
+```
+File: web-app/src/components/sessions/OmnibarResultList.test.tsx
+Function: "OmnibarResultList" > "hides SESSIONS header when sessionResults is empty"
+```
+
+Given: `OmnibarResultList` rendered with `sessionResults=[]` and `repoEntries=[{path: "/a"}]`.
+
+When: Component renders.
+
+Then: No element with text "SESSIONS" is present in the DOM.
+
+Pass criteria: `queryByText("SESSIONS") === null`.
+
+---
+
+#### T-UNIT-TS-018: Repo section hidden when repoEntries is empty
+
+```
+File: web-app/src/components/sessions/OmnibarResultList.test.tsx
+Function: "OmnibarResultList" > "hides REPOS header when repoEntries is empty"
+```
+
+Given: `OmnibarResultList` rendered with `repoEntries=[]` and `sessionResults=[{session: mockSession, score: 0, matchedFields: []}]`.
+
+When: Component renders.
+
+Then: No element with text "REPOS" is present in the DOM.
+
+Pass criteria: `queryByText("REPOS") === null`.
+
+---
+
+#### T-UNIT-TS-019: "+ New Session" item always renders
+
+```
+File: web-app/src/components/sessions/OmnibarResultList.test.tsx
+Function: "OmnibarResultList" > "always renders create-new item"
+```
+
+Given: `OmnibarResultList` rendered with both `sessionResults=[]` and `repoEntries=[]`.
+
+When: Component renders.
+
+Then: An element containing text matching "New Session" is present.
+
+Pass criteria: `getByText(/New Session/i)` does not throw.
+
+---
+
+#### T-UNIT-TS-020: dropdownDismissed resets on mode transition
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "dropdownDismissed" > "resets on InputType change"
+```
+
+Given: `Omnibar` rendered. User has typed `"~/projects"` (triggers `LocalPath`). User pressed Escape (`dropdownDismissed = true`).
+
+When: User backspaces fully to `"auth"` and waits >150ms (debounce fires, detection changes to `SessionSearch`).
+
+Then: `dropdownDismissed` is reset to `false`. Session results section is visible in the DOM.
+
+Pass criteria: `queryByText("SESSIONS")` is not null (or `queryAllByRole("option")` includes session results).
+
+---
+
+#### T-UNIT-TS-021: aria-activedescendant tracks highlighted item
+
+```
+File: web-app/src/components/sessions/OmnibarResultList.test.tsx
+Function: "accessibility" > "aria-activedescendant matches highlighted item id"
+```
+
+Given: `OmnibarResultList` with 2 session results and `highlightedIndex=1`.
+
+When: Component renders.
+
+Then: The input element's `aria-activedescendant` attribute equals the id of the second session result item (`omnibar-result-session-{session.id}`).
+
+Pass criteria: `input.getAttribute("aria-activedescendant") === "omnibar-result-session-" + sessions[1].id`.
+
+---
+
+#### T-UNIT-TS-022: Arrow down moves highlight from last session to first repo (skips header)
+
+```
+File: web-app/src/components/sessions/OmnibarResultList.test.tsx
+Function: "keyboard navigation" > "arrow down skips section header from sessions to repos"
+```
+
+Given: `OmnibarResultList` with 2 session results and 2 repo entries. Parent has `highlightedIndex` in state. The last session item (index 1) is currently highlighted.
+
+When: `ArrowDown` key event is fired on the input.
+
+Then: `highlightedIndex` advances to 2 (first repo item), not to the REPOS section header.
+
+Pass criteria: After arrow-down, the highlighted element has `id === "omnibar-result-repo-" + encodeURIComponent(repoEntries[0].path)`.
+
+---
+
+#### T-UNIT-TS-023: Enter on highlighted session calls onSessionSelect with correct session
+
+```
+File: web-app/src/components/sessions/OmnibarResultList.test.tsx
+Function: "keyboard navigation" > "Enter on session result triggers onSessionSelect"
+```
+
+Given: `OmnibarResultList` with 2 session results. `highlightedIndex=0` (first session). `onSessionSelect` is a jest mock.
+
+When: `Enter` key event is fired (without metaKey).
+
+Then: `onSessionSelect` is called once with `sessions[0]` as the argument.
+
+Pass criteria: `onSessionSelect.mock.calls.length === 1`, `onSessionSelect.mock.calls[0][0].id === sessions[0].id`.
+
+---
+
+#### T-UNIT-TS-024: Enter on highlighted repo calls onRepoSelect with correct path
+
+```
+File: web-app/src/components/sessions/OmnibarResultList.test.tsx
+Function: "keyboard navigation" > "Enter on repo result triggers onRepoSelect"
+```
+
+Given: `OmnibarResultList` with 0 session results and 1 repo entry `{ path: "/home/user/myrepo" }`. `highlightedIndex=0`. `onRepoSelect` is a jest mock.
+
+When: `Enter` key event is fired.
+
+Then: `onRepoSelect` is called once with `"/home/user/myrepo"`.
+
+Pass criteria: `onRepoSelect.mock.calls[0][0] === "/home/user/myrepo"`.
+
+---
+
+#### T-UNIT-TS-025: canSubmit is false when detection type is SessionSearch
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "canSubmit" > "false when InputType.SessionSearch"
+```
+
+Given: `Omnibar` rendered. Input value is `"squad"` (triggers `InputType.SessionSearch` after debounce).
+
+When: The submit button (or Cmd+Enter handler) is interrogated.
+
+Then: The form submit button is disabled OR `Cmd+Enter` does not trigger `onCreateSession`.
+
+Pass criteria: Submit button has `disabled` attribute, OR `onCreateSession` mock is not called after `Cmd+Enter` with `SessionSearch` detection active.
+
+---
+
+## TypeScript Integration Tests
+
+### Omnibar mode state machine (`web-app/src/components/sessions/Omnibar.test.tsx`)
+
+#### T-INT-001: Omnibar opens in discovery mode showing recent sessions and repos
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "integration" > "opens in discovery mode"
+```
+
+Given: `Omnibar` rendered with `isOpen=true`. Redux store has 3 active sessions. `usePathHistory` has 3 stored paths.
+
+When: Component mounts (no input typed).
+
+Then: Discovery mode UI is active. Session results section shows recent sessions. Repo results section shows recent repos. Form body (branch/program fields) is NOT visible.
+
+Pass criteria: Session items visible (`getAllByRole("option").length > 0`). No element with label for branch input visible (`queryByLabelText(/branch/i) === null`).
+
+---
+
+#### T-INT-002: Empty state shows top-5 recent sessions from Redux by updatedAt
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "integration" > "empty state shows 5 most recent sessions"
+```
+
+Given: Redux store with 8 active sessions with different `updatedAt` timestamps.
+
+When: Omnibar opens with empty input.
+
+Then: At most 5 session results are shown in discovery mode. They correspond to the 5 sessions with the most recent `updatedAt`.
+
+Pass criteria: `getAllByRole("option", { name: /session/ }).length <= 5`. The displayed sessions match the 5 with highest `updatedAt` seconds.
+
+---
+
+#### T-INT-003: Typing a path prefix transitions to creation mode
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "integration" > "path input triggers creation mode"
+```
+
+Given: `Omnibar` in discovery mode.
+
+When: User types `"~/projects"` into the input and waits 200ms (debounce fires with `InputType.LocalPath`).
+
+Then: Mode transitions to `"creation"`. Form body (branch and program fields) becomes visible. `OmnibarResultList` is hidden. `PathCompletionDropdown` is visible (or its aria-controls is present).
+
+Pass criteria: Form body visible (`getByLabelText(/branch/i)` does not throw). Session result list absent (`queryByRole("listbox", { name: /results/ }) === null`).
+
+---
+
+#### T-INT-004: Selecting a session result calls onNavigateToSession and closes omnibar
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "integration" > "session result selection navigates and closes"
+```
+
+Given: `Omnibar` in discovery mode with session results visible. `onNavigateToSession` and `onClose` are jest mocks.
+
+When: User clicks (or presses Enter on) the first session result.
+
+Then: `onNavigateToSession` is called with the correct session ID. `onClose` is called once.
+
+Pass criteria: `onNavigateToSession.mock.calls[0][0] === sessions[0].id`, `onClose.mock.calls.length === 1`.
+
+---
+
+#### T-INT-005: Session results visible after Escape + backspace sequence
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "integration" > "dropdownDismissed resets on mode transition"
+```
+
+Given: `Omnibar` open. User types `"~/proj"` (triggers LocalPath, path completion dropdown appears). User presses Escape (sets `dropdownDismissed=true`). User backspaces until input is `"auth"` and waits 200ms (triggers SessionSearch).
+
+When: The debounce fires and mode becomes discovery with query "auth".
+
+Then: Session results list is visible. Path completion dropdown is not visible. The "SESSIONS" section header is present.
+
+Pass criteria: `queryByText("SESSIONS")` is not null. `queryByRole("listbox", { name: /completions/ }) === null`.
+
+---
+
+#### T-INT-006: Repo result selection pre-fills input and transitions to creation mode
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "integration" > "repo select pre-fills path and enters creation mode"
+```
+
+Given: `Omnibar` in discovery mode with one repo entry `{ path: "/home/user/myrepo" }` visible.
+
+When: User clicks the repo result item.
+
+Then: Input value becomes `"/home/user/myrepo/"`. After debounce fires (200ms), mode becomes `"creation"`. Path completion dropdown appears. Form body is visible.
+
+Pass criteria: `input.value === "/home/user/myrepo/"`. After 200ms: form body visible (`getByLabelText(/branch/i)` does not throw).
+
+---
+
+#### T-INT-007: First Escape clears result highlight without closing omnibar
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "integration" > "first Escape clears highlight"
+```
+
+Given: `Omnibar` in discovery mode. User pressed ArrowDown (highlightedIndex = 0). `onClose` is a jest mock.
+
+When: Escape is pressed once.
+
+Then: `highlightedIndex` becomes -1 (no highlight). Omnibar is still open. `onClose` not called.
+
+Pass criteria: No item has `aria-selected="true"`. `onClose.mock.calls.length === 0`.
+
+---
+
+#### T-INT-008: Second Escape closes omnibar
+
+```
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "integration" > "second Escape closes omnibar"
+```
+
+Given: `Omnibar` open with no item highlighted (highlightedIndex = -1). `onClose` is a jest mock.
+
+When: Escape is pressed.
+
+Then: `onClose` is called once.
+
+Pass criteria: `onClose.mock.calls.length === 1`.
+
+---
+
+## E2E Tests
+
+E2E tests use the running application. Assume a test harness that can open a browser, interact with the UI, and assert on DOM state. Timing assertions use wall-clock measurements within the browser.
+
+### T-E2E-001: Reach existing session in ≤3 keystrokes
+
+```
+Requirement: SC-1
+```
+
+Precondition: Application is running with at least 3 active sessions. One session has the title "auth-service".
+
+Steps:
+1. Press Cmd+K — opens Omnibar (keystroke 1).
+2. Type "a" — filters session results to include "auth-service" (keystroke 2).
+3. Press Enter — selects the highlighted/first result (keystroke 3).
+
+Then: Omnibar is closed. The application has navigated to the "auth-service" session (e.g., session is visible/focused in the session list or terminal is active).
+
+Pass criteria:
+- Total keyboard events before session is active: exactly 3.
+- Omnibar `isOpen` is false after Enter.
+- Active session ID in app state matches "auth-service" session ID.
+- Wall-clock time from step 1 to session active: <2 seconds total.
+
+Failure modes to check: Omnibar stays open, wrong session selected, more than 3 key events required.
+
+---
+
+### T-E2E-002: Create session from recent repo in ≤5 keystrokes
+
+```
+Requirement: SC-2
+```
+
+Precondition: Application is running. `usePathHistory` has `"/home/user/myrepo"` stored as a recent path.
+
+Steps:
+1. Press Cmd+K — opens Omnibar (keystroke 1).
+2. Type "my" — filters repo results to include "myrepo" (keystroke 2).
+3. Press ArrowDown — highlights the first repo result (keystroke 3).
+4. Press Enter — selects the repo, pre-fills input with `"/home/user/myrepo/"` (keystroke 4).
+5. Press Cmd+Enter — creates the session (keystroke 5).
+
+Then: A new session creation is initiated with path `/home/user/myrepo/`. `onCreateSession` is called (or equivalent API call fires).
+
+Pass criteria:
+- Total keyboard events: exactly 5.
+- Session creation callback is triggered with path containing `"myrepo"`.
+- Wall-clock time from step 1 to session creation initiated: <3 seconds.
+
+---
+
+### T-E2E-003: Path completion cache hit completes in <100ms
+
+```
+Requirement: SC-3 (cache hit)
+```
+
+Precondition: Application running. The directory `~/projects` exists with at least 5 subdirectories.
+
+Steps:
+1. Open Omnibar (Cmd+K).
+2. Type `"~/projects/"` — triggers path completion. Wait for results (this is the cold call).
+3. Close Omnibar (Escape).
+4. Reopen Omnibar (Cmd+K).
+5. Type `"~/projects/"` again — triggers path completion from cache.
+6. Measure time from input change to results appearing.
+
+Then: Results appear in the second call within 100ms.
+
+Pass criteria: `responseTime < 100` (milliseconds, measured from the moment the input value is set to when result items appear in DOM). Verified by browser-side `performance.now()` instrumentation.
+
+---
+
+### T-E2E-004: Path completion cold start completes in <500ms
+
+```
+Requirement: SC-3 (cold start)
+```
+
+Precondition: Server restarted (cache empty). Directory `~/projects` exists.
+
+Steps:
+1. Open Omnibar (Cmd+K).
+2. Type `"~/projects/"` — triggers first-ever path completion call.
+3. Measure time from input change to results appearing.
+
+Then: Results appear within 500ms.
+
+Pass criteria: `responseTime < 500ms`. Any latency above 500ms is a regression on SC-3.
+
+---
+
+## Pitfall-Specific Tests
+
+These tests exist to prevent the specific pitfalls identified in pitfalls.md from shipping undetected.
+
+### P1-A: Detector does not block bare text (pitfalls.md § "Detector mode conflict")
+
+#### T-PITFALL-001: Bare-text query must NOT resolve to InputType.Unknown
+
+```
+Pitfall: P1 — Detector mode conflict
+File: web-app/src/lib/omnibar/detector.test.ts
+Function: "pitfall" > "bare text does not resolve to Unknown"
+```
+
+Given: Default detector registry (with SessionSearchDetector registered).
+
+When: `detect("squad")` is called.
+
+Then: `result.type !== InputType.Unknown`.
+
+Pass criteria: `result.type === InputType.SessionSearch`. If this test fails, session results will never appear for bare-word queries.
+
+---
+
+#### T-PITFALL-002: Bare-text query with hyphen resolves to SessionSearch
+
+```
+Pitfall: P1 — Detector mode conflict
+File: web-app/src/lib/omnibar/detector.test.ts
+Function: "pitfall" > "hyphenated bare text resolves to SessionSearch"
+```
+
+Given: Default detector registry.
+
+When: `detect("my-feature")` is called.
+
+Then: `result.type === InputType.SessionSearch` (not `InputType.Unknown`).
+
+Pass criteria: `result.type === InputType.SessionSearch`.
+
+---
+
+### P1-B: Enter key routing is unambiguous (pitfalls.md § "Enter key ambiguity")
+
+#### T-PITFALL-003: Enter on session result does not trigger session creation
+
+```
+Pitfall: P1 — Enter key ambiguity
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "pitfall" > "Enter on session result navigates, not creates"
+```
+
+Given: `Omnibar` in discovery mode with session results. `onCreateSession` and `onNavigateToSession` are jest mocks. First session result is highlighted (index 0).
+
+When: `Enter` is pressed (without Cmd).
+
+Then: `onNavigateToSession` is called. `onCreateSession` is NOT called.
+
+Pass criteria: `onNavigateToSession.mock.calls.length === 1`, `onCreateSession.mock.calls.length === 0`.
+
+---
+
+#### T-PITFALL-004: Cmd+Enter in creation mode still creates session (routing not broken)
+
+```
+Pitfall: P1 — Enter key ambiguity (regression check)
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "pitfall" > "Cmd+Enter in creation mode calls onCreateSession"
+```
+
+Given: `Omnibar` in creation mode (path typed, `InputType.LocalPath` detected). Form is valid. `onCreateSession` is a jest mock.
+
+When: `Cmd+Enter` is pressed.
+
+Then: `onCreateSession` is called once. `onNavigateToSession` is NOT called.
+
+Pass criteria: `onCreateSession.mock.calls.length === 1`, `onNavigateToSession.mock.calls.length === 0`.
+
+---
+
+### P1-C: PathCompletionService gets server-side cache (pitfalls.md § "stateless and uncached")
+
+#### T-PITFALL-005: DirCache is wired into PathCompletionService (not a no-op)
+
+```
+Pitfall: P1 — PathCompletionService stateless
+File: server/services/path_completion_service_test.go
+Function: TestListPathCompletions_CacheHit (same as T-INT-GO-001)
+```
+
+Given: `PathCompletionService` (real implementation, not a mock).
+
+When: `ListPathCompletions` is called twice for the same directory without any directory changes.
+
+Then: `os.ReadDir` is called exactly once (cache serves the second call).
+
+Pass criteria: `readDirCallCount == 1`. This test is identical to T-INT-GO-001 and dual-tagged as a pitfall guard.
+
+---
+
+### P2-A: BM25 tokenizer is not used for session search (pitfalls.md § "Ranking instability")
+
+#### T-PITFALL-006: Session search does not invoke the BM25 SearchEngine
+
+```
+Pitfall: P2 — BM25 tokenizer bypassed
+File: web-app/src/lib/hooks/useSessionSearch.test.ts
+Function: "pitfall" > "does not import or call BM25 SearchEngine"
+```
+
+Given: Source of `useSessionSearch.ts` (inspected statically or via import graph).
+
+When: The module's imports are examined.
+
+Then: No import from `session/search/` or equivalent BM25 module is present. The search is performed exclusively via `Fuse` from `fuse.js`.
+
+Pass criteria (static analysis): `grep -r "SearchEngine\|bm25\|tokenizer" web-app/src/lib/hooks/useSessionSearch.ts` returns empty. Alternatively, a Jest test that spies on the BM25 SearchEngine constructor confirms it is never called during `useSessionSearch` invocations.
+
+---
+
+### P2-B: dropdownDismissed stickiness is fixed (pitfalls.md § "dropdownDismissed resets on mode transition")
+
+#### T-PITFALL-007: Session results are not suppressed after Escape + backspace
+
+```
+Pitfall: P2 — dropdownDismissed stickiness
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: Same as T-INT-005 — dual-tagged as a pitfall guard
+```
+
+Given: `Omnibar` open. User typed path (Escape dismissed path completion dropdown). User backspaced to session query.
+
+When: Debounce fires with `InputType.SessionSearch`.
+
+Then: Session result list is visible.
+
+Pass criteria: `queryByText("SESSIONS")` is not null. This test is identical to T-INT-005 and dual-tagged.
+
+---
+
+### P2-C: Escape on result list has two-press contract (pitfalls.md § "Escape key")
+
+#### T-PITFALL-008: First Escape on result list does not close omnibar
+
+```
+Pitfall: P2 — Escape key contract
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: Same as T-INT-007 — dual-tagged as a pitfall guard
+```
+
+Given: `Omnibar` open with a result highlighted.
+
+When: Escape pressed once.
+
+Then: Omnibar remains open. Highlight is cleared. `onClose` not called.
+
+Pass criteria: `onClose.mock.calls.length === 0`. This test is identical to T-INT-007 and dual-tagged.
+
+---
+
+### P2-D: Separate ranked sections prevent repo paths from burying session results (pitfalls.md § "Mixed result-type ranking")
+
+#### T-PITFALL-009: Sessions always render above repos in the result list
+
+```
+Pitfall: P2 — Mixed result-type ranking
+File: web-app/src/components/sessions/OmnibarResultList.test.tsx
+Function: "pitfall" > "sessions section renders above repos section in DOM order"
+```
+
+Given: `OmnibarResultList` with both session results and repo entries.
+
+When: Component renders.
+
+Then: In the DOM, all session `<li>` items appear before any repo `<li>` items (inspected by DOM order of elements with roles "option").
+
+Pass criteria: `const options = getAllByRole("option"); const firstRepoIndex = options.findIndex(el => el.id.startsWith("omnibar-result-repo")); const lastSessionIndex = options.reduce((max, el, i) => el.id.startsWith("omnibar-result-session") ? i : max, -1); lastSessionIndex < firstRepoIndex`. (All sessions precede all repos in tab/navigation order.)
+
+---
+
+### P3-A: getMatching prefix-only limitation is avoided for recent repos (pitfalls.md § "getMatching does prefix matching only")
+
+#### T-PITFALL-010: Repo path fuzzy search matches non-prefix fragment
+
+```
+Pitfall: P3 — usePathHistory.getMatching prefix-only
+File: web-app/src/components/sessions/Omnibar.test.tsx
+Function: "pitfall" > "repo search matches non-prefix fragment"
+```
+
+Given: `Omnibar` rendered. `usePathHistory` contains `{ path: "/home/user/auth-service" }`.
+
+When: User types `"auth"` (which is not a prefix of the full path `/home/user/auth-service`).
+
+Then: The repo entry for `/home/user/auth-service` appears in the displayed repo results section.
+
+Pass criteria: An element with text `auth-service` is visible in the repo section of the result list. (This verifies the Fuse.js `repoFuse.search` path is used instead of `getMatching`.)
+
+---
+
+## Performance Benchmarks
+
+These are measured and recorded as pass/fail against concrete thresholds. They must be executed as part of CI or as a named `make` target.
+
+| Benchmark | Threshold | Measurement Method | Test ID |
+|---|---|---|---|
+| `useSessionSearch` with 500 sessions, single query | <16ms | Jest `performance.now()` timer around hook render | T-PERF-001 |
+| Fuse repo search over 50 history entries | <5ms | Jest `performance.now()` timer | T-PERF-002 |
+| DirCache Get (cache hit) | <100ms | Go benchmark `BenchmarkDirCache_Get` | T-PERF-003 |
+| Full path completion round-trip (cold) | <500ms | E2E wall-clock (T-E2E-004) | T-PERF-004 |
+
+#### T-PERF-001: useSessionSearch 500 sessions completes in <16ms
+
+```
+File: web-app/src/lib/hooks/useSessionSearch.test.ts
+Function: "performance" > "search completes in <16ms for 500 sessions"
+```
+
+Given: Redux store populated with 500 active sessions with varied titles, branches, and paths.
+
+When: `useSessionSearch("auth")` is invoked and the result is read. The call is timed with `performance.now()`.
+
+Then: Elapsed time is <16ms (one frame at 60fps — imperceptible to the user).
+
+Pass criteria: `elapsed < 16`.
+
+---
+
+#### T-PERF-002: Fuse repo search 50 entries completes in <5ms
+
+```
+File: web-app/src/lib/hooks/useSessionSearch.test.ts (or Omnibar.test.tsx)
+Function: "performance" > "repo Fuse search <5ms for 50 entries"
+```
+
+Given: A Fuse instance built from 50 `PathHistoryEntry` objects.
+
+When: `fuse.search("squad")` is called and timed.
+
+Then: Elapsed time <5ms.
+
+Pass criteria: `elapsed < 5`.
+
+---
+
+#### T-PERF-003: DirCache Get (cache hit) completes in <100ms
+
+```
+File: server/services/dir_cache_test.go
+Function: BenchmarkDirCache_Get
+Run with: go test -bench=BenchmarkDirCache_Get -benchmem ./server/services/...
+```
+
+Given: A `DirCache` with 256 entries (maxSize). One entry is populated.
+
+When: `Get` is called in a tight benchmark loop.
+
+Then: Per-operation time is well below 100ms (expected: nanoseconds to microseconds given it is a map lookup under RLock).
+
+Pass criteria: `BenchmarkDirCache_Get` reports <1ms/op. If it reports >100ms/op, the implementation is pathologically slow.
+
+---
+
+## Architecture / Constraint Tests
+
+These are verified via static analysis or targeted test assertions, not runtime behavior.
+
+#### T-ARCH-001: Zero new RPC endpoints for session search
+
+```
+Method: Static inspection
+```
+
+Given: The `server/` directory and `proto/session/v1/session.proto`.
+
+When: The diff of `server/server.go`, `server/services/`, and `proto/session/v1/session.proto` is inspected.
+
+Then: No new RPC handler registrations for session-search functionality. No new protobuf `rpc` method definitions. Session search results are computed client-side in `useSessionSearch.ts` from the Redux store.
+
+Pass criteria: `git diff main -- server/server.go proto/` shows no new `Connect` handler registrations for session search. Zero new `rpc` definitions in `.proto` files.
+
+---
+
+#### T-ARCH-002: Zero proto changes
+
+```
+Method: Static inspection / CI enforcement
+```
+
+Given: The proto files in `proto/session/v1/`.
+
+When: The diff from `main` is examined.
+
+Then: No `.proto` files are modified.
+
+Pass criteria: `git diff main -- proto/` is empty (or contains only Story 1/2/3 implementation additions to `.go` / `.ts` files — no `.proto` changes).
+
+---
+
+## Definition of Done
+
+All items in this checklist must be green before the implementation is considered complete.
+
+### Go Tests
+
+- [ ] `go test -race ./server/services/... -run TestDirCache` — all 7 DirCache unit tests pass with no race conditions
+- [ ] `go test ./server/services/... -run TestListPathCompletions` — both PathCompletionService integration tests pass
+- [ ] `go test -bench=BenchmarkDirCache_Get -benchmem ./server/services/...` — benchmark reports <1ms/op
+
+### TypeScript Tests
+
+- [ ] `npm test -- --testPathPattern="useSessionSearch"` — all 7 hook unit tests pass (T-UNIT-TS-001 through T-UNIT-TS-007)
+- [ ] `npm test -- --testPathPattern="detector"` — all 4 detector tests pass (T-UNIT-TS-008 through T-UNIT-TS-011), including pitfall guards T-PITFALL-001 and T-PITFALL-002
+- [ ] `npm test -- --testPathPattern="usePathHistory"` — all 4 path history tests pass (T-UNIT-TS-012 through T-UNIT-TS-015)
+- [ ] `npm test -- --testPathPattern="OmnibarResultList"` — all 9 result list tests pass (T-UNIT-TS-016 through T-UNIT-TS-024)
+- [ ] `npm test -- --testPathPattern="Omnibar"` — integration tests T-INT-001 through T-INT-008 pass, pitfall tests T-PITFALL-003 through T-PITFALL-010 pass
+- [ ] Performance benchmarks T-PERF-001 and T-PERF-002 pass (<16ms and <5ms respectively)
+
+### E2E Tests
+
+- [ ] T-E2E-001: Reach session in ≤3 keystrokes passes
+- [ ] T-E2E-002: Create from recent repo in ≤5 keystrokes passes
+- [ ] T-E2E-003: Path completion cache hit <100ms passes
+- [ ] T-E2E-004: Path completion cold start <500ms passes
+
+### Architecture Constraints
+
+- [ ] T-ARCH-001: No new RPC endpoints (verified via `git diff main -- proto/ server/server.go`)
+- [ ] T-ARCH-002: No proto changes (verified via `git diff main -- proto/`)
+
+### Build Health
+
+- [ ] `make lint` passes — no new lint errors introduced
+- [ ] `make build` passes — no compilation errors in Go or TypeScript
+- [ ] `go test -race ./server/services/...` passes — no data races
+
+### Known Acceptable Gaps (not blocking DoD)
+
+- Bug 1 (GitHubShorthand fires on `feature/auth-overhaul` style session names) — documented workaround: search for branch suffix. Tracked as future fix.
+- Bug 2 (deleted paths in recent repos list) — mitigated by `✓`/`✗` path indicator. Tracked as future fix.
+- Bug 3 (ConnectRPC transport created per-render) — predates this feature. Tracked as future fix.
+- Bug 5 (DirCache mtime unreliable on NFS) — documented limitation. Acceptable for solo-practitioner local-filesystem use.

--- a/project_plans/omni-bar-session-search/requirements.md
+++ b/project_plans/omni-bar-session-search/requirements.md
@@ -1,0 +1,88 @@
+# Requirements: Omni Bar Session Search
+
+Status: Draft | Phase: 1 - Ideation complete
+Created: 2026-04-14
+
+## Problem Statement
+
+The Omnibar (`Cmd+K`) is currently a **session creation tool only** — it has no way to jump to an existing session. Users who want to navigate to a session they already created must close the Omnibar, scroll the session list, and click manually. Session creation from known repos is also tedious because users must retype full paths even for repositories they use every day. The directory tree traversal (for path completion) is expensive and uncached, causing perceptible latency on repeated opens.
+
+Two user flows are broken:
+1. **Jump to existing session** — no keyboard-first way to navigate to a running/paused session by name, branch, or path
+2. **Create session from recent repo** — no "recent repos" shortcut; full path must be retyped every time
+
+## Success Criteria
+
+1. User can reach any existing session via Omnibar in ≤3 keystrokes after `Cmd+K`
+2. User can start a new session on any previously-used repo in ≤5 keystrokes after `Cmd+K`
+3. Path completion results appear in <100ms on repeated opens (cache hit) and <500ms cold (first open after restart)
+4. Fuzzy search matches feel natural — "myfeat" matches "my-feature-branch", "squad" matches "stapler-squad"
+
+## Scope
+
+### Must Have (MoSCoW)
+
+- **Session search in Omnibar** — fuzzy search across existing sessions (by title, branch, path, tags, program); selecting a result navigates to that session
+- **Recent repos quick-pick** — list of recently-used repo paths displayed when the input is empty or starts with a non-path query; selecting one pre-fills the path input for fast new-session creation
+- **Fuzzy matching quality** — proper fuzzy algorithm (e.g., fzf-style scoring: consecutive character bonus, start-of-word bonus) replacing naive substring for both session search and path completion
+- **Directory tree cache** — cache the directory tree listing between calls, keyed by root path + mtime; avoids full filesystem traversal on repeated Omnibar opens
+- **Keyboard shortcut to open** — `Cmd+K` (already implemented) opens the Omnibar from anywhere in the app
+
+### Nice to Have
+
+- Unified result list mixing sessions and repo paths (ranked by relevance)
+- Session result shows status badge (Running, Paused) inline
+- Recent repos show last-used timestamp
+- Persistent cache across server restarts (disk-backed)
+
+### Out of Scope
+
+- Global OS-level hotkey (system-wide, not just when app is focused)
+- AI/LLM-powered suggestions or recommendations
+- Non-session navigation (Settings, Help, etc.)
+- Mobile / responsive layout
+- Remote path support (SSH, network mounts)
+
+## Constraints
+
+**Tech stack (already decided):**
+- Frontend: React + TypeScript, ConnectRPC for API calls, vanilla-extract CSS (new components)
+- Backend: Go, ConnectRPC/Protobuf
+- Existing BM25 search engine in `session/search/` — must extend or replace with fuzzy-capable engine
+- Existing `path_completion_service.go` — must add caching layer
+- Existing `Omnibar.tsx` with `usePathCompletions`, `usePathHistory`, `useWorktreeSuggestions` hooks
+- `PathCompletionDropdown.tsx` component already exists
+
+**Cache strategy:** Open question — to be decided in research. Options: in-memory with TTL, disk-backed JSON, or background refresh on startup.
+
+**Search scope:** Session search operates on the in-memory session store (already loaded); no new persistence layer needed.
+
+**Dependencies:** Builds on top of completed `omni-bar-path-completion` work (path completion is done; session search is the new layer).
+
+## Context
+
+### Existing Work
+
+The path completion phase (`project_plans/omni-bar-path-completion/`) is complete:
+- `usePathCompletions` hook with debounced API calls
+- `PathCompletionDropdown` component with keyboard navigation
+- `path_completion_service.go` backend for directory listing and path validation
+- `usePathHistory` and `useWorktreeSuggestions` hooks
+
+What's NOT done (this project covers):
+1. Session search/navigation from Omnibar (was explicitly out of scope in path-completion project)
+2. Recent repos shortcut for session creation
+3. Fuzzy matching quality (current search is BM25 / substring; not fzf-quality)
+4. Directory tree caching (no caching layer currently in `path_completion_service.go`)
+
+### Stakeholders
+
+- Solo practitioner (Tyler) — primary user and developer
+- Workflow: Heavy multi-session usage across many repositories; frequent context-switching between running sessions
+
+## Research Dimensions Needed
+
+- [ ] Stack — fuzzy matching libraries for Go and TypeScript; caching patterns for filesystem data
+- [ ] Features — survey VS Code Command Palette, Raycast, Linear search UX patterns; how do they blend "navigate to existing" + "create new" in one input?
+- [ ] Architecture — where does session search live (client-side filter vs server RPC?); unified result ranking; cache invalidation for directory tree
+- [ ] Pitfalls — stale cache after directory changes; keyboard UX conflicts between session-select mode and path-completion mode; result ranking relevance drift

--- a/project_plans/omni-bar-session-search/research/architecture.md
+++ b/project_plans/omni-bar-session-search/research/architecture.md
@@ -1,0 +1,385 @@
+# Research: Architecture
+
+## Existing Architecture Audit
+
+### Frontend Session Data
+
+The full session list is already available client-side with zero additional RPCs needed.
+
+**How it works:**
+- `useSessionService` (`web-app/src/lib/hooks/useSessionService.ts`) calls `listSessions` on mount and opens a `WatchSessions` stream for real-time updates.
+- All session objects are stored in a Redux entity adapter (`sessionsSlice.ts`) keyed by session ID.
+- The `sessions` array from `useAppSelector(selectAllSessions)` is passed as a prop to `SessionList`, which does client-side filtering today (see `filteredSessions` `useMemo` in `SessionList.tsx:175–195`).
+- Session objects in Redux already carry every field needed for Omnibar search: `title`, `path`, `branch`, `category`, `tags`, `status`, `program`, `updatedAt`.
+
+**Conclusion:** Client-side fuzzy filtering is fully viable with zero new RPCs. The data is already in the Redux store when the Omnibar opens.
+
+### Existing Search Engine (session/search/)
+
+The `session/search/` package is a full BM25 search engine over Claude **conversation history** (the JSONL files in `~/.claude/`). It is completely separate from the live session list.
+
+**Components:**
+- `engine.go` — `SearchEngine` struct with `InvertedIndex`, `DocumentStore`, `BM25Scorer`. Supports `IncrementalSync` against `ClaudeSessionHistory`, incremental add/remove, and disk persistence via `IndexStore`.
+- `bm25.go` — Standard Okapi BM25 with K1=1.5, B=0.75.
+- `tokenizer.go` — Text tokenizer (splits on whitespace/punctuation, normalizes).
+- `inverted_index.go` — In-memory inverted index with `sync.RWMutex`.
+- `snippet.go` — Snippet generation with highlight ranges for search results.
+- `sync_types.go` — `SyncResult`, `IndexSyncMetadata` for incremental index maintenance.
+
+**Critical distinction:** This engine indexes _message content_ from historical Claude conversations, not the live session list. `SearchEngine.Search()` returns `SearchResult` objects with `SessionID` (conversation UUID), `MessageIndex`, BM25 score, and snippet text. It does **not** search active session titles/paths/branches.
+
+**Limitations for Omnibar use:**
+- No fuzzy matching — requires exact tokenized term hits.
+- No consecutive-character bonus, no start-of-word bonus.
+- Not designed for short, incomplete queries like "myfeat" or "squad".
+- Operates on Claude history, not the live session store.
+
+**Extending this engine for session search:** Technically possible but architecturally wrong. BM25 is a bag-of-words model; it does not reward subsequence/fuzzy matches. "squad" would not match "stapler-squad" because BM25 needs the token "squad" to appear in the document, but "stapler-squad" tokenizes to "stapler" and "squad" — actually this would work for exact word matches. However "myfeat" would never match "my-feature-branch" because BM25 has no character-level fuzzy matching. A separate lightweight fuzzy algorithm is needed.
+
+### Path Completion Service
+
+`path_completion_service.go` is **completely stateless**:
+
+```go
+type PathCompletionService struct{}
+```
+
+Every call to `ListPathCompletions` does a fresh `os.ReadDir` with a 2-second timeout. There is no cache. The only latency guard is the 150ms debounce in `usePathCompletions.ts` (client-side) and a module-level LRU cache in `usePathCompletions.ts` with 100 entries, 30s TTL.
+
+**Current client-side cache** (`usePathCompletions.ts:27–55`):
+- `completionCache`: `Map<string, CacheEntry>` (module-level, survives component remounts)
+- Key: `${pathPrefix}::${directoriesOnly}::${maxResults}`
+- TTL: 30 seconds
+- Max size: 100 entries, LRU eviction
+
+This client-side cache is already working. The requirement for a server-side cache would address the case where multiple browser tabs or clients share the server, or where the cache survives a full page reload (the client cache does not survive page reload). A server-side cache would also reduce filesystem I/O across all concurrent calls.
+
+### usePathHistory Hook
+
+`usePathHistory.ts` is a **client-side localStorage hook** — entirely frontend, no backend involvement.
+
+**What it stores:**
+```typescript
+interface PathHistoryEntry {
+  path: string;   // full absolute path
+  count: number;  // times used
+  lastUsed: number; // epoch ms
+}
+```
+
+**Storage key:** `"omnibar:path-history"` in `localStorage`
+**Max entries:** 50, trimmed by score on each save
+**Max results returned:** 10
+
+**Scoring function:**
+```typescript
+function entryScore(e: PathHistoryEntry): number {
+  return recencyScore(e.lastUsed) + Math.log1p(e.count);
+}
+// recencyScore: 1.0 (<1h), 0.8 (<1d), 0.6 (<1w), 0.4 (<1mo), 0.2 (older)
+```
+
+**`getMatching(prefix)`:** Returns entries where `e.path.startsWith(prefix)` (strict prefix filter, not fuzzy), sorted by score desc.
+
+**`save(path)`:** Called in `Omnibar.tsx` after a successful session creation (`saveHistory(detection.localPath)`).
+
+**What this means for "Recent Repos":** The data source for recent repos already exists in `usePathHistory`. It already tracks every path used for session creation with recency scoring. The hook only needs to be extended (or supplemented) to expose the full list (not just prefix-matching entries) when the Omnibar input is empty.
+
+---
+
+## Session Search Design Decision
+
+### Option A: Client-side filtering
+
+**Mechanism:** When the Omnibar input does not look like a path (no leading `~` or `/`), apply a fuzzy scoring function over the Redux session array already in memory. Render matching sessions as a separate result section.
+
+**Pros:**
+- Zero new RPCs — session data is already in Redux.
+- Zero latency — no network round trip, runs synchronously in a `useMemo`.
+- No new backend code.
+- Real-time: results update instantly as WatchSessions stream pushes changes.
+- Simple to implement: add a `useSessionSearch(query, sessions)` hook.
+
+**Cons:**
+- If session count is very large (1000+), filtering in the render loop may cause jank. In practice, most users have ≤100 sessions, making this a non-issue.
+- Fuzzy scoring happens on every keystroke. Acceptable if the algorithm is O(n * |query|), as it would be with a simple fuzzy scorer.
+
+**Feasibility:** High. The `filteredSessions` `useMemo` in `SessionList.tsx` already does client-side string matching today; this is an upgrade to that pattern.
+
+### Option B: New SearchSessions RPC
+
+**Mechanism:** Add `SearchSessions(SearchSessionsRequest)` RPC to the backend. Backend receives query string, runs fuzzy match over the in-memory session store, returns ranked results.
+
+**Pros:**
+- Search logic lives in one place (Go), reusable by TUI and web.
+- Can leverage existing `session/search/` infrastructure (though that's overkill here).
+- Future-proof if session count grows very large.
+
+**Cons:**
+- Network round trip for every keystroke (even with debounce, adds 20–50ms latency).
+- Adds backend complexity: new RPC, new proto messages, new handler, new tests.
+- The session store is already in Redux client-side — sending it to the server and back is redundant.
+- Breaks incremental update model: a search result could be stale if a session is updated between query and response.
+
+**Feasibility:** Medium. Technically straightforward but introduces unnecessary latency and complexity.
+
+### Option C: Extend existing SearchSessions RPC in ListSessionsRequest
+
+`ListSessionsRequest` already has a `search_query` field (proto field 4). The backend `session/storage.go` presumably uses this for filtering. However, examining the client, `listSessions` in `useSessionService.ts` does not pass `searchQuery` from the Omnibar — it would require a new call pattern and introduces the same network-round-trip problem as Option B.
+
+### Recommendation: Option A — Client-side filtering
+
+**Rationale:**
+1. The data is already in memory (Redux store, kept fresh by WatchSessions).
+2. Client-side filtering eliminates all network latency — results appear on every keypress.
+3. Session counts are small (typically <100). A fuzzy scorer over 100 sessions takes <1ms.
+4. The existing `filteredSessions` pattern in `SessionList.tsx` proves the approach works.
+5. Adding a `useSessionSearch(query, sessions)` hook requires no proto changes and no backend work.
+
+**Implementation sketch:**
+```typescript
+// web-app/src/lib/hooks/useSessionSearch.ts
+import { useAppSelector } from "@/lib/store";
+import { selectAllSessions } from "@/lib/store/sessionsSlice";
+import { useMemo } from "react";
+import { fuzzyScore } from "@/lib/fuzzy"; // new module
+
+export function useSessionSearch(query: string) {
+  const sessions = useAppSelector(selectAllSessions);
+  return useMemo(() => {
+    if (!query.trim()) return [];
+    return sessions
+      .map(s => ({
+        session: s,
+        score: fuzzyScore(query, [s.title, s.branch, s.path, ...(s.tags ?? [])].join(" "))
+      }))
+      .filter(r => r.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 10)
+      .map(r => r.session);
+  }, [query, sessions]);
+}
+```
+
+---
+
+## Recent Repos Design
+
+### Where the data comes from
+
+`usePathHistory` already captures every path used for session creation (called from `Omnibar.tsx:360`: `saveHistory(detection.localPath)`). It stores up to 50 entries with recency scoring.
+
+**Current limitation:** `getMatching(prefix)` only returns entries that start with the query prefix. For the "Recent Repos" empty-input case, we need `getAll()` — all entries sorted by score, not filtered by prefix.
+
+### Proposed extension to usePathHistory
+
+Add a `getAll()` method to the existing hook:
+```typescript
+const getAll = useCallback((): PathHistoryEntry[] => {
+  return [...entries].sort((a, b) => entryScore(b) - entryScore(a));
+}, [entries]);
+```
+
+This returns all stored paths sorted by recency+frequency score — exactly what "Recent Repos" needs.
+
+### Where the data lives
+
+**Frontend (localStorage):** All history data lives in `localStorage["omnibar:path-history"]`. This persists across page reloads but not across different browsers/devices. Sufficient for a solo-practitioner use case.
+
+**No backend needed:** Path history is already a client-side concern. Moving it to the backend would require a new RPC, new state persistence, and new proto messages for no functional gain.
+
+**Displayed when:** Input is empty OR when query is non-empty but does not look like a path (so it's in "session search mode"). The recent repos section is shown as a secondary list below session results.
+
+---
+
+## Directory Tree Cache Design
+
+The current `PathCompletionService` is stateless. Every `ListPathCompletions` call performs a fresh `os.ReadDir`. The client already has a 30s LRU cache in `usePathCompletions.ts`, but this is lost on page reload and not shared across browser sessions.
+
+### Recommended Server-Side Cache Design
+
+**Data structure:**
+
+```go
+type DirCacheEntry struct {
+    Entries   []os.DirEntry
+    CachedAt  time.Time
+    DirMtime  time.Time // mtime of the directory at cache time
+}
+
+type DirCache struct {
+    mu      sync.RWMutex
+    entries map[string]*DirCacheEntry // key: absolute baseDir path
+    maxSize int                       // max entries (LRU eviction)
+    ttl     time.Duration             // hard TTL (even if mtime unchanged)
+}
+```
+
+**Invalidation strategy — mtime-based with hard TTL:**
+
+On each cache lookup, stat the directory:
+```go
+func (c *DirCache) Get(path string) ([]os.DirEntry, bool) {
+    c.mu.RLock()
+    entry, ok := c.entries[path]
+    c.mu.RUnlock()
+
+    if !ok {
+        return nil, false
+    }
+
+    // Hard TTL check
+    if time.Since(entry.CachedAt) > c.ttl {
+        c.mu.Lock()
+        delete(c.entries, path)
+        c.mu.Unlock()
+        return nil, false
+    }
+
+    // mtime check: is the directory newer than our cache?
+    info, err := os.Stat(path)
+    if err != nil || info.ModTime().After(entry.DirMtime) {
+        c.mu.Lock()
+        delete(c.entries, path)
+        c.mu.Unlock()
+        return nil, false
+    }
+
+    return entry.Entries, true
+}
+```
+
+**Thread safety:** `sync.RWMutex` — multiple concurrent reads (multiple Omnibar users, though in practice this is a single user), exclusive writes on cache miss/invalidation.
+
+**Scope:** Global singleton, shared across all `ListPathCompletions` requests. This means the second time any client opens the Omnibar and browses the same directory, the cache is warm.
+
+**LRU eviction:** Keep at most 256 directory entries. When evicting, remove the entry with the oldest `CachedAt`. Simple O(n) scan is fine at this scale; a heap is unnecessary.
+
+**TTL recommendation:** 5 seconds. This covers the typical Omnibar interaction (open → type path → navigate → close) while preventing stale data from persisting across filesystem mutations (git checkout, npm install, etc.).
+
+**Why not background refresh:** Background goroutines that poll directories consume resources even when no user is active. mtime-check on demand is cheaper and simpler. A 5s TTL with mtime invalidation handles all real-world cases.
+
+**Integration into PathCompletionService:**
+
+```go
+type PathCompletionService struct {
+    cache *DirCache
+}
+
+func NewPathCompletionService() *PathCompletionService {
+    return &PathCompletionService{
+        cache: NewDirCache(256, 5*time.Second),
+    }
+}
+
+// In ListPathCompletions, replace os.ReadDir with:
+if cached, ok := p.cache.Get(baseDir); ok {
+    dirEntries = cached
+} else {
+    // existing ReadDir with timeout logic
+    dirEntries = ... // result of os.ReadDir
+    p.cache.Put(baseDir, dirEntries)
+}
+```
+
+**Client cache interaction:** The client's 30s LRU cache in `usePathCompletions.ts` still operates as the first layer. The server cache is only hit when the client cache misses (page reload, first open, or after 30s). This means the effective behavior is:
+- Reopening Omnibar within 30s: served from client cache (0ms overhead)
+- After 30s or page reload: hits server cache (1 stat call instead of ReadDir)
+- After server cache expires (5s TTL) or directory changed: fresh ReadDir
+
+---
+
+## Unified Result Ranking
+
+If session results and recent repo paths are shown in a single list, a unified ranking approach is needed.
+
+### Sections vs. Interleaved
+
+**Recommendation: Sections, not interleaved.** The mental model for the user is different: sessions are things to navigate to; repos are things to create new sessions in. Mixing them confuses the action. VS Code Command Palette and Linear both use sections with headers.
+
+**Layout:**
+```
+[Sessions]                    ← section header (only shown when query active)
+  my-feature-session   Running
+  stapler-squad-bug    Paused
+
+[Recent Repos]                ← section header
+  ~/projects/stapler-squad    2h ago
+  ~/work/api-server            3d ago
+```
+
+### Score normalization
+
+**Session scoring** (fuzzy score 0.0–1.0):
+- Base: character-sequence fuzzy match score (consecutive bonus, start-of-word bonus)
+- Status boost: Running × 1.2, Paused × 1.0, Stopped × 0.7
+- Recency boost: `Math.log1p(hoursSinceUpdate)` decay applied as a multiplier
+
+**Repo scoring** (from `usePathHistory`):
+- Uses `entryScore(e) = recencyScore(e.lastUsed) + Math.log1p(e.count)` already implemented in the hook
+- When query is active, also apply fuzzy match score against the path
+
+**Score normalization:** Since sessions and repos are in separate sections, there is no need to normalize scores against each other. Each section is ranked independently.
+
+### Implementation
+
+```typescript
+type OmnibarResult =
+  | { type: "session"; session: Session; score: number }
+  | { type: "repo";    entry: PathHistoryEntry; score: number };
+
+function rankSessions(query: string, sessions: Session[]): OmnibarResult[] { ... }
+function rankRepos(query: string, history: PathHistoryEntry[]): OmnibarResult[] { ... }
+```
+
+---
+
+## Required Proto/RPC Changes
+
+Session search via client-side filtering requires **no new proto messages or RPC methods**. All session data is already available through existing `ListSessions` / `WatchSessions` RPCs.
+
+However, the following changes may be needed as nice-to-haves:
+
+### Strictly Required (Must Have)
+
+None. The architecture decision (client-side search) requires no proto changes.
+
+### Potentially Useful
+
+**1. `ListSessionsRequest.search_query` already exists (field 4)** but the backend implementation is currently a substring filter. If the recommendation is later revised to use the server for ranking (e.g., for TUI consistency), the backend implementation of this field would need upgrading to fuzzy. No proto changes needed.
+
+**2. Server-side directory cache does not require proto changes.** It is an internal implementation change to `PathCompletionService`.
+
+### If unified result type is needed on a future server RPC
+
+```protobuf
+// OmnibarSearchRequest — future only, not needed for client-side approach
+message OmnibarSearchRequest {
+  string query = 1;
+  int32 max_sessions = 2;     // default 8
+  int32 max_repos = 3;        // default 5
+}
+
+// OmnibarResult — future only
+message OmnibarResult {
+  oneof item {
+    Session session = 1;
+    RecentRepo repo = 2;
+  }
+  float score = 3;
+  string match_source = 4;    // "title", "branch", "path", "tags"
+}
+
+message RecentRepo {
+  string path = 1;
+  google.protobuf.Timestamp last_used = 2;
+  int32 use_count = 3;
+}
+
+message OmnibarSearchResponse {
+  repeated OmnibarResult results = 1;
+  int64 query_time_ms = 2;
+}
+```
+
+**Verdict: No proto changes needed for the recommended client-side architecture.** The `ListSessionsRequest.search_query` field exists as a future hook if server-side ranking is ever desired for TUI/multi-client scenarios. The server-side directory cache is a pure internal refactor with no API surface changes.

--- a/project_plans/omni-bar-session-search/research/features.md
+++ b/project_plans/omni-bar-session-search/research/features.md
@@ -1,0 +1,355 @@
+# Research: Features
+
+Dimension: Features
+Researcher: agent
+Date: 2026-04-14
+Status: Complete
+
+---
+
+## VS Code Command Palette Patterns
+
+VS Code uses two keyboard shortcuts that solve the same problem this project faces: one input, two intents.
+
+**Cmd+P (Quick Open / File Picker)**
+- Opens with empty state showing recent files ordered by recency, with the most recently opened at top.
+- Typing filters the list fuzzy-first: the query "myfeat" matches "my-feature.ts" because VS Code uses a consecutive-character-bonus algorithm (contiguous runs score higher than scattered matches).
+- Result items are homogeneous: all file paths, no visual type distinction needed within the list. The icon (file vs folder) provides the only type signal.
+- Tab accepts the highlighted item and continues completion (directory drill-down).
+- Enter accepts and opens.
+- The placeholder text reads "Search files by name" — a single clear intent.
+
+**Cmd+Shift+P (Command Palette)**
+- Empty state shows recently-used commands, not all commands, with usage frequency as the secondary sort.
+- Prefix characters trigger mode-switching: typing `>` puts you in command mode (the default for Cmd+Shift+P), `@` switches to symbol mode, `:` switches to line-number mode, `#` switches to workspace symbol mode. Critically, these prefixes work in the *same* input — you do not need a different shortcut.
+- Result items show a category label (e.g., "File", "Edit", "View") in a dimmed secondary column on the right. The primary text is the command name. This asymmetric layout (bold left, dimmed right) is the VS Code signal for "primary intent / secondary context."
+- When multiple result types are mixed (commands + files + symbols), VS Code groups them with horizontal section headers ("recently opened", "other files") rather than interleaving.
+
+**Key Pattern: Sigil-Based Mode Switching**
+VS Code deliberately conflated Cmd+P and Cmd+Shift+P at the input layer. Typing `>` in the file picker switches to command mode. This is the canonical solution to the "single input, multiple intents" problem. The user does not need to remember different shortcuts; the input itself is the mode controller.
+
+**Recommendation for this app:** Do not implement sigil-based mode switching. Stapler Squad has only two modes (navigate existing vs create new), and sigil complexity adds friction. VS Code's sigil system works because it has 8+ intent modes. For two modes, visual grouping in results is sufficient.
+
+**Empty State Recommendation:**
+VS Code shows recent files immediately when input is empty — zero characters yields a useful list. This is the right model. "Nothing until they type" is a missed opportunity; the user opened the palette with intent, and showing them their most likely options immediately is faster than requiring a query.
+
+---
+
+## Raycast / Alfred Patterns
+
+Raycast is the clearest reference for the navigate-existing + create-new problem in a single input.
+
+**How Raycast Blends Navigation and Creation**
+
+Raycast treats every result item as a potential pivot point. When you type "Slack" and the result list shows the Slack application, you can:
+- Press Enter to open Slack (navigate to existing)
+- Press Tab or a secondary shortcut to see "actions" for that result (e.g., "New Message in Slack", "Quit Slack", "Open in Background")
+
+The secondary action system is the crucial pattern: the same result item can have a primary action (navigate) and secondary actions (create/modify). This is displayed as a small kbd shortcut hint at the right side of the highlighted row ("Tab for actions" or "Cmd+K for more actions").
+
+**Section Headers vs Interleaved Results**
+
+Raycast uses section headers when results come from distinct sources. For example, if you type "Notion" and get both an application result and Raycast extension commands, they appear under separate labeled sections:
+
+```
+APPLICATIONS
+  Notion  ·  Open
+
+RAYCAST COMMANDS
+  Search Notion pages
+  Create Notion page
+```
+
+The section header is visually light (all-caps, muted color, small font) and does not receive keyboard focus. Arrow keys skip over headers to items.
+
+When results are homogeneous (all from the same source), no headers appear.
+
+**Result Type Signaling**
+
+Raycast signals result type through:
+1. Icon on the left (app icon, folder icon, document icon, command icon)
+2. Section header above the group
+3. A subtle text annotation on the right showing the source ("Notion", "Browser History", "File System")
+
+The primary text (result name) is never diluted with type information inline — type is always a secondary visual element.
+
+**Empty State**
+
+Raycast shows "Pinned items" and "Recently used" sections when input is empty. The distinction matters: pinned items are intentional persistent shortcuts, recently used items reflect actual behavior. Most importantly, this means the palette is immediately useful — opening Raycast is never a blank screen experience.
+
+**Alfred Patterns**
+
+Alfred is more spartan than Raycast but shares the same structural insight: result rows are uniform in height, type is signaled via icon, and secondary actions are revealed on a secondary keypress (Cmd+L in Alfred reveals "large type", Cmd+Y reveals quick look). Alfred explicitly separates "file results" from "application results" from "workflow results" using section headers when results mix types.
+
+Alfred's fallback actions are relevant here: when no results match, Alfred shows "Search Google for X", "Search Amazon for X" — explicit creation/external-action affordances that surface when the navigation intent fails. This is directly analogous to: when no session matches the query, show "Create new session in /path/X."
+
+---
+
+## Linear / Notion Patterns
+
+**Linear Cmd+K**
+
+Linear's command menu is the closest analog to this project's needs because it explicitly blends navigation and creation in one input, across issue entities that have both a "go to" and a "create" action.
+
+Empty state shows two sections:
+1. "Recent" — the last 5-8 issues you visited, shown with their identifier (LIN-1234), title, and status icon
+2. "Suggested actions" — context-sensitive shortcuts like "Create issue in current project"
+
+When you type:
+- Fuzzy matching runs against issue title, identifier, and assignee simultaneously
+- Results show the issue identifier in a fixed-width monospace pill on the left, the title as primary text, and the team/project as secondary muted text
+- Status is shown as a colored circle icon on the left of the identifier
+
+**Navigate vs Create Signal in Linear**
+
+Linear does not use a prefix sigil. Instead, it uses result position to signal intent: navigation results (existing issues) always appear first, and at the bottom of the list appears a persistent "Create issue..." entry styled differently — it has a `+` icon and slightly different background treatment. This is always present regardless of what the user types.
+
+This is the most important pattern to borrow: a persistent "create" action at the bottom of the result list, styled to distinguish it from navigation results. The user can scroll past all navigation results to reach the creation action, or they can use the keyboard shortcut shown in the footer.
+
+**Mode Signaling Without Sigils**
+
+Linear uses visual hierarchy, not sigils:
+- Navigation results: icon on left, title bold, metadata muted on right
+- Create action: `+` icon, "Create new issue" text, full-width distinct background
+
+This is clean and requires no learned syntax.
+
+**Notion Cmd+K**
+
+Notion's quick-find blends page navigation (go to existing) with page creation more naturally than Linear. The key Notion pattern is **progressive disclosure of action**: when you select a page result, you see "Open", "Open in side peek", "Copy link" — the first action is navigation, but others are available. Notion does not offer inline creation from the quick-find; creation is a separate action.
+
+For Stapler Squad's purposes, Notion's pattern is less relevant because Stapler Squad needs both navigation and creation as first-class peers.
+
+**The Linear Model is the Right Baseline**
+
+The Stapler Squad omnibar should follow the Linear model:
+- Empty state: recent sessions (navigate) + recent repos (create)
+- Typing: fuzzy session results first, "create new session" entry persistent at bottom
+- Result type is visually distinguished (icon + background, not sigils)
+
+---
+
+## Current Omnibar Analysis
+
+### What exists today
+
+The current `Omnibar.tsx` is a **session creation wizard only**. It has:
+
+1. **A single text input** that detects input type via `detect()` from `/lib/omnibar/detector.ts`. The detector chain handles: GitHub PR URLs, GitHub branch URLs, GitHub repo URLs, GitHub shorthand (owner/repo), path with branch (path@branch syntax), and local paths.
+
+2. **Path completion dropdown** (`PathCompletionDropdown.tsx`) that appears when the input is detected as a local path. It merges history entries (from `usePathHistory`) with live filesystem completions (from `usePathCompletions`). History entries appear first with a clock icon and a divider separating them from live entries.
+
+3. **A form body** with session name, session type (new worktree / existing worktree / directory), branch controls, working directory, and advanced options (program, category, auto-yes). This is a multi-field form that appears below the input.
+
+4. **An icon + label detection badge** that shows the detected input type (e.g., "Local Path", "GitHub PR") with emoji icons.
+
+5. **A `usePathHistory` hook** stored in localStorage at `omnibar:path-history` with up to 50 entries. The hook tracks path, count, and lastUsed timestamp. Scoring is `recencyScore + log1p(count)`. It exposes `getMatching(prefix)` but **not** a method to get top items without a prefix.
+
+6. **A `useRepositorySuggestions` hook** that fetches all sessions via `listSessions` RPC and ranks paths by frecency. This hook exists and is ready — it is not yet wired into the Omnibar UI.
+
+### What is missing (critical gaps)
+
+1. **No session search or navigation**. The Omnibar has no way to show existing sessions as results. There is no search box mode, no session result type, no "select session to navigate" action. The omnibar is purely a creation tool.
+
+2. **The creation form appears immediately** for all non-empty input. There is no intermediate "here are things you might want" result list before the user is committed to creation. This makes the omnibar creation-first, with no discovery phase.
+
+3. **History entries are prefix-matched only**. `getMatching(prefix)` requires a matching prefix. There is no "show top N most-used repos without prefix" capability — meaning the empty state shows nothing history-related.
+
+4. **No session-type result rendering**. There is no component that renders a session as a selectable result item with status badge, branch, path, etc.
+
+5. **The path completion dropdown and the form are separate layers**. The dropdown is a transient overlay over the form. There is no unified result list that could show both session results and repo/path results in sections.
+
+6. **`useRepositorySuggestions` exists but is unused in Omnibar**. The hook fetches and ranks paths by frecency from existing sessions — this is the "recent repos" data source. It just needs to be surfaced in the UI.
+
+### What modes currently exist
+
+- **Path mode**: Input is a local path or path+branch → path completion dropdown activates, form shows worktree options
+- **GitHub mode**: Input is a GitHub URL or shorthand → form shows clone-related fields
+- **Unknown mode**: Input doesn't match any detector → badge shows "Unknown", form cannot be submitted
+
+There is no "search mode" or "navigate mode." Adding session search adds a third mode that activates when input is non-path, non-GitHub text (or when the omnibar opens with empty input).
+
+### What UI affordances exist
+
+- Modal overlay (dark backdrop, centered card)
+- Type indicator icon at left of input
+- Path existence indicator (✓/✗/⟳) at right of input
+- Path completion dropdown (listbox, keyboard navigable, history section + live section with divider)
+- Keyboard shortcuts footer (Esc, Cmd+Enter, arrow keys, Tab when dropdown is visible)
+- Error message area above footer
+
+---
+
+## Recent Items Patterns
+
+### Empty state: show recents or show all?
+
+Show recents. Never show nothing. An empty omnibar that presents a blank input is a missed UX opportunity. The user opened the palette because they want to do something — showing them their most likely options without requiring a query is strictly better.
+
+The correct empty state:
+- "Jump to session" section: top 5 most recently accessed sessions
+- "Recent repos" section: top 5 most recently used repo paths (from `useRepositorySuggestions`)
+
+5 items per section is the right limit. More than 5 creates scroll anxiety; fewer than 5 may not include the item the user wants. VS Code uses ~10 for file picker but 10 is too many for a two-section mixed display.
+
+### Recency vs frequency weighting
+
+`usePathHistory` already implements a combined recency+frequency score: `recencyScore(lastUsed) + log1p(count)`. This is the correct model. The `log1p` dampens the frequency contribution so a path used 100 times a month ago doesn't permanently outrank a path used twice yesterday.
+
+For session recency: use `session.updatedAt` (last activity timestamp) as the primary signal, not `session.createdAt`. A session created 3 months ago but actively used yesterday is a recent session.
+
+### How many recent items to show
+
+Empty state: 5 sessions + 5 repos = 10 items total, in two labeled sections.
+With query: max 8 total results (5 sessions + 3 repos, or all sessions if no repos match).
+
+Do not show more than 8 results with a query active. More than 8 items in a command palette creates scroll anxiety and slows keyboard navigation.
+
+### How to rank recents vs search results when user starts typing
+
+Once the user types anything, switch from "recents mode" to "search mode." Do not blend recency scores with search scores — the contexts are different. In recency mode, the user has not expressed intent; in search mode, they have. A search result that scores 0.3 should rank above a recent item that was used yesterday.
+
+Exception: if the query is very short (1-2 characters), recency should still boost results because the user may be using the first letter as a quick-filter rather than a deliberate search term. Implement this as: for queries of length <= 2, multiply the search score by (1 + 0.5 * recencyScore).
+
+---
+
+## Result Mixing: Sessions + Repos
+
+### Should they be separate sections or interleaved?
+
+Separate sections. The action on selection differs fundamentally:
+- Clicking a session result: navigates to that session (closes omnibar, scrolls/activates session)
+- Clicking a repo result: pre-fills the path input for new session creation (does not close omnibar, transitions to creation form)
+
+These two action models cannot be interleaved without confusion. If a user presses Enter on the top result not knowing whether it's a session or a repo, they will get unexpected behavior 50% of the time. Sections with distinct headers make the action semantics scannable before committing.
+
+### How to visually distinguish session results from repo results
+
+**Session result row:**
+```
+[status dot] [session title] (bold)          [branch name] (muted)
+             [repo path] (muted, smaller)     [Running/Paused badge]
+```
+
+- Status dot: colored circle (green = Running, yellow = Paused, grey = Stopped)
+- Title: bold, left-aligned
+- Branch: right-aligned, muted
+- Path: second line, smaller, muted
+- Status badge: right-aligned, colored text label
+
+**Repo result row:**
+```
+[folder icon] [repo path] (bold last segment, muted parent path)    [last used] (muted)
+              [N sessions] (muted)
+```
+
+- Folder icon distinguishes from session dot
+- Path rendering: bold the last segment (repo name), muted for parent path
+- Last-used timestamp (relative: "2 days ago")
+- Session count ("3 sessions") signals this is an active repo
+
+### Section headers
+
+```
+SESSIONS  (3 results)
+[session rows...]
+
+REPOS  (5 results)
+[repo rows...]
+```
+
+Headers are all-caps, small font, muted color, non-interactive. Session count shown in header for orientation. No section collapser — the list is short enough (max 8 items) that collapsing adds friction without benefit.
+
+### Keyboard behavior
+
+Arrow keys navigate all results in sequence, skipping headers. Enter executes the primary action for the focused item. The action difference (navigate vs fill-form) means the user must understand what type of result is highlighted — which is why the visual distinction (dot vs folder icon, section header) is load-bearing for keyboard users.
+
+### When to show each section
+
+- **Omnibar opens, no input**: Show both sections (recents mode, 5+5)
+- **User types a short query (1-3 chars)**: Show both sections, filtered
+- **User types a longer query**: Show sessions section if any match; show repos section if any match; hide empty sections entirely (do not show "no results" placeholder for a section)
+- **Input is detected as a local path (starts with /  or ~/)**: Hide session results entirely. Switch to path completion mode — the user is doing directory navigation, not session search. This is the current behavior and it's correct.
+- **Input is detected as GitHub URL**: Hide both sections. User is cloning a remote repo. This is the current behavior and it's correct.
+
+---
+
+## Recommended UX Model
+
+### The Model: Two-Phase Omnibar
+
+The omnibar operates in two phases separated by an intentional user action (selecting a result vs typing a path).
+
+**Phase 1: Discovery (the result list)**
+The input is a query. Results are sessions and repos. The user navigates with arrow keys and selects with Enter.
+
+- If the user selects a **session result**: omnibar closes, the selected session becomes active.
+- If the user selects a **repo result**: the omnibar transitions to Phase 2, pre-filling the path input with the selected repo path.
+- If the user's input is detected as a **local path** (starts with `/` or `~`): omnibar transitions directly to Phase 2 without showing a result list.
+
+**Phase 2: Creation (the existing form)**
+This is the current Omnibar.tsx creation form, unchanged except that the path field is pre-filled. The user fills in session name, session type, branch, etc., and submits with Cmd+Enter.
+
+### Interaction Model in Detail
+
+**On Cmd+K (open omnibar):**
+1. Input is empty and focused.
+2. Below the input: two sections visible immediately.
+   - "SESSIONS" with the 5 most recently active sessions.
+   - "REPOS" with the 5 most frecent repo paths.
+3. Keyboard shortcut hint in footer: "↑↓ to navigate · Enter to jump · Tab to complete"
+
+**User types characters (any non-path, non-GitHub text):**
+1. Both sections update in real time with fuzzy-matched results.
+2. Empty sections collapse (no "SESSIONS" header if no sessions match).
+3. Minimum 1 character to trigger search (do not search on empty — show recents instead).
+4. If no results in either section: show a single "Create session in `<query>`?" item at the bottom, styled like a "new item" affordance (+ icon, italic text). This prevents the dead-end of zero results.
+
+**User types a path (starts with / or ~):**
+1. Session results section disappears immediately.
+2. The path completion dropdown activates (existing behavior).
+3. REPOS section is hidden — user is in path navigation mode.
+
+**User selects a session result (Enter or click):**
+1. Omnibar closes.
+2. The selected session becomes focused/highlighted in the session list.
+3. If the app has a session detail view or terminal panel, it opens for that session.
+
+**User selects a repo result (Enter or click):**
+1. The input is pre-filled with the repo path.
+2. The result list disappears.
+3. The creation form body appears (Phase 2).
+4. The session name field is auto-filled with the suggested name (existing behavior).
+5. The user is now in creation mode.
+
+**The "Create New" escape hatch:**
+A persistent "+ New Session" item appears at the very bottom of the result list, below all sections and a visual separator. It is always present when the result list is showing. Pressing End or scrolling down reaches it. Its label adapts: "New session in /queried/path" if the query looks like a path, otherwise "New session". Selecting it transitions to Phase 2 with empty path field.
+
+### What NOT to do
+
+Do not change the creation form (Phase 2) at all. The form is correct — it collects the right information, and adding session navigation on top of it would make the component too large. The architectural split between Phase 1 (result list, new component) and Phase 2 (existing form, unchanged) is the right boundary.
+
+Do not implement sigil-based mode switching (e.g., `>` for session search, `/` for path). Two intents do not need a sigil system. Visual grouping and input-type detection are sufficient.
+
+Do not interleave session results and repo results by relevance score. The action difference (navigate vs fill-form) makes interleaving dangerous for keyboard users.
+
+Do not show more than 8 results total. Command palette fatigue sets in past 8 items; users stop reading and start scrolling, which defeats the keyboard-first value proposition.
+
+### Component Architecture Implication
+
+The recommended model implies the following component decomposition:
+
+1. **`OmnibarResultList` (new component)**: Renders session results + repo results in sections. Handles keyboard navigation within the list. Emits `onSessionSelect(session)` and `onRepoSelect(path)` events.
+
+2. **`OmnibarSessionResult` (new component)**: Renders a single session result row with status dot, title, branch, path, status badge.
+
+3. **`OmnibarRepoResult` (new component)**: Renders a single repo result row with folder icon, path (bold last segment), last-used, session count.
+
+4. **`Omnibar.tsx` (modified)**: Gains a mode state: `'discovery' | 'creation'`. In `discovery` mode, renders `OmnibarResultList` below the input instead of the form body. In `creation` mode, renders the existing form body (current behavior, unchanged). Transitions from `discovery` to `creation` when a repo is selected or when path detection activates.
+
+5. **Session search hook (new)**: `useSessionSearch(query)` — takes the current query, returns ranked session results. This is the client-side fuzzy search layer that this research does not cover in depth (that is the Stack and Architecture dimensions).
+
+This two-phase, two-mode architecture satisfies the requirements:
+- "reach any existing session in ≤3 keystrokes after Cmd+K" — open (1), type first letter (2), Enter (3)
+- "start new session on any previously-used repo in ≤5 keystrokes" — open (1), arrow to repo (2-3), Enter (4), Cmd+Enter (5)
+- The path completion and GitHub URL flows are unaffected (they are Phase 2 entry points)

--- a/project_plans/omni-bar-session-search/research/pitfalls.md
+++ b/project_plans/omni-bar-session-search/research/pitfalls.md
@@ -1,0 +1,227 @@
+# Research: Pitfalls
+
+Dimension: Pitfalls for Omnibar Session Search + Fuzzy Matching + Directory Tree Cache
+Date: 2026-04-14
+Status: Complete
+
+---
+
+## P1: Critical (will break the feature if ignored)
+
+### Detector mode conflict: session-search input vs path input
+
+The existing `detector.ts` uses input shape to classify what the user is typing. A bare word like `squad` resolves to `InputType.Unknown` (no leading `/`, `~/`, `./`, no `://`). That means session search queries — which are natural-language strings like `my-feature` or `squad` — will produce `InputType.Unknown`, which today blocks submission entirely (`canSubmit` returns false when `detection.type === InputType.Unknown`, line 306 of `Omnibar.tsx`).
+
+Risk: Adding session search without touching the detector means no session result is ever reachable by typing a bare word. Every search query except those starting with a path sigil falls through to Unknown.
+
+Mitigation: Introduce a new `InputType.SessionSearch` that is returned when the input does not match any existing pattern. The detector's `LocalPathDetector` (priority 100) is the current catch-all fallback returning `null` for non-path strings; the default registry's final fallback returns `InputType.Unknown`. Session search should sit *after* `LocalPath` detection so path typing still activates path completion, but anything else activates session search mode.
+
+---
+
+### Enter key ambiguity: "navigate to session" vs "create session"
+
+Currently `handleKeyDown` treats Enter in the dropdown as a path completion acceptance, and `Cmd+Enter` as form submit. When session results appear in the same omnibar, a plain Enter on a session result should *navigate* (not create). This conflicts with the current submission model where submitting requires `canSubmit` to be true and calls `onCreateSession`.
+
+Risk: Without explicit routing of Enter by result type, the user presses Enter on a session result and either (a) nothing happens (session-search result doesn't satisfy `canSubmit`), or (b) a new session is accidentally created with the session name as path.
+
+Mitigation: The omnibar needs two distinct Enter behaviors: if the focused item is a session result, Enter calls a navigation callback (e.g., `onNavigateToSession`). If the focused item is a path completion or the user is in creation mode, Enter selects the path completion or triggers `handleSubmit`. This must be explicit in the keyboard handler, not inferred.
+
+---
+
+### `PathCompletionService` is stateless and uncached — every keystroke hits the filesystem
+
+`PathCompletionService` is explicitly documented "stateless; each call performs a fresh directory listing" (line 26, `path_completion_service.go`). The client-side `usePathCompletions` hook has a 30-second TTL LRU with 100 entries (`CACHE_MAX = 100`, `CACHE_TTL_MS = 30_000`), but this only helps for burst typing at the same prefix. Opening the omnibar a second time with the same prefix will hit the cache; however the directory tree cache requirement in the requirements doc is about server-side caching so that even the *first* call within a server session is fast.
+
+Risk: Without a server-side cache, the cold-open latency target of <100ms (requirement #3) cannot be met, especially for home directory traversal (hundreds of entries). Currently each `ListPathCompletions` call does a full `os.ReadDir` on every invocation. A user typing `~/` five times across five omnibar opens will trigger five separate `os.ReadDir("~")` calls.
+
+Mitigation: Add a server-side cache keyed by `(baseDir, maxResults, directoriesOnly)` with the directory's mtime as a cache-validity signal. The mtime approach has its own pitfall (see P3-C4).
+
+---
+
+### `usePathCompletions` creates a new transport and client on every render cycle
+
+Lines 147–153 of `usePathCompletions.ts` create `createConnectTransport({ baseUrl })` and `createClient(SessionService, transport)` inside the debounce callback. This is inside a `useEffect` that re-runs on every change to `pathPrefix`, `baseUrl`, `enabled`, `directoriesOnly`, or `maxResults`. While the debounce/abort/generation pattern correctly discards stale results, a new HTTP transport object is created per keypress. At high typing speed this has memory and connection overhead. When session search adds a *second* async hook (for session results), the two hooks firing simultaneously could create connection contention.
+
+Risk: Not an outright breakage, but it degrades performance and adds complexity when a second async hook is added alongside it.
+
+Mitigation: Lift the transport/client creation to module level (similar to how the cache is module-level). The pattern is already used for the cache (`const completionCache = new Map(...)`) — extend it to the client instance.
+
+---
+
+## P2: High (significant UX or reliability impact)
+
+### Ranking instability: BM25 tokenizer strips hyphens → session titles become unrecognizable
+
+The `Tokenizer.Tokenize()` method splits on `!unicode.IsLetter(r) && !unicode.IsNumber(r)` (line 61–63, `tokenizer.go`). A session title like `my-feature-branch` becomes tokens `["my", "featur", "branch"]` (after Porter stemming). A query of `my-feature` would tokenize to `["my", "featur"]`, which matches, but BM25 scoring treats these as three separate tokens competing against all other documents. More importantly, hyphenated names like `stapler-squad` stem to `["stapl", "squad"]`, meaning "squad" matches dozens of unrelated sessions if they contain that word.
+
+Risk: BM25 was built for long-form document search. Session titles are short (2–5 tokens). In a small corpus of 20–50 sessions, IDF will be near-zero for common tokens (every session might be in the `stapler-squad` repo), making scores nearly identical and result order unpredictable across queries.
+
+Mitigation: Session search should not use the existing BM25 `SearchEngine` at all. It should use a dedicated fuzzy matcher operating on session metadata fields (title, branch, path, tags) with field-specific weights. The BM25 engine is for conversation history search, not session list navigation.
+
+---
+
+### Escape key: first press should dismiss session-search dropdown, not close omnibar
+
+Current behavior (line 253–259 of `Omnibar.tsx`): when the path-completion dropdown is visible and Escape is pressed, `e.nativeEvent.stopImmediatePropagation()` is called and only the dropdown is dismissed. A second Escape closes the omnibar. This is correct behavior.
+
+When session search results appear, the same two-press Escape contract must hold: first Escape dismisses the session result list, second Escape closes the omnibar. If session results and path completions share the same `dropdownDismissed` / `dropdownIndex` state, toggling between modes (typing a path, then backspacing to session-search) could leave `dropdownDismissed = true` and suppress session results.
+
+Risk: Sessions results never appear after the user types a path, then deletes it, because `dropdownDismissed` is sticky and not reset when the input type changes.
+
+Mitigation: Either add a separate `sessionResultsDismissed` state, or reset `dropdownDismissed` on every mode transition detected by the detector.
+
+---
+
+### Symlink loops in directory traversal for tree cache
+
+`path_completion_service.go` follows symlinks for directory detection (lines 134–141) using `os.Stat` (follows symlinks) while walking with `os.ReadDir` (does not recurse). The current code only reads a single directory level, so symlink loops are not a problem now. However, if the server-side cache implementation adds recursive traversal (to pre-warm the cache with subdirectory contents), a symlink loop like `~/projects/link → ~/` would cause infinite recursion.
+
+Risk: Not a current bug, but will become a critical bug if the cache is implemented with recursive pre-warming.
+
+Mitigation: Any recursive cache-warming code must track visited real paths using `filepath.EvalSymlinks` and skip already-visited directories.
+
+---
+
+### Recent repos: localStorage path history not validated on load
+
+`usePathHistory.ts` stores paths in `localStorage` keyed by `"omnibar:path-history"` (line 5). On load, `loadFromStorage()` returns the raw parsed array with no validation that paths still exist on disk. The `getMatching` function (line 68–77) returns entries sorted by score with no existence check.
+
+Risk: The recents list accumulates deleted, renamed, or unmounted paths silently. When shown in the "Recent Repos" quick-pick for new-session creation, deleted paths lead to session creation failure (caught only at the server level with an error message).
+
+Mitigation: On each omnibar open, validate recent repo entries against the path-existence endpoint (`pathExists` from `usePathCompletions`) before displaying them. Stale entries should be surfaced with a visual indicator or silently pruned. Cap the list to entries used within the last 30 days.
+
+---
+
+### Mixed result-type ranking: sessions and repos competing for the same slots
+
+The requirements spec lists "unified result list mixing sessions and repo paths" as a Nice-to-Have but session search and recent repos as Must-Have. Even without explicit mixing, the UI must decide which results take priority when the query matches both a session title ("auth-service") and a recent repo path (`~/work/auth-service`).
+
+Risk: If sessions and repos are mixed naively with no type-aware boosting, repo paths (which have longer strings with more matching characters) will typically outscore short session titles in fuzzy scoring algorithms, hiding the sessions the user actually wants to navigate to.
+
+Mitigation: Use separate ranked sections (sessions first, then repos) rather than a single merged rank. Apply type-specific boosts: exact title match > prefix match > fuzzy match, with sessions ranked above repos when both match equally.
+
+---
+
+## P3: Medium (noticeable but workaround exists)
+
+### mtime cache invalidation is unreliable for subdirectory changes
+
+The requirements specify caching keyed by "root path + mtime." On macOS (HFS+/APFS), the mtime of a directory only updates when files are *directly* added or removed in that directory — not in subdirectories. So `~/projects` mtime does not change when `~/projects/myrepo/src/new-file.ts` is created.
+
+Risk: Cache will serve stale results if a user clones a repo into an existing directory. The parent directory listing won't change (no new entry there), but the subdirectory listing at the leaf has changed. For shallow single-level listings (current behavior), this is mostly benign because a new subdirectory in `~/projects` *does* update `~/projects` mtime. The risk is higher for nested caching if ever implemented.
+
+Mitigation: For single-level `os.ReadDir` caching, mtime-based invalidation is acceptable. Document the limitation. Set a short TTL (30–60 seconds) as a backstop. Do not rely solely on mtime if implementing multi-level caching.
+
+---
+
+### `usePathCompletions` generation counter only increments, never wraps — safe for React lifecycle
+
+The `generationRef.current` counter in `usePathCompletions.ts` (line 109) increments on every effect run and is compared at line 155. JavaScript Numbers are IEEE 754 doubles (safe integers up to 2^53). In practice the user would need to trigger ~9 quadrillion debounce firings before overflow. Not a real risk, documented here for completeness.
+
+---
+
+### Concurrent session search requests arriving at `ListSessions` during session creation
+
+`ListSessions` in `session_service.go` (line 364) reads from `reviewQueuePoller.GetInstances()`, which is the live in-memory instance list. If a session-search RPC fires while another request is adding a new session, the response may include the session before it is fully initialized (tmux session not yet started, worktree not yet created). A session search that navigates to such a session would navigate to a session with status "ready" that has no live terminal.
+
+Risk: Navigating to a partially-created session. Not a crash, but confusing UX.
+
+Mitigation: Session search results should filter for fully-started sessions (`instance.Started() == true`). The protobuf session `status` field should be used client-side to visually indicate sessions that are still initializing.
+
+---
+
+### Go filesystem walk performance: home directory traversal without recursion limit
+
+`os.ReadDir` on `~` returns 50–200 entries on a typical developer machine. The current code caps at `pathCompletionHardMax = 500` entries and applies a 2-second timeout. This is adequate for single-directory reads.
+
+Risk: If a user types `~/` and the home directory contains symlinked directories pointing to large trees (e.g., `~/node_modules` via a misconfigured symlink), the `os.Stat` call on each symlinked entry (line 136) multiplies syscall overhead. 200 entries × 1 `os.Stat` each = 200 extra stat calls per request.
+
+Mitigation: The current broken-symlink skip (line 138–141) already handles most cases. Add a per-entry stat timeout using a context passed through, or pre-filter entries to skip obviously non-repo directories (`.DS_Store`, `Library`, `Applications`).
+
+---
+
+### `usePathHistory.getMatching` does prefix matching only — not fuzzy
+
+The history matching in `Omnibar.tsx` (lines 107–118) calls `getMatching(completionPrefix)` which uses `e.path.startsWith(prefix)` (line 72 of `usePathHistory.ts`). This is purely a prefix filter, not fuzzy matching. If the user types `auth` hoping to find `~/projects/auth-service`, the history will not surface it because `~/projects/auth-service` does not start with `auth`.
+
+Risk: The "recent repos quick-pick" will only surface repos when the user types the beginning of the full path. Typing a repo name fragment will show no history matches even if the user has used that repo dozens of times.
+
+Mitigation: Replace the `startsWith` filter with a fuzzy match (same algorithm being added for session search). Score history entries by: fuzzy match quality × recency score × frequency count.
+
+---
+
+### Omnibar `dropdownDismissed` resets on any character change but not on mode transition
+
+In `Omnibar.tsx` line 399–401 (`onChange` of the main input), `setDropdownDismissed(false)` is called on every character change. However, the detection mode change (from `LocalPath` to session-search mode) is debounced by 150ms (line 174). During the debounce window, if `dropdownDismissed` has been set true (user pressed Escape to dismiss path completions) and the user then backspaces to a non-path string, the dropdown will remain dismissed until the next character change because the mode transition happens asynchronously.
+
+Risk: Minor: session results are suppressed for up to 150ms after Escape is pressed during mode switching.
+
+Mitigation: Reset `dropdownDismissed` when the detected `InputType` changes.
+
+---
+
+## P4: Low (edge case, nice to handle)
+
+### Path deduplication: same repo accessed via symlink and real path
+
+On macOS, `~/Documents` may be a symlink, and `/Users/tyler/Documents` is the real path. A user who accesses the same repo as both `~/projects/myrepo` and `/Users/tyler/projects/myrepo` will see two separate history entries in the recents list, and two separate "recent repo" suggestions.
+
+Risk: Minor duplicate clutter in recents.
+
+Mitigation: Run `filepath.EvalSymlinks` on each recent-repo path before storing and before comparison. Store only canonical (resolved) paths.
+
+---
+
+### Porter stemmer treats branch names and technical terms incorrectly
+
+The BM25 `Tokenizer.porterStem` (lines 168–195, `tokenizer.go`) was designed for English prose. Branch names and session titles like `fix-login-bug` stem to `["fix", "login", "bug"]`, `feature/add-oauth` stems to `["featur", "add", "oauth"]`. The stem `featur` will not match a query of `feat` because Porter does not stem abbreviations.
+
+Risk: Fuzzy session search built on top of BM25 tokenization would produce counter-intuitive non-matches. For example, `feat` does not match `feature/add-oauth` through the tokenizer path because `feat` → `feat` (no stem applied) and `featur` ≠ `feat`.
+
+Mitigation: Session search should bypass the BM25 tokenizer entirely. Use a character-level fuzzy matcher (e.g., fzf-style scoring) on the raw, lowercased session metadata fields, not on stemmed tokens.
+
+---
+
+### `GitHubShorthandDetector` priority 40 fires before session names that look like `org/repo`
+
+The shorthand detector pattern `^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)` (line 118, `detector.ts`) will match a session title like `frontend/auth-overhaul` if the user types it. This means typing a session name that contains a slash would trigger GitHub shorthand detection instead of session search, adding confusing visual feedback (GitHub icon) and blocking session navigation.
+
+Risk: Rare but confusing. Session titles with slashes are used in the category system (e.g., "Work/Frontend" becomes tags, but branch names like `feature/auth` appear in the input via `path@branch`).
+
+Mitigation: The session-search mode should run before (or be explicitly excluded from) shorthand detection. If the user is clearly searching for an existing session (matching against the live session list), the omnibar should show session results even if the input pattern matches a GitHub shorthand.
+
+---
+
+### `localStorage` quota exceeded in private/restrictive environments
+
+`usePathHistory.persistToStorage` (line 42–47, `usePathHistory.ts`) silently swallows `localStorage.setItem` errors with an empty catch. In Safari private browsing, `localStorage` throws a `QuotaExceededError` on every write. The history will appear to save but will not persist across opens.
+
+Risk: Silent failure means the recent repos feature appears to work during a session but resets on every omnibar open in private-mode browsers or locked-down environments.
+
+Mitigation: Already handled by the empty catch (graceful degradation). No change needed, but document the behavior as expected. Consider server-side recent-repos storage if this becomes a user complaint.
+
+---
+
+### `useWorktreeSuggestions` fires a git subprocess for every omnibar open where `sessionType === "existing_worktree"`
+
+`PathCompletionService.ListWorktrees` (line 170–192, `path_completion_service.go`) runs `exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain")` for every call. This is uncached. If the user opens the omnibar, switches to "existing_worktree" mode, and navigates away, a subprocess is spawned each time. Session search does not change this, but the omnibar refactor must not regress this behavior.
+
+Risk: No regression risk unless omnibar refactoring causes `useWorktreeSuggestions` to fire more frequently.
+
+Mitigation: Cache `git worktree list` output per repo path with a 10-second TTL, consistent with the proposed directory tree cache.
+
+---
+
+## Implementation Checklist
+
+- [ ] Add `InputType.SessionSearch` to `detector.ts` types and registry — all non-path, non-URL inputs must route to session search mode, not `Unknown`
+- [ ] Update `canSubmit` in `Omnibar.tsx` to exclude session-search mode from the submission gate (session results navigate, not create)
+- [ ] Implement separate keyboard routing for Enter: session result item → navigate; path completion item → accept; neither → submit form
+- [ ] Add server-side cache to `PathCompletionService` (keyed by baseDir + mtime + options) — required to hit <100ms repeated-open target
+- [ ] Session search must NOT use BM25 tokenizer — use character-level fuzzy matching on raw session metadata fields
+- [ ] Reset `dropdownDismissed` on `InputType` mode transition, not only on character change
+- [ ] Replace `startsWith` prefix matching in `usePathHistory.getMatching` with the same fuzzy algorithm used for session search
+- [ ] Validate recent-repo paths before display (skip paths that no longer exist on disk)
+- [ ] Add symlink loop protection to any recursive directory traversal in cache-warming code
+- [ ] Filter session-search results to fully-started sessions (`instance.Started() == true`) to avoid navigation to partially-initialized sessions
+- [ ] Lift ConnectRPC transport/client creation out of the `useEffect` in `usePathCompletions.ts` to module-level singleton to reduce connection overhead

--- a/project_plans/omni-bar-session-search/research/stack.md
+++ b/project_plans/omni-bar-session-search/research/stack.md
@@ -1,0 +1,248 @@
+# Research: Stack
+
+## Fuzzy Matching - Go Libraries
+
+### `github.com/sahilm/fuzzy`
+
+**Algorithm:** Ports the Sublime Text fuzzy match algorithm (forrestthewoods' reverse-engineering write-up). Scores results based on four weighted bonuses:
+- **First-character match** — pattern starts at position 0 of the target
+- **Consecutive adjacency bonus** — matched characters appear back-to-back in the target
+- **Word-boundary bonus** — matched character follows a separator (space, `/`, `-`, `_`)
+- **CamelCase bonus** — matched character is an uppercase letter preceded by lowercase
+
+**API:**
+```go
+// Simple slice of strings
+matches := fuzzy.Find("myfeat", []string{"my-feature-branch", "main", "fix-bug"})
+// Custom types via Source interface
+matches := fuzzy.FindFrom("squad", mySource)
+// Match.Str, Match.Index, Match.MatchedIndexes []int (for highlighting)
+```
+
+**Performance:** Benchmarked on ~16K files in 12.9ms, ~60K files in 30.9ms. For the session-search use case (tens to hundreds of sessions) this is negligible — sub-millisecond. Zero external dependencies (pure stdlib).
+
+**Assessment for this project:** This is the right choice. The consecutive-char bonus and word-boundary bonus are exactly what makes "myfeat" → "my-feature-branch" and "squad" → "stapler-squad" feel natural. Highlighted match positions (`.MatchedIndexes`) are a bonus for UI rendering.
+
+---
+
+### `github.com/lithammer/fuzzysearch`
+
+**Algorithm:** Fuzzy character-subsequence matching (all pattern chars must appear in order, not necessarily adjacent), scored by Levenshtein distance. Higher score = better match, -1 = no match.
+
+**API:**
+```go
+fuzzy.Match("myfeat", "my-feature-branch")  // bool
+fuzzy.RankMatch("myfeat", "my-feature-branch")  // int score, -1 if no match
+fuzzy.RankFind("query", []string{...})  // []Rank, sortable
+```
+
+**Scoring quality:** Levenshtein distance is a reasonable proxy for similarity but does not give bonuses for word boundaries or consecutive chars. "squad" matching "stapler-squad" relies purely on edit distance, so the ranking relative to other matches may be less intuitive than fzf-style.
+
+**Performance:** Described as "tiny and fast." No published benchmarks, but Levenshtein on short strings is O(mn) where m and n are string lengths — this is fast enough for a few hundred sessions.
+
+**Assessment:** Adequate for basic matching but produces noticeably worse ranking than sahilm/fuzzy for the "jump to existing session" use case. The lack of word-boundary and consecutive-char bonuses makes results feel random when multiple sessions share common substrings.
+
+---
+
+### `github.com/junegunn/fzf` (the CLI tool's internals)
+
+The fzf repository contains `src/algo` with the authoritative Smith-Waterman-like scoring used by the fzf CLI. However, this package is **not designed as a library** — it's an internal package of the CLI tool. Extracting it would require forking. `github.com/ktr0731/go-fuzzyfinder` wraps fzf-style TUI selection but does not expose public scoring functions.
+
+**Assessment:** Not directly usable as a library. Use `sahilm/fuzzy` instead, which is a clean reimplementation of the same scoring philosophy (Sublime Text algorithm, which is similar in spirit to fzf's Smith-Waterman approach).
+
+---
+
+### Recommendation (Go)
+
+**Use `github.com/sahilm/fuzzy`.** It is the only Go library surveyed that implements all three quality signals the requirements explicitly call out: consecutive-char bonus, word-boundary bonus, and match-position highlighting. It is zero-dependency, actively maintained, and performant far beyond what the session-count scale requires.
+
+Note: `github.com/agext/levenshtein` is already in `go.mod` as an indirect dependency, but it is a Levenshtein distance utility, not a multi-field fuzzy search API. It does not meet the scoring quality requirements.
+
+---
+
+## Fuzzy Matching - TypeScript Libraries
+
+### `fuse.js`
+
+**Algorithm:** Bitap algorithm (Shift-or/Shift-and), a classic approximate string matching algorithm. Returns scores from 0.0 (exact) to 1.0 (no match). Scoring is threshold-based — results with score above a configurable `threshold` are excluded.
+
+**Bundle size:** ~8 kB gzipped (full), ~6.5 kB gzipped (basic build). Zero dependencies.
+
+**Multi-field support:** First-class. The `keys` config accepts an array of field names with optional weights:
+```ts
+const fuse = new Fuse(sessions, {
+  keys: [
+    { name: "title", weight: 0.5 },
+    { name: "branch", weight: 0.3 },
+    { name: "path", weight: 0.1 },
+    { name: "tags", weight: 0.1 },
+  ],
+  includeScore: true,
+  threshold: 0.4,
+});
+```
+
+**TypeScript:** Full TypeScript types included. `fuse.search(query)` returns `Array<{ item, score, refIndex }>`.
+
+**Assessment:** The most capable option for multi-field weighted search. Bitap scoring is solid, though it does not give explicit consecutive-char or word-start bonuses the way fzf does. The threshold-based filter can cut legitimate matches if tuned poorly. Good fit for session search where multiple fields matter.
+
+---
+
+### `match-sorter`
+
+**Algorithm:** Seven-tier ranking (case-sensitive equals → case-insensitive equals → starts-with → word-starts-with → contains → acronym → simple match). Not a fuzzy-distance algorithm — it is a ranked filter.
+
+**Bundle size:** Not published in official docs, but the package is minimal (no runtime dependencies beyond `@babel/runtime`). Estimated ~3–4 kB gzipped.
+
+**Multi-field support:** Yes, via `keys` array with nested dot notation, array wildcards, and custom getter callbacks. Items matching across multiple keys get the best (lowest) rank from any of their fields.
+
+**Assessment:** Excellent for UX quality — the tier system ensures that "starts-with" results always appear above "contains" results. However, it is not true fuzzy matching: "myfeat" will not match "my-feature-branch" because none of the tiers handle non-contiguous character patterns. This makes it unsuitable as the sole matching strategy for the "≤3 keystrokes" requirement. It could be used as a post-filter or ranking layer on top of another algorithm.
+
+---
+
+### `fzf` npm package (`fzf-for-js`)
+
+**Package:** `fzf` on npm (https://github.com/ajitid/fzf-for-js), version 0.5.2 as of research date.
+
+**Algorithm:** A port of fzf's main algorithm to browser/Node context. Implements the same Smith-Waterman-like scoring with consecutive-char bonus and word-boundary bonus as the fzf CLI. This is the closest TypeScript equivalent to `sahilm/fuzzy` in Go.
+
+**Bundle size:** Not prominently documented. As a port of the fzf algorithm in pure TypeScript it should be small (estimated <10 kB), but no authoritative gzipped size found.
+
+**Multi-field support:** Not first-class. The fzf algorithm operates on a single string. Multi-field search requires building a composite string (e.g., `${title} ${branch} ${path} ${tags.join(' ')}`) or running multiple searches and merging.
+
+**Assessment:** Best single-field fuzzy quality (closest to fzf CLI feel). Not ideal for the multi-field weighted scoring needed for session search. Composite-string workaround is functional but loses per-field weight control.
+
+---
+
+### Recommendation (TypeScript)
+
+**Use `fuse.js`** for session search in the Omnibar. The multi-field weighted `keys` configuration is exactly what's needed to rank title matches above path matches above tag matches. The Bitap algorithm produces good enough fuzzy results for a session list. Bundle size (~8 kB gzip) is acceptable given the existing bundle is already 5 MB limit.
+
+For path completion filtering (which is single-field, operating on directory entry names), **`fzf-for-js`** would produce better feel (consecutive/word-boundary bonuses) if the current `strings.HasPrefix` filter is replaced. This is a separate decision from session search.
+
+Neither library is currently in `web-app/package.json` — both would be new additions.
+
+---
+
+## Client-side vs Server-side Session Search
+
+**Recommendation: Client-side only.**
+
+Sessions are already loaded into Redux state (`sessionsSlice`) via `useSessionService`. The `selectAllSessions` selector gives instant O(1) access to the full session list. A typical deployment has tens to low-hundreds of sessions — well within the range where JavaScript fuzzy matching on pre-loaded data is indistinguishable from instant.
+
+Factors that confirm client-side:
+1. **Data already in memory.** The Redux store holds the complete `Session[]`. There is no I/O cost.
+2. **Session count is bounded.** Even at 500 sessions, `fuse.js` Bitap runs in <1ms.
+3. **Latency budget.** The requirement is "reach any session in ≤3 keystrokes." A round-trip RPC (even on localhost) adds 5–20ms latency per keystroke. Client-side filtering is synchronous.
+4. **No new proto/service needed.** Adding a `SearchSessions` RPC endpoint would require proto changes, code generation, server implementation, and transport — all for a problem that JavaScript solves in 10 lines.
+5. **Offline/reconnect resilience.** Client-side filtering works during brief WebSocket reconnects; server search would degrade.
+
+**The existing BM25 `SearchEngine` in `session/search/` is irrelevant for this use case.** It indexes Claude conversation message history (full-text search within chat), not session metadata. Session search (by title, branch, path, tags) is a different problem entirely and should remain client-side.
+
+---
+
+## Directory Tree Caching Patterns
+
+Four patterns are viable for caching `os.ReadDir` results in Go:
+
+### Pattern 1: In-memory map with mtime check (recommended)
+
+```go
+type dirCacheEntry struct {
+    entries []os.DirEntry
+    mtime   time.Time
+    cachedAt time.Time
+}
+var cache sync.Map // key: string (baseDir), value: *dirCacheEntry
+```
+
+On each call: `os.Stat(baseDir)` to get mtime. If mtime matches cached entry, return cache hit. If mtime changed or entry missing, call `os.ReadDir` and store new entry.
+
+**Pros:** Correct invalidation (mtime changes when directory contents change). No background goroutine needed. Low memory overhead (only entries requested by users).
+**Cons:** `os.Stat` on every call, but `os.Stat` is a single syscall (~1µs) — acceptable overhead for a 100ms cold / <100ms warm target. Race between stat and readdir is negligible for the UX use case.
+
+### Pattern 2: TTL-based expiry (simpler, slightly less correct)
+
+Cache entries expire after a fixed TTL (e.g., 30s). No mtime check.
+
+**Pros:** Simpler code. Works for the UX case where "eventual consistency" within 30s is fine.
+**Cons:** Stale results between directory change and TTL expiry. For the "recent repos" use case this is mostly fine, but a user who just created a new directory would see it missing until TTL expires.
+
+This is exactly what `usePathCompletions.ts` already does on the client side (30s TTL LRU). Adding the same pattern server-side doubles the protection.
+
+### Pattern 3: `sync.RWMutex` map vs `sync.Map`
+
+`sync.Map` is optimized for read-heavy workloads with infrequent writes — which is the directory cache profile exactly (many reads, rare writes). Use `sync.Map` over a custom `RWMutex` map unless profiling shows contention.
+
+### Pattern 4: Disk-backed JSON
+
+Persist the cache to `~/.stapler-squad/dir_cache.json` on writes, load on startup. Survives server restarts.
+
+**Assessment:** Complexity is high for marginal gain. The cold-start cost (first open after restart) is already budgeted at <500ms in the requirements. A disk-backed cache would only matter if the <500ms cold target is being violated in practice.
+
+### Recommendation
+
+**Pattern 1 (mtime-keyed in-memory sync.Map) as the primary cache, with Pattern 2 (TTL) as a safety fallback.** Specifically:
+
+- Key: `baseDir` (absolute path after tilde expansion)
+- Invalidation: compare `os.Stat(baseDir).ModTime()` against cached mtime
+- Fallback TTL: 60s (to handle cases where mtime isn't updated, e.g., network filesystems)
+- Max cache size: 200 entries (covers typical home directory tree traversal depth)
+- No disk persistence initially — implement only if cold-start timing fails the <500ms requirement
+
+---
+
+## Existing `path_completion_service.go` Analysis
+
+### Current approach
+
+`PathCompletionService` is **stateless** by design (the struct comment says so explicitly). Every RPC call:
+
+1. Expands `~` in the path prefix (`expandTilde`)
+2. Calls `os.Stat(expanded)` to check if the full path exists as a directory
+3. Calls `splitPathPrefix(expanded)` to separate `baseDir` and `filterPrefix`
+4. Calls `os.Stat(baseDir)` to check if the base directory exists
+5. Spawns a goroutine to call `os.ReadDir(baseDir)` with a 2s timeout via channel
+6. Filters entries: skip hidden unless filter starts with `.`, skip non-matching prefixes, skip non-directories if `directoriesOnly=true`, follow symlinks
+7. Returns up to `maxResults` (default 100, hard max 500) entries
+
+The service also has a `ListWorktrees` method that runs `git worktree list --porcelain` via `exec.CommandContext` — this is also uncached.
+
+### Where a cache slots in
+
+The cache should be inserted at step 5 — wrapping the `os.ReadDir(baseDir)` call:
+
+```
+Before step 5: check cache[baseDir]
+  Cache hit (mtime unchanged): skip goroutine + ReadDir, use cached entries
+  Cache miss / mtime changed: proceed with ReadDir goroutine, store result in cache
+
+After ReadDir returns: store entries + mtime in cache
+```
+
+The struct must become stateful to hold the cache:
+
+```go
+type PathCompletionService struct {
+    cache sync.Map  // map[string]*dirCacheEntry
+}
+```
+
+Steps 6 (filtering) and 7 (pagination) still run on every request — they are cheap CPU operations on the cached entries, and the filter depends on the user's input which changes per-call.
+
+The `ListWorktrees` method (`git worktree list --porcelain`) is a separate caching candidate. It runs a subprocess, which is expensive (~50ms). A cache keyed on `repoPath + worktree list mtime` (or simply a short TTL cache on `repoPath`) would eliminate redundant subprocess invocations. This is lower priority than the directory listing cache since worktree listing is called once per repo path selection, not on every keystroke.
+
+**Key implementation note:** The `NewPathCompletionService()` constructor currently takes no arguments. After adding the cache field, the constructor signature stays the same (`sync.Map` zero value is ready to use). No change needed to callers.
+
+---
+
+## Recommendations Summary
+
+| Decision | Recommendation | Rationale |
+|---|---|---|
+| Go fuzzy library | `github.com/sahilm/fuzzy` | Only Go library with consecutive-char + word-boundary bonuses; zero deps; sub-ms for hundreds of items |
+| TypeScript fuzzy library | `fuse.js` | Best multi-field weighted scoring; 8kB gzip; first-class TypeScript types |
+| Session search location | Client-side only (no RPC) | Sessions already in Redux state; 0 round-trip; synchronous; no proto changes needed |
+| Directory cache strategy | In-memory `sync.Map`, mtime-keyed, 60s TTL fallback | Correct invalidation, low complexity, no background goroutines |
+| Cache insertion point | Wrap `os.ReadDir(baseDir)` in `ListPathCompletions` | `PathCompletionService` becomes stateful; constructor unchanged; filtering still per-request |
+| `ListWorktrees` cache | Short TTL (5–10s) keyed on `repoPath` | Subprocess is expensive; worktree lists change rarely |

--- a/server/services/dir_cache.go
+++ b/server/services/dir_cache.go
@@ -1,0 +1,122 @@
+// Package services provides the server-side service implementations.
+package services
+
+import (
+	"os"
+	"sync"
+	"time"
+)
+
+type dirCacheEntry struct {
+	entries  []os.DirEntry
+	dirMtime time.Time
+	cachedAt time.Time
+}
+
+// DirCache is a thread-safe, mtime+TTL-invalidated cache of os.DirEntry slices
+// keyed by directory path. It is intended to reduce repeated os.ReadDir calls for
+// the same directory within a short window (e.g., repeated Omnibar opens).
+//
+// Invalidation policy:
+//   - An entry is stale if time.Since(cachedAt) > ttl.
+//   - An entry is stale if the directory's mtime has advanced since the entry was stored.
+//   - Eviction is LRU by insertion order: when len(entries) >= maxSize, the oldest
+//     entry (earliest cachedAt) is removed before storing a new one.
+//
+// No background goroutines are used; all operations are on-demand.
+type DirCache struct {
+	mu      sync.RWMutex
+	entries map[string]*dirCacheEntry
+	maxSize int
+	ttl     time.Duration
+}
+
+// NewDirCache creates a DirCache with the given capacity and TTL.
+func NewDirCache(maxSize int, ttl time.Duration) *DirCache {
+	return &DirCache{
+		entries: make(map[string]*dirCacheEntry, maxSize),
+		maxSize: maxSize,
+		ttl:     ttl,
+	}
+}
+
+// Get returns the cached DirEntry slice for path if the entry is still valid.
+//
+// Validity requires both:
+//  1. time.Since(entry.cachedAt) <= c.ttl  (TTL not expired)
+//  2. os.Stat(path).ModTime() == entry.dirMtime  (directory unchanged)
+//
+// Returns (nil, false) on any miss: entry absent, TTL expired, or mtime changed.
+// A stale-mtime entry is removed from the cache under a write lock so the next
+// Put does not exceed maxSize unnecessarily.
+func (c *DirCache) Get(path string) ([]os.DirEntry, bool) {
+	// Fast path: read lock.
+	c.mu.RLock()
+	entry, ok := c.entries[path]
+	c.mu.RUnlock()
+
+	if !ok {
+		return nil, false
+	}
+
+	// TTL check — no lock needed; cachedAt is immutable after Put.
+	if time.Since(entry.cachedAt) > c.ttl {
+		// Evict the stale entry so it doesn't occupy a slot until the next Put.
+		c.mu.Lock()
+		delete(c.entries, path)
+		c.mu.Unlock()
+		return nil, false
+	}
+
+	// Mtime check: one stat call per Get, cheap on local filesystems.
+	info, err := os.Stat(path)
+	if err != nil {
+		// Path no longer accessible; treat as miss.
+		return nil, false
+	}
+	if info.ModTime().After(entry.dirMtime) {
+		// Directory has changed; evict the stale entry.
+		c.mu.Lock()
+		delete(c.entries, path)
+		c.mu.Unlock()
+		return nil, false
+	}
+
+	return entry.entries, true
+}
+
+// Put stores entries for path with the provided dirMtime.
+// If the cache is at capacity, the entry with the oldest cachedAt is evicted first.
+func (c *DirCache) Put(path string, entries []os.DirEntry, dirMtime time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.entries) >= c.maxSize {
+		c.evictOldest()
+	}
+
+	c.entries[path] = &dirCacheEntry{
+		entries:  entries,
+		dirMtime: dirMtime,
+		cachedAt: time.Now(),
+	}
+}
+
+// evictOldest removes the entry with the smallest cachedAt timestamp.
+// Caller must hold the write lock.
+// O(n) scan is acceptable for the small cache sizes used in practice (n ≤ 256).
+func (c *DirCache) evictOldest() {
+	var oldestKey string
+	var oldestTime time.Time
+
+	for k, e := range c.entries {
+		if oldestKey == "" || e.cachedAt.Before(oldestTime) {
+			oldestKey = k
+			oldestTime = e.cachedAt
+		}
+	}
+
+	if oldestKey != "" {
+		delete(c.entries, oldestKey)
+	}
+}

--- a/server/services/dir_cache_test.go
+++ b/server/services/dir_cache_test.go
@@ -1,0 +1,293 @@
+package services
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	sessionv1 "github.com/tstapler/stapler-squad/gen/proto/go/session/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newReqCtx returns a background context for use in test RPC calls.
+func newReqCtx(_ *testing.T) context.Context {
+	return context.Background()
+}
+
+// entryNames extracts the Name field from a slice of PathEntry protos.
+func entryNames(entries []*sessionv1.PathEntry) []string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+	return names
+}
+
+// TestDirCache_Hit verifies that a Put followed by an immediate Get returns
+// the same entries without performing a second disk read.
+func TestDirCache_Hit(t *testing.T) {
+	dir := t.TempDir()
+	makeFile(t, filepath.Join(dir, "a.txt"))
+	makeFile(t, filepath.Join(dir, "b.txt"))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+
+	cache := NewDirCache(16, 60*time.Second)
+	cache.Put(dir, entries, info.ModTime())
+
+	got, ok := cache.Get(dir)
+	assert.True(t, ok, "expected cache hit")
+	assert.Equal(t, entries, got, "expected same slice from cache")
+}
+
+// TestDirCache_MissOnMtimeChange verifies that after a directory is modified
+// (which advances its mtime), Get returns a miss and removes the stale entry.
+func TestDirCache_MissOnMtimeChange(t *testing.T) {
+	dir := t.TempDir()
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	cache := NewDirCache(16, 60*time.Second)
+	cache.Put(dir, entries, info.ModTime())
+
+	// Modify the directory by creating a new file.
+	// On most filesystems this advances the directory's mtime.
+	makeFile(t, filepath.Join(dir, "newfile.txt"))
+
+	got, ok := cache.Get(dir)
+	assert.False(t, ok, "expected cache miss after directory was modified")
+	assert.Nil(t, got)
+
+	// Verify the stale entry was evicted.
+	cache.mu.RLock()
+	_, stillPresent := cache.entries[dir]
+	cache.mu.RUnlock()
+	assert.False(t, stillPresent, "stale entry should have been removed from cache")
+}
+
+// TestDirCache_MissOnTTLExpiry verifies that an entry is not returned after the TTL
+// has elapsed, even if the directory has not changed.
+func TestDirCache_MissOnTTLExpiry(t *testing.T) {
+	dir := t.TempDir()
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	// 1 ms TTL so it expires almost immediately.
+	cache := NewDirCache(16, 1*time.Millisecond)
+	cache.Put(dir, entries, info.ModTime())
+
+	// Wait long enough for the TTL to expire.
+	time.Sleep(5 * time.Millisecond)
+
+	got, ok := cache.Get(dir)
+	assert.False(t, ok, "expected cache miss after TTL expiry")
+	assert.Nil(t, got)
+}
+
+// TestDirCache_NoEvictionBelowMax verifies that no eviction occurs when the cache
+// has fewer entries than maxSize.
+func TestDirCache_NoEvictionBelowMax(t *testing.T) {
+	const maxSize = 4
+	cache := NewDirCache(maxSize, 60*time.Second)
+
+	root := t.TempDir()
+	for i := 0; i < maxSize-1; i++ {
+		dir := filepath.Join(root, string(rune('a'+i)))
+		makeDir(t, dir)
+
+		info, err := os.Stat(dir)
+		require.NoError(t, err)
+		cache.Put(dir, nil, info.ModTime())
+	}
+
+	cache.mu.RLock()
+	n := len(cache.entries)
+	cache.mu.RUnlock()
+
+	assert.Equal(t, maxSize-1, n, "no eviction expected below maxSize")
+}
+
+// TestDirCache_EvictsOldestAtMax verifies that adding an entry when the cache is at
+// capacity evicts the entry with the oldest cachedAt, keeping len(entries) == maxSize.
+func TestDirCache_EvictsOldestAtMax(t *testing.T) {
+	const maxSize = 3
+	cache := NewDirCache(maxSize, 60*time.Second)
+
+	root := t.TempDir()
+
+	// Create maxSize directories and insert them in order, each with a distinct
+	// cachedAt. We manipulate cachedAt directly so the test is deterministic.
+	dirs := make([]string, maxSize)
+	for i := 0; i < maxSize; i++ {
+		d := filepath.Join(root, string(rune('a'+i)))
+		makeDir(t, d)
+		dirs[i] = d
+
+		info, err := os.Stat(d)
+		require.NoError(t, err)
+
+		cache.mu.Lock()
+		if len(cache.entries) >= cache.maxSize {
+			cache.evictOldest()
+		}
+		cache.entries[d] = &dirCacheEntry{
+			entries:  nil,
+			dirMtime: info.ModTime(),
+			// stagger cachedAt so "a" is oldest, "b" is middle, "c" is newest
+			cachedAt: time.Now().Add(time.Duration(i) * time.Millisecond),
+		}
+		cache.mu.Unlock()
+	}
+
+	// Cache is now at maxSize. Adding one more entry should evict "a" (oldest).
+	extraDir := filepath.Join(root, "extra")
+	makeDir(t, extraDir)
+
+	extraInfo, err := os.Stat(extraDir)
+	require.NoError(t, err)
+	cache.Put(extraDir, nil, extraInfo.ModTime())
+
+	cache.mu.RLock()
+	_, aPresent := cache.entries[dirs[0]] // "a" — oldest, should be evicted
+	totalLen := len(cache.entries)
+	cache.mu.RUnlock()
+
+	assert.Equal(t, maxSize, totalLen, "cache size should remain at maxSize after eviction")
+	assert.False(t, aPresent, "oldest entry should have been evicted")
+}
+
+// TestDirCache_ConcurrentReads verifies that many simultaneous Get calls after a Put
+// do not cause data races. Run with: go test -race ./server/services/...
+func TestDirCache_ConcurrentReads(t *testing.T) {
+	dir := t.TempDir()
+	makeFile(t, filepath.Join(dir, "file.txt"))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+
+	cache := NewDirCache(16, 60*time.Second)
+	cache.Put(dir, entries, info.ModTime())
+
+	const workers = 100
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			got, ok := cache.Get(dir)
+			// Either a hit or a miss is fine; no panic or race is the requirement.
+			if ok {
+				assert.NotNil(t, got)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestDirCache_NonexistentDir verifies that Get for a path that does not exist returns
+// a miss and does not store anything in the cache.
+func TestDirCache_NonexistentDir(t *testing.T) {
+	cache := NewDirCache(16, 60*time.Second)
+
+	got, ok := cache.Get("/does/not/exist/anywhere")
+	assert.False(t, ok)
+	assert.Nil(t, got)
+
+	cache.mu.RLock()
+	n := len(cache.entries)
+	cache.mu.RUnlock()
+	assert.Equal(t, 0, n, "Get on nonexistent path should not populate cache")
+}
+
+// TestListPathCompletions_CacheHit verifies that calling ListPathCompletions twice
+// for the same directory returns identical entries and exercises the cache hit path
+// (indirectly: the second call completes without error and returns consistent results).
+func TestListPathCompletions_CacheHit(t *testing.T) {
+	dir := t.TempDir()
+	makeDir(t, filepath.Join(dir, "alpha"))
+	makeFile(t, filepath.Join(dir, "beta.txt"))
+
+	svc := NewPathCompletionService()
+
+	resp1, err := svc.ListPathCompletions(newReqCtx(t), newReq(&sessionv1.ListPathCompletionsRequest{
+		PathPrefix: dir + "/",
+	}))
+	require.NoError(t, err)
+	require.True(t, resp1.Msg.BaseDirExists)
+
+	names1 := entryNames(resp1.Msg.Entries)
+
+	svc.cache.mu.RLock()
+	entry1, inCache := svc.cache.entries[dir]
+	svc.cache.mu.RUnlock()
+	require.True(t, inCache, "entry should be in cache after first call")
+	cachedAtFirst := entry1.cachedAt
+
+	resp2, err := svc.ListPathCompletions(newReqCtx(t), newReq(&sessionv1.ListPathCompletionsRequest{
+		PathPrefix: dir + "/",
+	}))
+	require.NoError(t, err)
+	require.True(t, resp2.Msg.BaseDirExists)
+
+	names2 := entryNames(resp2.Msg.Entries)
+
+	svc.cache.mu.RLock()
+	entry2, stillInCache := svc.cache.entries[dir]
+	svc.cache.mu.RUnlock()
+	require.True(t, stillInCache, "entry should still be in cache after second call")
+	assert.Equal(t, cachedAtFirst, entry2.cachedAt, "second call must use cache hit - cachedAt must not change")
+
+	assert.Equal(t, names1, names2, "second call should return same entries as first (cache hit)")
+}
+
+// TestListPathCompletions_CacheMissAfterMtimeChange verifies that if the directory
+// changes between two ListPathCompletions calls, the second call returns the updated
+// contents (cache miss due to mtime change).
+func TestListPathCompletions_CacheMissAfterMtimeChange(t *testing.T) {
+	dir := t.TempDir()
+	makeDir(t, filepath.Join(dir, "alpha"))
+
+	svc := NewPathCompletionService()
+
+	resp1, err := svc.ListPathCompletions(newReqCtx(t), newReq(&sessionv1.ListPathCompletionsRequest{
+		PathPrefix: dir + "/",
+	}))
+	require.NoError(t, err)
+	names1 := entryNames(resp1.Msg.Entries)
+	assert.Contains(t, names1, "alpha")
+	assert.NotContains(t, names1, "beta")
+
+	// Modify the directory after the first call.
+	makeDir(t, filepath.Join(dir, "beta"))
+
+	resp2, err := svc.ListPathCompletions(newReqCtx(t), newReq(&sessionv1.ListPathCompletionsRequest{
+		PathPrefix: dir + "/",
+	}))
+	require.NoError(t, err)
+	names2 := entryNames(resp2.Msg.Entries)
+
+	assert.Contains(t, names2, "alpha", "original entry should still be present")
+	assert.Contains(t, names2, "beta", "new entry should appear after cache miss")
+}

--- a/server/services/path_completion_service.go
+++ b/server/services/path_completion_service.go
@@ -19,15 +19,21 @@ const (
 	pathCompletionDefaultMax = 100
 	pathCompletionHardMax    = 500
 	pathCompletionTimeout    = 2 * time.Second
+	dirCacheMaxSize          = 256
+	dirCacheTTL              = 60 * time.Second
 )
 
 // PathCompletionService handles RPC methods for filesystem path completion.
-// It is stateless; each call performs a fresh directory listing.
-type PathCompletionService struct{}
+// It caches directory listings in a DirCache to avoid repeated os.ReadDir calls.
+type PathCompletionService struct {
+	cache *DirCache
+}
 
-// NewPathCompletionService creates a PathCompletionService.
+// NewPathCompletionService creates a PathCompletionService with a DirCache.
 func NewPathCompletionService() *PathCompletionService {
-	return &PathCompletionService{}
+	return &PathCompletionService{
+		cache: NewDirCache(dirCacheMaxSize, dirCacheTTL),
+	}
 }
 
 // ListPathCompletions returns filesystem entries matching the given path prefix.
@@ -75,40 +81,49 @@ func (p *PathCompletionService) ListPathCompletions(
 		}), nil
 	}
 
-	// Read the directory with a timeout to guard against slow/network filesystems.
-	type dirResult struct {
-		entries []os.DirEntry
-		err     error
-	}
-	resultCh := make(chan dirResult, 1)
+	// Capture directory mtime from the already-computed baseDirInfo for cache keying.
+	dirMtime := baseDirInfo.ModTime()
 
-	listCtx, cancel := context.WithTimeout(ctx, pathCompletionTimeout)
-	defer cancel()
-
-	go func() {
-		entries, readErr := os.ReadDir(baseDir)
-		resultCh <- dirResult{entries: entries, err: readErr}
-	}()
-
+	// Check the cache before hitting the filesystem.
 	var dirEntries []os.DirEntry
-	select {
-	case result := <-resultCh:
-		if result.err != nil {
-			if os.IsPermission(result.err) {
-				return nil, connect.NewError(connect.CodePermissionDenied, result.err)
-			}
-			if os.IsNotExist(result.err) {
-				return connect.NewResponse(&sessionv1.ListPathCompletionsResponse{
-					BaseDir:       baseDir,
-					BaseDirExists: false,
-					PathExists:    pathExists,
-				}), nil
-			}
-			return nil, connect.NewError(connect.CodeInternal, result.err)
+	if cached, ok := p.cache.Get(baseDir); ok {
+		dirEntries = cached
+	} else {
+		// Cache miss: read the directory with a timeout to guard against slow/network filesystems.
+		type dirResult struct {
+			entries []os.DirEntry
+			err     error
 		}
-		dirEntries = result.entries
-	case <-listCtx.Done():
-		return nil, connect.NewError(connect.CodeDeadlineExceeded, fmt.Errorf("directory listing timed out"))
+		resultCh := make(chan dirResult, 1)
+
+		listCtx, cancel := context.WithTimeout(ctx, pathCompletionTimeout)
+		defer cancel()
+
+		go func() {
+			entries, readErr := os.ReadDir(baseDir)
+			resultCh <- dirResult{entries: entries, err: readErr}
+		}()
+
+		select {
+		case result := <-resultCh:
+			if result.err != nil {
+				if os.IsPermission(result.err) {
+					return nil, connect.NewError(connect.CodePermissionDenied, result.err)
+				}
+				if os.IsNotExist(result.err) {
+					return connect.NewResponse(&sessionv1.ListPathCompletionsResponse{
+						BaseDir:       baseDir,
+						BaseDirExists: false,
+						PathExists:    pathExists,
+					}), nil
+				}
+				return nil, connect.NewError(connect.CodeInternal, result.err)
+			}
+			dirEntries = result.entries
+			p.cache.Put(baseDir, dirEntries, dirMtime)
+		case <-listCtx.Done():
+			return nil, connect.NewError(connect.CodeDeadlineExceeded, fmt.Errorf("directory listing timed out"))
+		}
 	}
 
 	// Filter entries and build the response.

--- a/session/detection/ratelimit/detector_test.go
+++ b/session/detection/ratelimit/detector_test.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -170,9 +171,9 @@ func TestScheduler_ScheduleRecovery(t *testing.T) {
 	scheduler := NewScheduler("test-session")
 	scheduler.SetBuffer(1)
 
-	var executed bool
+	var executed atomic.Bool
 	scheduler.SetRecoveryCallback(func() error {
-		executed = true
+		executed.Store(true)
 		return nil
 	})
 
@@ -185,7 +186,7 @@ func TestScheduler_ScheduleRecovery(t *testing.T) {
 
 	time.Sleep(1500 * time.Millisecond)
 
-	if !executed {
+	if !executed.Load() {
 		t.Error("expected recovery callback to be executed")
 	}
 }
@@ -193,9 +194,9 @@ func TestScheduler_ScheduleRecovery(t *testing.T) {
 func TestScheduler_CancelRecovery(t *testing.T) {
 	scheduler := NewScheduler("test-session")
 
-	var executed bool
+	var executed atomic.Bool
 	scheduler.SetRecoveryCallback(func() error {
-		executed = true
+		executed.Store(true)
 		return nil
 	})
 
@@ -206,7 +207,7 @@ func TestScheduler_CancelRecovery(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	if executed {
+	if executed.Load() {
 		t.Error("expected recovery callback to NOT be executed after cancel")
 	}
 }

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -35,6 +35,7 @@
         "@xterm/xterm": "^6.0.0",
         "ansi-to-html": "^0.7.2",
         "codemirror": "^6.0.2",
+        "fuse.js": "^7.3.0",
         "it-ws": "^6.1.5",
         "lzma-js": "^1.0.1",
         "next": "15.3.2",
@@ -7016,6 +7017,18 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/generator-function": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -49,6 +49,7 @@
     "@xterm/xterm": "^6.0.0",
     "ansi-to-html": "^0.7.2",
     "codemirror": "^6.0.2",
+    "fuse.js": "^7.3.0",
     "it-ws": "^6.1.5",
     "lzma-js": "^1.0.1",
     "next": "15.3.2",

--- a/web-app/src/components/sessions/Omnibar.tsx
+++ b/web-app/src/components/sessions/Omnibar.tsx
@@ -1,18 +1,25 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import Fuse from "fuse.js";
 import { detect, InputType, INPUT_TYPE_INFO, DetectionResult } from "@/lib/omnibar";
 import { PROGRAMS } from "@/lib/constants/programs";
 import { usePathCompletions } from "@/lib/hooks/usePathCompletions";
 import { usePathHistory } from "@/lib/hooks/usePathHistory";
 import { useWorktreeSuggestions } from "@/lib/hooks/useWorktreeSuggestions";
+import { useSessionSearch, type SessionSearchResult } from "@/lib/hooks/useSessionSearch";
+import { useAppSelector } from "@/lib/store";
+import { selectAllSessions } from "@/lib/store/sessionsSlice";
+import { Session, SessionStatus } from "@/gen/session/v1/types_pb";
 import { PathCompletionDropdown, type CompletionEntry } from "./PathCompletionDropdown";
+import { OmnibarResultList, getResultListItemCount, getHighlightedItemId } from "./OmnibarResultList";
 import styles from "./Omnibar.module.css";
 
 interface OmnibarProps {
   isOpen: boolean;
   onClose: () => void;
   onCreateSession: (data: OmnibarSessionData) => Promise<void>;
+  onNavigateToSession: (sessionId: string) => void;
 }
 
 export interface OmnibarSessionData {
@@ -33,7 +40,11 @@ export interface OmnibarSessionData {
   workingDir?: string;
 }
 
-export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
+type OmnibarMode = "discovery" | "creation";
+
+const RESULT_LISTBOX_ID = "omnibar-result-listbox";
+
+export function Omnibar({ isOpen, onClose, onCreateSession, onNavigateToSession }: OmnibarProps) {
   // Input state
   const [input, setInput] = useState("");
   const [detection, setDetection] = useState<DetectionResult | null>(null);
@@ -60,10 +71,18 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
   const [dropdownIndex, setDropdownIndex] = useState(-1);
   const [dropdownDismissed, setDropdownDismissed] = useState(false);
 
+  // Two-phase mode state
+  const [mode, setMode] = useState<OmnibarMode>("discovery");
+  const [resultHighlightIndex, setResultHighlightIndex] = useState(-1);
+
   // Refs
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const lastSuggestedNameRef = useRef<string>("");
+  const prevDetectionTypeRef = useRef<string | null>(null);
+  // Stable ref so handleKeyDown can always call the latest handleSubmit without
+  // a circular declaration-order dependency (handleKeyDown is declared before handleSubmit).
+  const handleSubmitRef = useRef<() => void>(() => {});
 
   // Determine whether completions should be active.
   const isPathInput =
@@ -84,7 +103,7 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
     directoriesOnly: true,
   });
 
-  const { getMatching: getHistoryMatching, save: saveHistory } = usePathHistory();
+  const { getMatching: getHistoryMatching, getAll: getAllHistory, save: saveHistory } = usePathHistory();
 
   // Worktree suggestions for the "Use Existing Worktree" mode
   const repoPathForWorktrees = isPathInput ? (detection?.localPath ?? "") : "";
@@ -130,6 +149,63 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
   const isDropdownVisible =
     isPathInput && mergedEntries.length > 0 && !dropdownDismissed;
 
+  // Discovery mode hooks
+  const isDiscoveryMode = mode === "discovery";
+
+  // Compute session search query without waiting for the 150ms detection debounce.
+  // Bare text (no path/URL/github prefix) passes to Fuse immediately for zero-lag search.
+  const sessionSearchQuery = useMemo(() => {
+    if (!input.trim()) return "";
+    if (detection?.type === InputType.SessionSearch) return input;
+    // Eagerly treat as session search if input doesn't look like a path or URL
+    if (!input.startsWith("/") && !input.startsWith("~") && !input.startsWith("http")) {
+      return input;
+    }
+    return "";
+  }, [input, detection]);
+  const sessionResults = useSessionSearch(sessionSearchQuery);
+
+  const allRepoEntries = useMemo(() => getAllHistory(50), [getAllHistory]);
+  const repoFuse = useMemo(
+    () =>
+      new Fuse(allRepoEntries, {
+        keys: [{ name: "path", weight: 1.0 }],
+        threshold: 0.4,
+        ignoreLocation: true,
+        minMatchCharLength: 1,
+      }),
+    [allRepoEntries]
+  );
+
+  const allSessions = useAppSelector(selectAllSessions);
+
+  const displayedSessionResults = useMemo((): SessionSearchResult[] => {
+    if (!input.trim()) {
+      const active = allSessions
+        .filter((s) => s.status !== SessionStatus.UNSPECIFIED)
+        .sort((a, b) => {
+          const aTime = Number(a.updatedAt?.seconds ?? 0);
+          const bTime = Number(b.updatedAt?.seconds ?? 0);
+          return bTime - aTime;
+        })
+        .slice(0, 5);
+      return active.map((s) => ({ session: s, score: 0, matchedFields: [] }));
+    }
+    return sessionResults;
+  }, [input, sessionResults, allSessions]);
+
+  const displayedRepoEntries = useMemo(() => {
+    if (!input.trim()) {
+      return allRepoEntries.slice(0, 5);
+    }
+    return repoFuse.search(input).map((r) => r.item).slice(0, 8);
+  }, [input, allRepoEntries, repoFuse]);
+
+  const totalResultCount = getResultListItemCount(
+    displayedSessionResults.length,
+    displayedRepoEntries.length
+  );
+
   // Accept a completion entry: fill the input and continue for further completion.
   const handleCompletionSelect = useCallback(
     (entry: CompletionEntry) => {
@@ -153,6 +229,29 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
         const result = detect(input);
         setDetection(result);
 
+        // Reset dropdown dismissed state when input type changes modes.
+        // Prevents session results from being suppressed after user dismisses
+        // path completion dropdown then backspaces to bare text.
+        if (result.type !== prevDetectionTypeRef.current) {
+          setDropdownDismissed(false);
+        }
+        prevDetectionTypeRef.current = result.type;
+
+        // Update mode based on detection type
+        if (
+          result.type === InputType.LocalPath ||
+          result.type === InputType.PathWithBranch ||
+          result.type === InputType.GitHubPR ||
+          result.type === InputType.GitHubBranch ||
+          result.type === InputType.GitHubRepo ||
+          result.type === InputType.GitHubShorthand
+        ) {
+          setMode("creation");
+        } else if (result.type === InputType.SessionSearch) {
+          setMode("discovery");
+          setResultHighlightIndex(-1);
+        }
+
         // Auto-fill session name if:
         // 1. Session name is empty, OR
         // 2. Session name matches the last auto-suggested name (not manually edited)
@@ -170,6 +269,8 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
         }
       } else {
         setDetection(null);
+        setMode("discovery");
+        setResultHighlightIndex(-1);
       }
     }, 150); // 150ms debounce
 
@@ -204,14 +305,78 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
       setExistingWorktree("");
       setWorkingDir("");
       lastSuggestedNameRef.current = "";
+      prevDetectionTypeRef.current = null;
       setDropdownIndex(-1);
       setDropdownDismissed(false);
+      setMode("discovery");
+      setResultHighlightIndex(-1);
     }
   }, [isOpen]);
+
+  // Session result selection handlers
+  const handleSessionSelect = useCallback(
+    (session: Session) => {
+      onNavigateToSession(session.id);
+      onClose();
+    },
+    [onNavigateToSession, onClose]
+  );
+
+  const handleRepoSelect = useCallback(
+    (path: string) => {
+      setInput(path + "/");
+      setMode("creation");
+      setResultHighlightIndex(-1);
+      setDropdownDismissed(false);
+      inputRef.current?.focus();
+    },
+    []
+  );
+
+  const dispatchHighlightedResultAction = useCallback(
+    (index: number) => {
+      if (index < displayedSessionResults.length) {
+        handleSessionSelect(displayedSessionResults[index].session);
+      } else {
+        const repoIndex = index - displayedSessionResults.length;
+        if (repoIndex < displayedRepoEntries.length) {
+          handleRepoSelect(displayedRepoEntries[repoIndex].path);
+        } else {
+          setMode("creation");
+          setResultHighlightIndex(-1);
+        }
+      }
+    },
+    [displayedSessionResults, displayedRepoEntries, handleSessionSelect, handleRepoSelect]
+  );
 
   // Handle keyboard shortcuts
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // Discovery mode navigation (before dropdown check)
+      if (isDiscoveryMode && (resultHighlightIndex >= 0 || e.key === "ArrowDown")) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setResultHighlightIndex((i) => Math.min(i + 1, totalResultCount - 1));
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setResultHighlightIndex((i) => Math.max(i - 1, -1));
+          return;
+        }
+        if (e.key === "Enter" && !e.metaKey && resultHighlightIndex >= 0) {
+          e.preventDefault();
+          dispatchHighlightedResultAction(resultHighlightIndex);
+          return;
+        }
+        if (e.key === "Escape" && resultHighlightIndex >= 0) {
+          e.nativeEvent.stopImmediatePropagation();
+          setResultHighlightIndex(-1);
+          return;
+        }
+      }
+
       if (isDropdownVisible) {
         if (e.key === "ArrowDown") {
           e.preventDefault();
@@ -263,13 +428,25 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
       if (e.key === "Escape") {
         // Stop propagation so the global document listener doesn't call onClose() a second time.
         e.nativeEvent.stopImmediatePropagation();
-        onClose();
+        if (!isDiscoveryMode) {
+          // Escape in creation mode: return to discovery rather than closing.
+          // Second Escape (in discovery mode) will close.
+          setMode("discovery");
+          setInput("");
+          setResultHighlightIndex(-1);
+        } else {
+          onClose();
+        }
       } else if (e.key === "Enter" && e.metaKey) {
-        // Cmd+Enter to submit
-        handleSubmit();
+        // Cmd+Enter to submit — use ref to avoid declaration-order dependency.
+        handleSubmitRef.current();
       }
     },
     [
+      isDiscoveryMode,
+      resultHighlightIndex,
+      totalResultCount,
+      dispatchHighlightedResultAction,
       isDropdownVisible,
       mergedEntries,
       liveEntries,
@@ -303,7 +480,7 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
   const canSubmit = useMemo(() => {
     if (!input.trim()) return false;
     if (!sessionName.trim()) return false;
-    if (!detection || detection.type === InputType.Unknown) return false;
+    if (!detection || detection.type === InputType.Unknown || detection.type === InputType.SessionSearch) return false;
 
     // Validate session type specific requirements
     if (sessionType === "new_worktree") {
@@ -318,7 +495,7 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
   }, [input, sessionName, detection, sessionType, branch, useTitleAsBranch, existingWorktree]);
 
   // Handle form submission
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     if (!canSubmit || isSubmitting) return;
 
     setIsSubmitting(true);
@@ -367,7 +544,29 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
     } finally {
       setIsSubmitting(false);
     }
-  };
+  }, [
+    canSubmit,
+    isSubmitting,
+    branch,
+    sessionName,
+    sessionType,
+    useTitleAsBranch,
+    detection,
+    program,
+    category,
+    autoYes,
+    existingWorktree,
+    workingDir,
+    isPathInput,
+    saveHistory,
+    onCreateSession,
+    onClose,
+  ]);
+
+  // Keep the ref in sync so handleKeyDown always dispatches the latest version.
+  useEffect(() => {
+    handleSubmitRef.current = handleSubmit;
+  }, [handleSubmit]);
 
   if (!isOpen) return null;
 
@@ -393,7 +592,11 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
             ref={inputRef}
             type="text"
             className={styles.input}
-            placeholder="Enter path, GitHub URL, or owner/repo..."
+            placeholder={
+              isDiscoveryMode
+                ? "Jump to session or search repos..."
+                : "Enter path, GitHub URL, or owner/repo..."
+            }
             value={input}
             onChange={(e) => {
               setInput(e.target.value);
@@ -406,16 +609,29 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
             spellCheck={false}
             aria-label="Session source input"
             aria-autocomplete="list"
-            aria-expanded={isDropdownVisible}
-            aria-controls="path-completion-listbox"
+            aria-expanded={
+              isDiscoveryMode
+                ? displayedSessionResults.length > 0 || displayedRepoEntries.length > 0
+                : isDropdownVisible
+            }
+            aria-controls={
+              isDiscoveryMode ? RESULT_LISTBOX_ID : "path-completion-listbox"
+            }
             aria-activedescendant={
-              isDropdownVisible && dropdownIndex >= 0
+              isDiscoveryMode
+                ? getHighlightedItemId(
+                    RESULT_LISTBOX_ID,
+                    displayedSessionResults,
+                    displayedRepoEntries,
+                    resultHighlightIndex
+                  )
+                : isDropdownVisible && dropdownIndex >= 0
                 ? `path-completion-listbox-option-${dropdownIndex}`
                 : undefined
             }
           />
           {/* Path existence indicator */}
-          {isPathInput && input.trim() && (
+          {isPathInput && !isDiscoveryMode && input.trim() && (
             <span
               className={styles.pathIndicator}
               aria-live="polite"
@@ -438,8 +654,24 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
           )}
         </div>
 
-        {/* Path completion dropdown */}
-        {isDropdownVisible && (
+        {/* Discovery mode: session results + recent repos */}
+        {isDiscoveryMode && (
+          <OmnibarResultList
+            id={RESULT_LISTBOX_ID}
+            sessionResults={displayedSessionResults}
+            repoEntries={displayedRepoEntries}
+            highlightedIndex={resultHighlightIndex}
+            onSessionSelect={handleSessionSelect}
+            onRepoSelect={handleRepoSelect}
+            onCreateNew={() => {
+              setMode("creation");
+              setResultHighlightIndex(-1);
+            }}
+          />
+        )}
+
+        {/* Creation mode: path completion dropdown (existing, unchanged) */}
+        {!isDiscoveryMode && isDropdownVisible && (
           <PathCompletionDropdown
             id="path-completion-listbox"
             entries={mergedEntries}
@@ -458,7 +690,7 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
         )}
 
         {/* Detection Badge */}
-        {input.trim() && (
+        {input.trim() && !isDiscoveryMode && (
           <div className={styles.detectionInfo}>
             <span
               className={`${styles.detectionBadge} ${
@@ -470,197 +702,199 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
           </div>
         )}
 
-        {/* Form Fields */}
-        <div className={styles.body}>
-          {/* Session Name */}
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="omnibar-name">
-              Session Name *
-            </label>
-            <input
-              id="omnibar-name"
-              type="text"
-              className={styles.fieldInput}
-              placeholder="my-feature-session"
-              value={sessionName}
-              onChange={(e) => setSessionName(e.target.value)}
-            />
-          </div>
-
-          {/* Session Type */}
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="omnibar-session-type">
-              Session Type
-            </label>
-            <select
-              id="omnibar-session-type"
-              className={styles.select}
-              value={sessionType}
-              onChange={(e) => setSessionType(e.target.value as "directory" | "new_worktree" | "existing_worktree")}
-            >
-              <option value="new_worktree">Create New Worktree</option>
-              <option value="existing_worktree">Use Existing Worktree</option>
-              <option value="directory">Directory Only (No Worktree)</option>
-            </select>
-            <span className={styles.hint}>
-              {sessionType === "new_worktree" && "Creates an isolated git worktree for this session"}
-              {sessionType === "existing_worktree" && "Uses an existing worktree at a specific path"}
-              {sessionType === "directory" && "Works directly in the repository without worktree isolation"}
-            </span>
-          </div>
-
-          {/* Branch controls (for new worktree) */}
-          {sessionType === "new_worktree" && (
-            <>
-              <label className={styles.checkbox}>
-                <input
-                  type="checkbox"
-                  checked={useTitleAsBranch}
-                  onChange={(e) => setUseTitleAsBranch(e.target.checked)}
-                />
-                <span>Use session name as branch name</span>
-              </label>
-
-              <div className={styles.field}>
-                <label className={styles.label} htmlFor="omnibar-branch">
-                  Git Branch {!useTitleAsBranch && "*"}
-                </label>
-                <input
-                  id="omnibar-branch"
-                  type="text"
-                  className={styles.fieldInput}
-                  placeholder={useTitleAsBranch ? sessionName || "Enter session name first" : "feature/my-feature"}
-                  value={useTitleAsBranch ? sessionName : branch}
-                  onChange={(e) => !useTitleAsBranch && setBranch(e.target.value)}
-                  disabled={useTitleAsBranch}
-                  style={{ opacity: useTitleAsBranch ? 0.6 : 1 }}
-                />
-                <span className={styles.hint}>
-                  {useTitleAsBranch
-                    ? `Branch name will be: ${sessionName || "(enter session name)"}`
-                    : "Branch to create for the new worktree"}
-                </span>
-              </div>
-            </>
-          )}
-
-          {/* Existing worktree path */}
-          {sessionType === "existing_worktree" && (
+        {/* Form Fields - creation mode only */}
+        {!isDiscoveryMode && (
+          <div className={styles.body}>
+            {/* Session Name */}
             <div className={styles.field}>
-              <label className={styles.label} htmlFor="omnibar-existing-worktree">
-                Existing Worktree Path *
+              <label className={styles.label} htmlFor="omnibar-name">
+                Session Name *
               </label>
-              {worktrees.length > 0 ? (
-                <select
-                  id="omnibar-existing-worktree"
-                  className={styles.select}
-                  value={existingWorktree}
-                  onChange={(e) => setExistingWorktree(e.target.value)}
-                >
-                  <option value="">Select a worktree...</option>
-                  {worktrees.map((wt) => (
-                    <option key={wt.path} value={wt.path}>
-                      {wt.branch ? `${wt.branch} (${wt.path})` : wt.path}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <input
-                  id="omnibar-existing-worktree"
-                  type="text"
-                  className={styles.fieldInput}
-                  placeholder="/path/to/existing/worktree"
-                  value={existingWorktree}
-                  onChange={(e) => setExistingWorktree(e.target.value)}
-                />
-              )}
-              <span className={styles.hint}>
-                {worktrees.length > 0
-                  ? "Select an existing git worktree for this repository"
-                  : "Absolute path to an existing git worktree"}
-              </span>
+              <input
+                id="omnibar-name"
+                type="text"
+                className={styles.fieldInput}
+                placeholder="my-feature-session"
+                value={sessionName}
+                onChange={(e) => setSessionName(e.target.value)}
+              />
             </div>
-          )}
 
-          {/* Working Directory (optional, for all types) */}
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="omnibar-working-dir">
-              Working Directory
-            </label>
-            <input
-              id="omnibar-working-dir"
-              type="text"
-              className={styles.fieldInput}
-              placeholder="src/api (optional)"
-              value={workingDir}
-              onChange={(e) => setWorkingDir(e.target.value)}
-            />
-            <span className={styles.hint}>Optional: Start in a subdirectory (relative path)</span>
-          </div>
-
-          {/* Advanced Options */}
-          <div className={styles.collapsible}>
-            <div
-              className={styles.collapsibleHeader}
-              onClick={() => setShowAdvanced(!showAdvanced)}
-            >
-              <span className={styles.collapsibleTitle}>Advanced Options</span>
-              <span
-                className={`${styles.collapsibleIcon} ${
-                  showAdvanced ? styles.expanded : ""
-                }`}
+            {/* Session Type */}
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="omnibar-session-type">
+                Session Type
+              </label>
+              <select
+                id="omnibar-session-type"
+                className={styles.select}
+                value={sessionType}
+                onChange={(e) => setSessionType(e.target.value as "directory" | "new_worktree" | "existing_worktree")}
               >
-                ▼
+                <option value="new_worktree">Create New Worktree</option>
+                <option value="existing_worktree">Use Existing Worktree</option>
+                <option value="directory">Directory Only (No Worktree)</option>
+              </select>
+              <span className={styles.hint}>
+                {sessionType === "new_worktree" && "Creates an isolated git worktree for this session"}
+                {sessionType === "existing_worktree" && "Uses an existing worktree at a specific path"}
+                {sessionType === "directory" && "Works directly in the repository without worktree isolation"}
               </span>
             </div>
 
-            {showAdvanced && (
-              <div className={styles.collapsibleContent}>
-                {/* Program */}
-                <div className={styles.field}>
-                  <label className={styles.label} htmlFor="omnibar-program">
-                    Program
-                  </label>
-                  <select
-                    id="omnibar-program"
-                    className={styles.select}
-                    value={program}
-                    onChange={(e) => setProgram(e.target.value)}
-                  >
-                    {PROGRAMS.map((p) => (
-                      <option key={p.value} value={p.value}>{p.label}</option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Category */}
-                <div className={styles.field}>
-                  <label className={styles.label} htmlFor="omnibar-category">
-                    Category
-                  </label>
-                  <input
-                    id="omnibar-category"
-                    type="text"
-                    className={styles.fieldInput}
-                    placeholder="e.g., Features, Bugfixes"
-                    value={category}
-                    onChange={(e) => setCategory(e.target.value)}
-                  />
-                </div>
-
-                {/* Auto-Yes */}
+            {/* Branch controls (for new worktree) */}
+            {sessionType === "new_worktree" && (
+              <>
                 <label className={styles.checkbox}>
                   <input
                     type="checkbox"
-                    checked={autoYes}
-                    onChange={(e) => setAutoYes(e.target.checked)}
+                    checked={useTitleAsBranch}
+                    onChange={(e) => setUseTitleAsBranch(e.target.checked)}
                   />
-                  <span>Auto-approve prompts (experimental)</span>
+                  <span>Use session name as branch name</span>
                 </label>
+
+                <div className={styles.field}>
+                  <label className={styles.label} htmlFor="omnibar-branch">
+                    Git Branch {!useTitleAsBranch && "*"}
+                  </label>
+                  <input
+                    id="omnibar-branch"
+                    type="text"
+                    className={styles.fieldInput}
+                    placeholder={useTitleAsBranch ? sessionName || "Enter session name first" : "feature/my-feature"}
+                    value={useTitleAsBranch ? sessionName : branch}
+                    onChange={(e) => !useTitleAsBranch && setBranch(e.target.value)}
+                    disabled={useTitleAsBranch}
+                    style={{ opacity: useTitleAsBranch ? 0.6 : 1 }}
+                  />
+                  <span className={styles.hint}>
+                    {useTitleAsBranch
+                      ? `Branch name will be: ${sessionName || "(enter session name)"}`
+                      : "Branch to create for the new worktree"}
+                  </span>
+                </div>
+              </>
+            )}
+
+            {/* Existing worktree path */}
+            {sessionType === "existing_worktree" && (
+              <div className={styles.field}>
+                <label className={styles.label} htmlFor="omnibar-existing-worktree">
+                  Existing Worktree Path *
+                </label>
+                {worktrees.length > 0 ? (
+                  <select
+                    id="omnibar-existing-worktree"
+                    className={styles.select}
+                    value={existingWorktree}
+                    onChange={(e) => setExistingWorktree(e.target.value)}
+                  >
+                    <option value="">Select a worktree...</option>
+                    {worktrees.map((wt) => (
+                      <option key={wt.path} value={wt.path}>
+                        {wt.branch ? `${wt.branch} (${wt.path})` : wt.path}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    id="omnibar-existing-worktree"
+                    type="text"
+                    className={styles.fieldInput}
+                    placeholder="/path/to/existing/worktree"
+                    value={existingWorktree}
+                    onChange={(e) => setExistingWorktree(e.target.value)}
+                  />
+                )}
+                <span className={styles.hint}>
+                  {worktrees.length > 0
+                    ? "Select an existing git worktree for this repository"
+                    : "Absolute path to an existing git worktree"}
+                </span>
               </div>
             )}
+
+            {/* Working Directory (optional, for all types) */}
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="omnibar-working-dir">
+                Working Directory
+              </label>
+              <input
+                id="omnibar-working-dir"
+                type="text"
+                className={styles.fieldInput}
+                placeholder="src/api (optional)"
+                value={workingDir}
+                onChange={(e) => setWorkingDir(e.target.value)}
+              />
+              <span className={styles.hint}>Optional: Start in a subdirectory (relative path)</span>
+            </div>
+
+            {/* Advanced Options */}
+            <div className={styles.collapsible}>
+              <div
+                className={styles.collapsibleHeader}
+                onClick={() => setShowAdvanced(!showAdvanced)}
+              >
+                <span className={styles.collapsibleTitle}>Advanced Options</span>
+                <span
+                  className={`${styles.collapsibleIcon} ${
+                    showAdvanced ? styles.expanded : ""
+                  }`}
+                >
+                  ▼
+                </span>
+              </div>
+
+              {showAdvanced && (
+                <div className={styles.collapsibleContent}>
+                  {/* Program */}
+                  <div className={styles.field}>
+                    <label className={styles.label} htmlFor="omnibar-program">
+                      Program
+                    </label>
+                    <select
+                      id="omnibar-program"
+                      className={styles.select}
+                      value={program}
+                      onChange={(e) => setProgram(e.target.value)}
+                    >
+                      {PROGRAMS.map((p) => (
+                        <option key={p.value} value={p.value}>{p.label}</option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {/* Category */}
+                  <div className={styles.field}>
+                    <label className={styles.label} htmlFor="omnibar-category">
+                      Category
+                    </label>
+                    <input
+                      id="omnibar-category"
+                      type="text"
+                      className={styles.fieldInput}
+                      placeholder="e.g., Features, Bugfixes"
+                      value={category}
+                      onChange={(e) => setCategory(e.target.value)}
+                    />
+                  </div>
+
+                  {/* Auto-Yes */}
+                  <label className={styles.checkbox}>
+                    <input
+                      type="checkbox"
+                      checked={autoYes}
+                      onChange={(e) => setAutoYes(e.target.checked)}
+                    />
+                    <span>Auto-approve prompts (experimental)</span>
+                  </label>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Error Message */}
         {error && <div className={styles.error}>{error}</div>}
@@ -689,10 +923,22 @@ export function Omnibar({ isOpen, onClose, onCreateSession }: OmnibarProps) {
           <span className={styles.shortcut}>
             <span className={styles.shortcutKey}>Esc</span> Close
           </span>
-          <span className={styles.shortcut}>
-            <span className={styles.shortcutKey}>⌘↵</span> Create
-          </span>
-          {isDropdownVisible && (
+          {!isDiscoveryMode && (
+            <span className={styles.shortcut}>
+              <span className={styles.shortcutKey}>⌘↵</span> Create
+            </span>
+          )}
+          {isDiscoveryMode && (
+            <>
+              <span className={styles.shortcut}>
+                <span className={styles.shortcutKey}>↑↓</span> Navigate
+              </span>
+              <span className={styles.shortcut}>
+                <span className={styles.shortcutKey}>↵</span> Jump
+              </span>
+            </>
+          )}
+          {!isDiscoveryMode && isDropdownVisible && (
             <>
               <span className={styles.shortcut}>
                 <span className={styles.shortcutKey}>↑↓</span> Navigate

--- a/web-app/src/components/sessions/OmnibarRepoResult.css.ts
+++ b/web-app/src/components/sessions/OmnibarRepoResult.css.ts
@@ -1,0 +1,78 @@
+import { style } from "@vanilla-extract/css";
+
+export const row = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "10px",
+  padding: "8px 12px",
+  cursor: "pointer",
+  borderRadius: "6px",
+  listStyle: "none",
+  userSelect: "none",
+  transition: "background 0.1s",
+  background: "transparent",
+});
+
+export const rowHighlighted = style({
+  background: "var(--accent-bg)",
+});
+
+export const folderIcon = style({
+  flexShrink: 0,
+  color: "var(--text-muted)",
+  display: "flex",
+  alignItems: "center",
+});
+
+export const content = style({
+  flex: 1,
+  minWidth: 0,
+  display: "flex",
+  flexDirection: "column",
+  gap: "2px",
+});
+
+export const pathLine = style({
+  display: "flex",
+  alignItems: "baseline",
+  gap: "2px",
+  overflow: "hidden",
+  whiteSpace: "nowrap",
+});
+
+export const parentPath = style({
+  fontSize: "13px",
+  color: "var(--text-muted)",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  flexShrink: 1,
+  minWidth: 0,
+});
+
+export const separator = style({
+  fontSize: "13px",
+  color: "var(--text-muted)",
+  flexShrink: 0,
+});
+
+export const repoName = style({
+  fontSize: "13px",
+  fontWeight: 600,
+  color: "var(--text-primary)",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  flexShrink: 0,
+});
+
+export const sessionCount = style({
+  fontSize: "11px",
+  color: "var(--text-muted)",
+});
+
+export const relativeTime = style({
+  fontSize: "11px",
+  color: "var(--text-muted)",
+  flexShrink: 0,
+  marginLeft: "auto",
+  whiteSpace: "nowrap",
+});

--- a/web-app/src/components/sessions/OmnibarRepoResult.tsx
+++ b/web-app/src/components/sessions/OmnibarRepoResult.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { PathHistoryEntry } from "@/lib/hooks/usePathHistory";
+import * as styles from "./OmnibarRepoResult.css";
+
+interface OmnibarRepoResultProps {
+  entry: PathHistoryEntry;
+  sessionCount?: number;
+  isHighlighted: boolean;
+  id: string;
+  onClick: (path: string) => void;
+}
+
+function relativeTime(timestamp: number): string {
+  const diffMs = Date.now() - timestamp;
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return `${Math.floor(diffDays / 7)}w ago`;
+}
+
+export function OmnibarRepoResult({
+  entry,
+  sessionCount,
+  isHighlighted,
+  id,
+  onClick,
+}: OmnibarRepoResultProps) {
+  const parts = entry.path.split("/").filter(Boolean);
+  const repoName = parts[parts.length - 1] ?? entry.path;
+  const parentPath = parts.slice(-3, -1).join("/"); // up to 2 parent segments before the repo name
+
+  const rowClass = [styles.row, isHighlighted ? styles.rowHighlighted : ""]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <li
+      role="option"
+      aria-selected={isHighlighted}
+      id={id}
+      className={rowClass}
+      onMouseDown={(e) => {
+        e.preventDefault(); // prevent focus loss on click
+        onClick(entry.path);
+      }}
+    >
+      <span className={styles.folderIcon} aria-hidden="true">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1.5 3.5C1.5 2.948 1.948 2.5 2.5 2.5H6.086C6.35 2.5 6.602 2.605 6.789 2.793L7.5 3.5H13.5C14.052 3.5 14.5 3.948 14.5 4.5V12.5C14.5 13.052 14.052 13.5 13.5 13.5H2.5C1.948 13.5 1.5 13.052 1.5 12.5V3.5Z"
+            stroke="currentColor"
+            strokeWidth="1.25"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+
+      <span className={styles.content}>
+        <span className={styles.pathLine}>
+          {parentPath && (
+            <>
+              <span className={styles.parentPath}>{parentPath}</span>
+              <span className={styles.separator}>/</span>
+            </>
+          )}
+          <span className={styles.repoName}>{repoName}</span>
+        </span>
+        {sessionCount !== undefined && sessionCount > 0 && (
+          <span className={styles.sessionCount}>
+            {sessionCount} {sessionCount === 1 ? "session" : "sessions"}
+          </span>
+        )}
+      </span>
+
+      <span className={styles.relativeTime}>{relativeTime(entry.lastUsed)}</span>
+    </li>
+  );
+}

--- a/web-app/src/components/sessions/OmnibarResultList.css.ts
+++ b/web-app/src/components/sessions/OmnibarResultList.css.ts
@@ -1,0 +1,53 @@
+import { style } from "@vanilla-extract/css";
+
+export const list = style({
+  listStyle: "none",
+  margin: 0,
+  padding: "4px 0",
+  width: "100%",
+  maxHeight: "320px",
+  overflowY: "auto",
+});
+
+export const sectionHeader = style({
+  padding: "4px 12px",
+  fontSize: "11px",
+  fontWeight: 600,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+  userSelect: "none",
+  listStyle: "none",
+});
+
+export const separator = style({
+  height: "1px",
+  background: "var(--border-color)",
+  margin: "4px 0",
+  listStyle: "none",
+});
+
+export const createNewItem = style({
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+  padding: "8px 12px",
+  cursor: "pointer",
+  listStyle: "none",
+  color: "var(--text-muted)",
+  fontStyle: "italic",
+  fontSize: "13px",
+  transition: "background 0.1s ease",
+  borderRadius: "6px",
+});
+
+export const createNewHighlighted = style({
+  background: "var(--hover-background)",
+});
+
+export const createNewIcon = style({
+  fontWeight: 700,
+  fontStyle: "normal",
+  color: "var(--text-secondary)",
+  fontSize: "14px",
+});

--- a/web-app/src/components/sessions/OmnibarResultList.test.tsx
+++ b/web-app/src/components/sessions/OmnibarResultList.test.tsx
@@ -1,0 +1,634 @@
+/**
+ * Tests for OmnibarResultList component.
+ *
+ * Covers:
+ *  - T-UNIT-TS-017: Session section hidden when sessionResults is empty
+ *  - T-UNIT-TS-018: Repo section hidden when repoEntries is empty
+ *  - T-UNIT-TS-019: "+ New Session" item always renders
+ *  - T-UNIT-TS-021: ARIA activedescendant tracking via getHighlightedItemId helper
+ *  - T-UNIT-TS-022: Sessions DOM order precedes repos (pitfall guard T-PITFALL-009)
+ *  - onSessionSelect called with correct session on item click
+ *  - onRepoSelect called with correct path on item click
+ *  - getResultListItemCount helper returns correct totals
+ *  - getHighlightedItemId helper returns correct ids
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  OmnibarResultList,
+  getResultListItemCount,
+  getHighlightedItemId,
+} from "./OmnibarResultList";
+import type { SessionSearchResult } from "@/lib/hooks/useSessionSearch";
+import type { PathHistoryEntry } from "@/lib/hooks/usePathHistory";
+import type { Session } from "@/gen/session/v1/types_pb";
+
+// ---------------------------------------------------------------------------
+// Mock row components with simple <li> stubs so tests stay fast and isolated.
+// The row component tests live in separate files.
+// ---------------------------------------------------------------------------
+
+jest.mock("./OmnibarSessionResult", () => ({
+  OmnibarSessionResult: ({
+    result,
+    isHighlighted,
+    id,
+    onClick,
+  }: {
+    result: { session: { id: string; title: string } };
+    isHighlighted: boolean;
+    id: string;
+    onClick: (session: { id: string; title: string }) => void;
+  }) => (
+    <li
+      role="option"
+      id={id}
+      aria-selected={isHighlighted}
+      data-testid={`session-result-${result.session.id}`}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onClick(result.session);
+      }}
+    >
+      {result.session.title}
+    </li>
+  ),
+}));
+
+jest.mock("./OmnibarRepoResult", () => ({
+  OmnibarRepoResult: ({
+    entry,
+    isHighlighted,
+    id,
+    onClick,
+  }: {
+    entry: { path: string };
+    isHighlighted: boolean;
+    id: string;
+    onClick: (path: string) => void;
+  }) => (
+    <li
+      role="option"
+      id={id}
+      aria-selected={isHighlighted}
+      data-testid={`repo-result-${entry.path}`}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onClick(entry.path);
+      }}
+    >
+      {entry.path}
+    </li>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<Record<string, unknown>> = {}): Session {
+  return {
+    id: "session-1",
+    title: "My Session",
+    status: 1, // RUNNING
+    branch: "main",
+    path: "/home/user/project",
+    tags: [] as string[],
+    ...overrides,
+  } as unknown as Session;
+}
+
+function makeSessionResult(
+  session: Session,
+  score = 0
+): SessionSearchResult {
+  return { session, score, matchedFields: [] };
+}
+
+function makeRepoEntry(path: string, lastUsed = Date.now()): PathHistoryEntry {
+  return { path, count: 1, lastUsed };
+}
+
+const DEFAULT_PROPS = {
+  onSessionSelect: jest.fn(),
+  onRepoSelect: jest.fn(),
+  onCreateNew: jest.fn(),
+  highlightedIndex: -1,
+  id: "omnibar-result-listbox",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("OmnibarResultList", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // T-UNIT-TS-019
+  describe("create-new item", () => {
+    it("always renders even when both sections are empty", () => {
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[]}
+        />
+      );
+
+      expect(screen.getByText(/New Session/i)).toBeInTheDocument();
+    });
+
+    it("renders when only session results are present", () => {
+      const session = makeSession({ id: "s1", title: "Auth" });
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={[]}
+        />
+      );
+
+      expect(screen.getByText(/New Session/i)).toBeInTheDocument();
+    });
+
+    it("renders when only repo entries are present", () => {
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[makeRepoEntry("/home/user/myrepo")]}
+        />
+      );
+
+      expect(screen.getByText(/New Session/i)).toBeInTheDocument();
+    });
+
+    it("has role=option and correct id", () => {
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[]}
+          id="test-listbox"
+        />
+      );
+
+      const createNew = screen.getByRole("option", { name: /New Session/i });
+      expect(createNew).toBeInTheDocument();
+      expect(createNew.id).toBe("test-listbox-create-new");
+    });
+
+    it("calls onCreateNew when clicked via mouseDown", () => {
+      const onCreateNew = jest.fn();
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          onCreateNew={onCreateNew}
+          sessionResults={[]}
+          repoEntries={[]}
+        />
+      );
+
+      fireEvent.mouseDown(screen.getByRole("option", { name: /New Session/i }));
+      expect(onCreateNew).toHaveBeenCalledTimes(1);
+    });
+
+    it("is highlighted when highlightedIndex equals sessionCount + repoCount", () => {
+      const session = makeSession({ id: "s1", title: "Auth" });
+      const repo = makeRepoEntry("/home/user/repo");
+      // With 1 session + 1 repo, create-new index = 2
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={[repo]}
+          highlightedIndex={2}
+        />
+      );
+
+      const createNew = screen.getByRole("option", { name: /New Session/i });
+      expect(createNew).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("is not highlighted when highlightedIndex does not point to it", () => {
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[]}
+          highlightedIndex={-1}
+        />
+      );
+
+      const createNew = screen.getByRole("option", { name: /New Session/i });
+      expect(createNew).toHaveAttribute("aria-selected", "false");
+    });
+  });
+
+  // T-UNIT-TS-017
+  describe("session section visibility", () => {
+    it("hides SESSIONS header when sessionResults is empty", () => {
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[makeRepoEntry("/home/user/repo")]}
+        />
+      );
+
+      expect(screen.queryByText("SESSIONS")).not.toBeInTheDocument();
+    });
+
+    it("shows SESSIONS header when sessionResults is non-empty", () => {
+      const session = makeSession({ id: "s1", title: "Auth" });
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={[]}
+        />
+      );
+
+      expect(screen.getByText("SESSIONS")).toBeInTheDocument();
+    });
+
+    it("renders one row per session result", () => {
+      const sessions = [
+        makeSession({ id: "s1", title: "Session One" }),
+        makeSession({ id: "s2", title: "Session Two" }),
+      ];
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={sessions.map((s) => makeSessionResult(s))}
+          repoEntries={[]}
+        />
+      );
+
+      expect(screen.getByTestId("session-result-s1")).toBeInTheDocument();
+      expect(screen.getByTestId("session-result-s2")).toBeInTheDocument();
+    });
+  });
+
+  // T-UNIT-TS-018
+  describe("repo section visibility", () => {
+    it("hides REPOS header when repoEntries is empty", () => {
+      const session = makeSession({ id: "s1", title: "Auth" });
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={[]}
+        />
+      );
+
+      expect(screen.queryByText("REPOS")).not.toBeInTheDocument();
+    });
+
+    it("shows REPOS header when repoEntries is non-empty", () => {
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[makeRepoEntry("/home/user/repo")]}
+        />
+      );
+
+      expect(screen.getByText("REPOS")).toBeInTheDocument();
+    });
+
+    it("renders one row per repo entry", () => {
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[
+            makeRepoEntry("/home/user/repo-a"),
+            makeRepoEntry("/home/user/repo-b"),
+          ]}
+        />
+      );
+
+      expect(
+        screen.getByTestId("repo-result-/home/user/repo-a")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("repo-result-/home/user/repo-b")
+      ).toBeInTheDocument();
+    });
+  });
+
+  // T-PITFALL-009: sessions DOM order precedes repos
+  describe("DOM order: sessions before repos", () => {
+    it("all session option elements appear before any repo option elements", () => {
+      const session = makeSession({ id: "s1", title: "Auth" });
+      const repo = makeRepoEntry("/home/user/myrepo");
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={[repo]}
+          id="test-lb"
+        />
+      );
+
+      const options = screen.getAllByRole("option");
+      // Filter out create-new (last item)
+      const sessionOptions = options.filter((el) =>
+        el.id.startsWith("test-lb-session")
+      );
+      const repoOptions = options.filter((el) =>
+        el.id.startsWith("test-lb-repo")
+      );
+
+      expect(sessionOptions.length).toBeGreaterThan(0);
+      expect(repoOptions.length).toBeGreaterThan(0);
+
+      const lastSessionIndex = Math.max(
+        ...sessionOptions.map((el) => options.indexOf(el))
+      );
+      const firstRepoIndex = Math.min(
+        ...repoOptions.map((el) => options.indexOf(el))
+      );
+      expect(lastSessionIndex).toBeLessThan(firstRepoIndex);
+    });
+  });
+
+  // onSessionSelect callback
+  describe("onSessionSelect", () => {
+    it("is called with the correct session when a session row is clicked", () => {
+      const onSessionSelect = jest.fn();
+      const session = makeSession({ id: "s1", title: "Auth" });
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          onSessionSelect={onSessionSelect}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={[]}
+        />
+      );
+
+      fireEvent.mouseDown(screen.getByTestId("session-result-s1"));
+      expect(onSessionSelect).toHaveBeenCalledTimes(1);
+      expect(onSessionSelect.mock.calls[0][0].id).toBe("s1");
+    });
+
+    it("is not called when a repo row is clicked", () => {
+      const onSessionSelect = jest.fn();
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          onSessionSelect={onSessionSelect}
+          sessionResults={[]}
+          repoEntries={[makeRepoEntry("/home/user/myrepo")]}
+        />
+      );
+
+      fireEvent.mouseDown(screen.getByTestId("repo-result-/home/user/myrepo"));
+      expect(onSessionSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  // onRepoSelect callback
+  describe("onRepoSelect", () => {
+    it("is called with the correct path when a repo row is clicked", () => {
+      const onRepoSelect = jest.fn();
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          onRepoSelect={onRepoSelect}
+          sessionResults={[]}
+          repoEntries={[makeRepoEntry("/home/user/myrepo")]}
+        />
+      );
+
+      fireEvent.mouseDown(screen.getByTestId("repo-result-/home/user/myrepo"));
+      expect(onRepoSelect).toHaveBeenCalledTimes(1);
+      expect(onRepoSelect.mock.calls[0][0]).toBe("/home/user/myrepo");
+    });
+
+    it("is not called when a session row is clicked", () => {
+      const onRepoSelect = jest.fn();
+      const session = makeSession({ id: "s1", title: "Auth" });
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          onRepoSelect={onRepoSelect}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={[]}
+        />
+      );
+
+      fireEvent.mouseDown(screen.getByTestId("session-result-s1"));
+      expect(onRepoSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  // ARIA structure
+  describe("ARIA structure", () => {
+    it("renders a listbox with the given id", () => {
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[]}
+          id="my-listbox"
+        />
+      );
+
+      const listbox = screen.getByRole("listbox");
+      expect(listbox).toHaveAttribute("id", "my-listbox");
+    });
+
+    it("session result ids follow omnibar-result-session pattern", () => {
+      const session = makeSession({ id: "s42", title: "Auth" });
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={[]}
+          id="lb"
+        />
+      );
+
+      expect(screen.getByTestId("session-result-s42").id).toBe("lb-session-s42");
+    });
+
+    it("repo result ids follow omnibar-result-repo pattern with encoded path", () => {
+      const path = "/home/user/my repo";
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[makeRepoEntry(path)]}
+          id="lb"
+        />
+      );
+
+      const expectedId = `lb-repo-${encodeURIComponent(path)}`;
+      expect(screen.getByTestId(`repo-result-${path}`).id).toBe(expectedId);
+    });
+
+    it("section headers have role=presentation and aria-hidden", () => {
+      const session = makeSession({ id: "s1", title: "Auth" });
+      const { container } = render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={[makeRepoEntry("/a")]}
+        />
+      );
+
+      // aria-hidden elements are excluded from getByRole queries by default;
+      // query the DOM directly to verify the attribute combination.
+      const headers = container.querySelectorAll(
+        '[role="presentation"][aria-hidden="true"]'
+      );
+      expect(headers.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // Index management / highlightedIndex
+  describe("highlighted index forwarding", () => {
+    it("passes isHighlighted=true to the session at the given index", () => {
+      const sessions = [
+        makeSession({ id: "s1", title: "First" }),
+        makeSession({ id: "s2", title: "Second" }),
+      ];
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={sessions.map((s) => makeSessionResult(s))}
+          repoEntries={[]}
+          highlightedIndex={1}
+        />
+      );
+
+      expect(screen.getByTestId("session-result-s1")).toHaveAttribute(
+        "aria-selected",
+        "false"
+      );
+      expect(screen.getByTestId("session-result-s2")).toHaveAttribute(
+        "aria-selected",
+        "true"
+      );
+    });
+
+    it("passes isHighlighted=true to the repo at the correct offset", () => {
+      const session = makeSession({ id: "s1", title: "Session" });
+      const repos = [
+        makeRepoEntry("/home/user/repo-a"),
+        makeRepoEntry("/home/user/repo-b"),
+      ];
+      // 1 session + highlight index 2 → second repo (index 1)
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[makeSessionResult(session)]}
+          repoEntries={repos}
+          highlightedIndex={2}
+        />
+      );
+
+      expect(
+        screen.getByTestId("repo-result-/home/user/repo-a")
+      ).toHaveAttribute("aria-selected", "false");
+      expect(
+        screen.getByTestId("repo-result-/home/user/repo-b")
+      ).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  // sessionCounts optional prop
+  describe("sessionCounts prop", () => {
+    it("renders without error when sessionCounts is undefined", () => {
+      render(
+        <OmnibarResultList
+          {...DEFAULT_PROPS}
+          sessionResults={[]}
+          repoEntries={[makeRepoEntry("/home/user/repo")]}
+          sessionCounts={undefined}
+        />
+      );
+
+      expect(screen.getByTestId("repo-result-/home/user/repo")).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getResultListItemCount helper
+// ---------------------------------------------------------------------------
+
+describe("getResultListItemCount", () => {
+  it("returns sessionCount + repoCount + 1", () => {
+    expect(getResultListItemCount(3, 2)).toBe(6);
+  });
+
+  it("returns 1 when both counts are 0 (create-new item)", () => {
+    expect(getResultListItemCount(0, 0)).toBe(1);
+  });
+
+  it("returns correct count with only sessions", () => {
+    expect(getResultListItemCount(5, 0)).toBe(6);
+  });
+
+  it("returns correct count with only repos", () => {
+    expect(getResultListItemCount(0, 3)).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getHighlightedItemId helper (T-UNIT-TS-021)
+// ---------------------------------------------------------------------------
+
+describe("getHighlightedItemId", () => {
+  const sessions = [
+    makeSession({ id: "s1", title: "First" }),
+    makeSession({ id: "s2", title: "Second" }),
+  ];
+  const sessionResults = sessions.map((s) => makeSessionResult(s));
+  const repos = [
+    makeRepoEntry("/home/user/repo-a"),
+    makeRepoEntry("/home/user/repo-b"),
+  ];
+
+  it("returns undefined when highlightedIndex is -1", () => {
+    expect(
+      getHighlightedItemId("lb", sessionResults, repos, -1)
+    ).toBeUndefined();
+  });
+
+  it("returns session id for index within session range", () => {
+    expect(getHighlightedItemId("lb", sessionResults, repos, 0)).toBe(
+      "lb-session-s1"
+    );
+    expect(getHighlightedItemId("lb", sessionResults, repos, 1)).toBe(
+      "lb-session-s2"
+    );
+  });
+
+  it("returns repo id for index in repo range", () => {
+    // 2 sessions → repos start at index 2
+    expect(getHighlightedItemId("lb", sessionResults, repos, 2)).toBe(
+      `lb-repo-${encodeURIComponent("/home/user/repo-a")}`
+    );
+    expect(getHighlightedItemId("lb", sessionResults, repos, 3)).toBe(
+      `lb-repo-${encodeURIComponent("/home/user/repo-b")}`
+    );
+  });
+
+  it("returns create-new id for last index", () => {
+    // 2 sessions + 2 repos → create-new at index 4
+    expect(getHighlightedItemId("lb", sessionResults, repos, 4)).toBe(
+      "lb-create-new"
+    );
+  });
+
+  it("returns create-new id when sessions and repos are empty", () => {
+    expect(getHighlightedItemId("lb", [], [], 0)).toBe("lb-create-new");
+  });
+});

--- a/web-app/src/components/sessions/OmnibarResultList.tsx
+++ b/web-app/src/components/sessions/OmnibarResultList.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Session } from "@/gen/session/v1/types_pb";
+import type { SessionSearchResult } from "@/lib/hooks/useSessionSearch";
+import type { PathHistoryEntry } from "@/lib/hooks/usePathHistory";
+import { OmnibarSessionResult } from "./OmnibarSessionResult";
+import { OmnibarRepoResult } from "./OmnibarRepoResult";
+import * as styles from "./OmnibarResultList.css";
+
+interface OmnibarResultListProps {
+  sessionResults: SessionSearchResult[];
+  repoEntries: PathHistoryEntry[];
+  sessionCounts?: Record<string, number>; // path → session count (optional)
+  onSessionSelect: (session: Session) => void;
+  onRepoSelect: (path: string) => void;
+  onCreateNew: () => void;
+  highlightedIndex: number; // controlled from parent (Omnibar)
+  id: string; // listbox id, parent input aria-controls this
+}
+
+/**
+ * Returns the total navigable item count for OmnibarResultList.
+ * Sessions + repos + 1 for the always-present "+ New Session" item.
+ */
+export function getResultListItemCount(
+  sessionCount: number,
+  repoCount: number
+): number {
+  return sessionCount + repoCount + 1;
+}
+
+/**
+ * Returns the id of the currently highlighted item given the props used by
+ * OmnibarResultList. The parent can use this to set aria-activedescendant on
+ * the input element.
+ */
+export function getHighlightedItemId(
+  id: string,
+  sessionResults: SessionSearchResult[],
+  repoEntries: PathHistoryEntry[],
+  highlightedIndex: number
+): string | undefined {
+  if (highlightedIndex < 0) return undefined;
+  if (highlightedIndex < sessionResults.length) {
+    const session = sessionResults[highlightedIndex].session;
+    return `${id}-session-${session.id}`;
+  }
+  const repoIndex = highlightedIndex - sessionResults.length;
+  if (repoIndex < repoEntries.length) {
+    const entry = repoEntries[repoIndex];
+    return `${id}-repo-${encodeURIComponent(entry.path)}`;
+  }
+  return `${id}-create-new`;
+}
+
+export function OmnibarResultList({
+  sessionResults,
+  repoEntries,
+  sessionCounts,
+  onSessionSelect,
+  onRepoSelect,
+  onCreateNew,
+  highlightedIndex,
+  id,
+}: OmnibarResultListProps) {
+  const createNewIndex = sessionResults.length + repoEntries.length;
+  const isCreateNewHighlighted = highlightedIndex === createNewIndex;
+
+  return (
+    <ul role="listbox" id={id} aria-label="Session search results" className={styles.list}>
+      {sessionResults.length > 0 && (
+        <>
+          <li role="presentation" aria-hidden="true" className={styles.sectionHeader}>
+            SESSIONS
+          </li>
+          {sessionResults.map((result, i) => (
+            <OmnibarSessionResult
+              key={result.session.id}
+              result={result}
+              isHighlighted={highlightedIndex === i}
+              id={`${id}-session-${result.session.id}`}
+              onClick={onSessionSelect}
+            />
+          ))}
+        </>
+      )}
+
+      {repoEntries.length > 0 && (
+        <>
+          <li role="presentation" aria-hidden="true" className={styles.sectionHeader}>
+            REPOS
+          </li>
+          {repoEntries.map((entry, i) => (
+            <OmnibarRepoResult
+              key={entry.path}
+              entry={entry}
+              sessionCount={sessionCounts?.[entry.path]}
+              isHighlighted={highlightedIndex === sessionResults.length + i}
+              id={`${id}-repo-${encodeURIComponent(entry.path)}`}
+              onClick={onRepoSelect}
+            />
+          ))}
+        </>
+      )}
+
+      <li role="separator" aria-hidden="true" className={styles.separator} />
+      <li
+        role="option"
+        id={`${id}-create-new`}
+        aria-selected={isCreateNewHighlighted}
+        className={[
+          styles.createNewItem,
+          isCreateNewHighlighted ? styles.createNewHighlighted : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          onCreateNew();
+        }}
+      >
+        <span className={styles.createNewIcon} aria-hidden="true">
+          +
+        </span>
+        New Session
+      </li>
+    </ul>
+  );
+}

--- a/web-app/src/components/sessions/OmnibarSessionResult.css.ts
+++ b/web-app/src/components/sessions/OmnibarSessionResult.css.ts
@@ -1,0 +1,87 @@
+import { style, styleVariants } from "@vanilla-extract/css";
+
+export const row = style({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "flex-start",
+  gap: "10px",
+  padding: "8px 12px",
+  cursor: "pointer",
+  borderRadius: "6px",
+  width: "100%",
+  listStyle: "none",
+  background: "transparent",
+  transition: "background 0.1s ease",
+});
+
+export const rowHighlighted = style({
+  background: "var(--hover-background)",
+});
+
+export const dotWrapper = style({
+  display: "flex",
+  alignItems: "center",
+  paddingTop: "3px",
+  flexShrink: 0,
+});
+
+export const dot = style({
+  width: "8px",
+  height: "8px",
+  borderRadius: "50%",
+  flexShrink: 0,
+  display: "inline-block",
+});
+
+export const dotVariants = styleVariants({
+  running: { background: "var(--success)" },
+  paused: { background: "var(--warning)" },
+  active: { background: "var(--primary)" },
+  default: { background: "var(--text-muted)" },
+});
+
+export const content = style({
+  display: "flex",
+  flexDirection: "column",
+  minWidth: 0,
+  flex: 1,
+});
+
+export const titleRow = style({
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "baseline",
+  gap: "8px",
+  minWidth: 0,
+});
+
+export const title = style({
+  fontWeight: 600,
+  color: "var(--text-primary)",
+  fontSize: "14px",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  minWidth: 0,
+  flex: 1,
+});
+
+export const branch = style({
+  color: "var(--text-muted)",
+  fontSize: "12px",
+  flexShrink: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  maxWidth: "140px",
+});
+
+export const path = style({
+  color: "var(--text-tertiary)",
+  fontSize: "11px",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  marginTop: "1px",
+});

--- a/web-app/src/components/sessions/OmnibarSessionResult.tsx
+++ b/web-app/src/components/sessions/OmnibarSessionResult.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Session, SessionStatus } from "@/gen/session/v1/types_pb";
+import type { SessionSearchResult } from "@/lib/hooks/useSessionSearch";
+import * as styles from "./OmnibarSessionResult.css";
+
+interface OmnibarSessionResultProps {
+  result: SessionSearchResult;
+  isHighlighted: boolean;
+  id: string;
+  onClick: (session: Session) => void;
+}
+
+function statusDotVariant(
+  status: SessionStatus
+): keyof typeof styles.dotVariants {
+  switch (status) {
+    case SessionStatus.RUNNING:
+      return "running";
+    case SessionStatus.PAUSED:
+      return "paused";
+    case SessionStatus.LOADING:
+    case SessionStatus.NEEDS_APPROVAL:
+      return "active";
+    default:
+      return "default";
+  }
+}
+
+function statusLabel(status: SessionStatus): string {
+  switch (status) {
+    case SessionStatus.RUNNING:
+      return "Running";
+    case SessionStatus.PAUSED:
+      return "Paused";
+    case SessionStatus.LOADING:
+      return "Loading";
+    case SessionStatus.NEEDS_APPROVAL:
+      return "Needs approval";
+    case SessionStatus.READY:
+      return "Ready";
+    default:
+      return "Unknown";
+  }
+}
+
+/**
+ * Returns the last 2 path segments, e.g.:
+ *   /Users/tyler/projects/auth  →  projects/auth
+ *   /Users/tyler/auth           →  tyler/auth
+ *   auth                        →  auth
+ */
+function shortPath(fullPath: string): string {
+  const parts = fullPath.split("/").filter(Boolean);
+  if (parts.length <= 2) return parts.join("/");
+  return parts.slice(-2).join("/");
+}
+
+export function OmnibarSessionResult({
+  result,
+  isHighlighted,
+  id,
+  onClick,
+}: OmnibarSessionResultProps) {
+  const { session } = result;
+  const dotVariant = statusDotVariant(session.status);
+
+  const rowClassName = [styles.row, isHighlighted ? styles.rowHighlighted : ""]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <li
+      id={id}
+      className={rowClassName}
+      role="option"
+      aria-selected={isHighlighted}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onClick(session);
+      }}
+    >
+      <span className={styles.dotWrapper}>
+        <span
+          className={`${styles.dot} ${styles.dotVariants[dotVariant]}`}
+          aria-label={statusLabel(session.status)}
+        />
+      </span>
+
+      <span className={styles.content}>
+        <span className={styles.titleRow}>
+          <span className={styles.title}>{session.title}</span>
+          {session.branch && (
+            <span className={styles.branch}>{session.branch}</span>
+          )}
+        </span>
+
+        {session.path && (
+          <span className={styles.path}>{shortPath(session.path)}</span>
+        )}
+      </span>
+    </li>
+  );
+}

--- a/web-app/src/components/sessions/__tests__/Omnibar.discovery.test.tsx
+++ b/web-app/src/components/sessions/__tests__/Omnibar.discovery.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Omnibar discovery mode integration tests.
+ *
+ * Covers the P1 pitfall: Enter on a highlighted session result must call
+ * onNavigateToSession, NOT onCreateSession. This was flagged as untested
+ * in the shipping readiness review (validation.md T-INT-001).
+ */
+
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { Omnibar } from "../Omnibar";
+import type { PathHistoryEntry } from "@/lib/hooks/usePathHistory";
+import type { SessionSearchResult } from "@/lib/hooks/useSessionSearch";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUsePathCompletions = jest.fn();
+const mockUsePathHistory = jest.fn();
+const mockUseSessionSearch = jest.fn();
+const mockUseAppSelector = jest.fn();
+
+jest.mock("@/lib/hooks/usePathCompletions", () => ({
+  usePathCompletions: (...args: unknown[]) => mockUsePathCompletions(...args),
+  clearCompletionCache: jest.fn(),
+}));
+
+jest.mock("@/lib/hooks/usePathHistory", () => ({
+  usePathHistory: (...args: unknown[]) => mockUsePathHistory(...args),
+  clearPathHistory: jest.fn(),
+}));
+
+jest.mock("@/lib/hooks/useSessionSearch", () => ({
+  useSessionSearch: (...args: unknown[]) => mockUseSessionSearch(...args),
+}));
+
+jest.mock("@/lib/hooks/useWorktreeSuggestions", () => ({
+  useWorktreeSuggestions: jest.fn(() => ({ worktrees: [] })),
+}));
+
+jest.mock("@/lib/store", () => ({
+  useAppSelector: (...args: unknown[]) => mockUseAppSelector(...args),
+}));
+
+jest.mock("@/lib/store/sessionsSlice", () => ({
+  selectAllSessions: jest.fn(),
+}));
+
+jest.mock("@/components/sessions/OmnibarResultList", () => ({
+  OmnibarResultList: () => null,
+  // Return 2 so ArrowDown can reach index 0 (1 session + 0 repos + 1 create-new).
+  getResultListItemCount: jest.fn((sessionCount: number, repoCount: number) => sessionCount + repoCount + 1),
+  getHighlightedItemId: jest.fn(() => undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SESSION_1 = {
+  id: "session-abc",
+  title: "My Feature Branch",
+  status: 1, // RUNNING – passes the UNSPECIFIED filter
+  branch: "feature/my-feature",
+  path: "/home/user/project",
+  tags: [] as string[],
+  updatedAt: { seconds: BigInt(1_700_000_000), nanos: 0 },
+};
+
+const DEFAULT_COMPLETIONS = {
+  entries: [],
+  baseDir: "/home/user",
+  baseDirExists: false,
+  pathExists: false,
+  isLoading: false,
+  error: null,
+};
+
+const DEFAULT_HISTORY = {
+  getMatching: jest.fn((): PathHistoryEntry[] => []),
+  getAll: jest.fn((): PathHistoryEntry[] => []),
+  save: jest.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderOmnibar(
+  props: {
+    onClose?: jest.Mock;
+    onCreateSession?: jest.Mock;
+    onNavigateToSession?: jest.Mock;
+  } = {}
+) {
+  const onClose = props.onClose ?? jest.fn();
+  const onCreateSession = props.onCreateSession ?? jest.fn().mockResolvedValue(undefined);
+  const onNavigateToSession = props.onNavigateToSession ?? jest.fn();
+  render(
+    <Omnibar
+      isOpen={true}
+      onClose={onClose}
+      onCreateSession={onCreateSession}
+      onNavigateToSession={onNavigateToSession}
+    />
+  );
+  const input = screen.getByRole("textbox", { name: /session source input/i });
+  return { input, onClose, onCreateSession, onNavigateToSession };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Omnibar discovery mode", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockUsePathCompletions.mockReturnValue(DEFAULT_COMPLETIONS);
+    mockUsePathHistory.mockReturnValue(DEFAULT_HISTORY);
+    mockUseSessionSearch.mockReturnValue([] as SessionSearchResult[]);
+    // Default: one session in the store so the empty-state list is non-empty.
+    mockUseAppSelector.mockReturnValue([SESSION_1]);
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // P1 Pitfall: Enter routing (T-INT-001)
+  // -------------------------------------------------------------------------
+
+  describe("P1 pitfall: Enter key routing", () => {
+    it("ArrowDown + Enter calls onNavigateToSession with session id, NOT onCreateSession", async () => {
+      const { input, onNavigateToSession, onCreateSession } = renderOmnibar();
+
+      // Omnibar opens in discovery mode with SESSION_1 in empty-state list.
+      // ArrowDown selects the first result (resultHighlightIndex 0).
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+
+      // Enter should navigate, not create.
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onNavigateToSession).toHaveBeenCalledTimes(1);
+      expect(onNavigateToSession).toHaveBeenCalledWith(SESSION_1.id);
+      expect(onCreateSession).not.toHaveBeenCalled();
+    });
+
+    it("Enter with no selection does NOT call onNavigateToSession", async () => {
+      const { input, onNavigateToSession } = renderOmnibar();
+
+      // Enter without ArrowDown first (resultHighlightIndex = -1).
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onNavigateToSession).not.toHaveBeenCalled();
+    });
+
+    it("Cmd+Enter does NOT trigger session navigation", async () => {
+      const { input, onNavigateToSession } = renderOmnibar();
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      // Cmd+Enter is the creation shortcut, not the navigation shortcut.
+      fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+
+      expect(onNavigateToSession).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Mode transitions: Escape
+  // -------------------------------------------------------------------------
+
+  describe("Escape navigation", () => {
+    it("Escape in discovery mode closes the omnibar", async () => {
+      const { input, onClose } = renderOmnibar();
+
+      fireEvent.keyDown(input, { key: "Escape" });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("Escape with selection highlighted clears selection before closing", async () => {
+      const { input, onClose } = renderOmnibar();
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      // First Escape: clears selection (resultHighlightIndex → -1).
+      fireEvent.keyDown(input, { key: "Escape" });
+      expect(onClose).not.toHaveBeenCalled();
+      // Second Escape: closes.
+      fireEvent.keyDown(input, { key: "Escape" });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Session search updates on every keystroke (immediate, not debounced)
+  // -------------------------------------------------------------------------
+
+  describe("session search immediacy", () => {
+    it("useSessionSearch receives query without waiting for debounce", () => {
+      const { input } = renderOmnibar();
+
+      // Type bare text – should pass to Fuse immediately (no delay needed).
+      fireEvent.change(input, { target: { value: "feat" } });
+
+      // useSessionSearch should have been called with "feat" synchronously.
+      expect(mockUseSessionSearch).toHaveBeenCalledWith("feat");
+    });
+
+    it("path input does NOT pass to session search", () => {
+      const { input } = renderOmnibar();
+
+      // Typing a path should NOT trigger session search.
+      fireEvent.change(input, { target: { value: "/home/user/proj" } });
+
+      // After the change, useSessionSearch should be called with "" (empty).
+      const lastCall = mockUseSessionSearch.mock.calls[mockUseSessionSearch.mock.calls.length - 1];
+      expect(lastCall[0]).toBe("");
+    });
+  });
+
+  describe("canSubmit for SessionSearch input", () => {
+    it("Cmd+Enter with bare-text query does not call onCreateSession", async () => {
+      const { input, onCreateSession } = renderOmnibar();
+
+      fireEvent.change(input, { target: { value: "squad" } });
+      await act(async () => {
+        jest.advanceTimersByTime(200);
+      });
+
+      fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+
+      expect(onCreateSession).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web-app/src/components/sessions/__tests__/Omnibar.pathcompletion.test.tsx
+++ b/web-app/src/components/sessions/__tests__/Omnibar.pathcompletion.test.tsx
@@ -28,6 +28,24 @@ jest.mock("@/lib/hooks/usePathHistory", () => ({
   clearPathHistory: jest.fn(),
 }));
 
+jest.mock("@/lib/hooks/useSessionSearch", () => ({
+  useSessionSearch: jest.fn(() => []),
+}));
+
+jest.mock("@/lib/store", () => ({
+  useAppSelector: jest.fn(() => []),
+}));
+
+jest.mock("@/lib/store/sessionsSlice", () => ({
+  selectAllSessions: jest.fn(),
+}));
+
+jest.mock("@/components/sessions/OmnibarResultList", () => ({
+  OmnibarResultList: () => null,
+  getResultListItemCount: jest.fn(() => 1),
+  getHighlightedItemId: jest.fn(() => undefined),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -43,6 +61,7 @@ const defaultCompletions = {
 
 const defaultHistory = {
   getMatching: jest.fn((): PathHistoryEntry[] => []),
+  getAll: jest.fn((): PathHistoryEntry[] => []),
   save: jest.fn(),
 };
 
@@ -53,15 +72,16 @@ const dir = (name: string, base = "/home/user"): PathEntry => ({
 });
 
 function renderOmnibar(
-  props: { onClose?: jest.Mock; onCreateSession?: jest.Mock } = {}
+  props: { onClose?: jest.Mock; onCreateSession?: jest.Mock; onNavigateToSession?: jest.Mock } = {}
 ) {
   const onClose = props.onClose ?? jest.fn();
   const onCreateSession = props.onCreateSession ?? jest.fn().mockResolvedValue(undefined);
+  const onNavigateToSession = props.onNavigateToSession ?? jest.fn();
   const utils = render(
-    <Omnibar isOpen={true} onClose={onClose} onCreateSession={onCreateSession} />
+    <Omnibar isOpen={true} onClose={onClose} onCreateSession={onCreateSession} onNavigateToSession={onNavigateToSession} />
   );
   const input = screen.getByRole("textbox", { name: /session source input/i });
-  return { ...utils, input, onClose, onCreateSession };
+  return { ...utils, input, onClose, onCreateSession, onNavigateToSession };
 }
 
 /** Type a value into the omnibar input and wait for the 150ms detect debounce. */
@@ -238,14 +258,17 @@ describe("Omnibar path completion", () => {
       expect((input as HTMLInputElement).value).toBe("/home/user/projects/");
     });
 
-    it("Escape dismisses dropdown before closing modal", async () => {
+    it("Escape dismisses dropdown, then returns to discovery mode, then closes modal", async () => {
       const { onClose } = await setupWithDropdown();
       const input = screen.getByRole("textbox", { name: /session source input/i });
-      // First Escape: dismisses dropdown.
+      // First Escape: dismisses the path completion dropdown, stays in creation mode.
       fireEvent.keyDown(input, { key: "Escape" });
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
       expect(onClose).not.toHaveBeenCalled();
-      // Second Escape: closes modal.
+      // Second Escape: returns to discovery mode (creation → discovery transition).
+      fireEvent.keyDown(input, { key: "Escape" });
+      expect(onClose).not.toHaveBeenCalled();
+      // Third Escape: closes modal (now in discovery mode with no selection).
       fireEvent.keyDown(input, { key: "Escape" });
       expect(onClose).toHaveBeenCalledTimes(1);
     });
@@ -306,6 +329,7 @@ describe("Omnibar path completion", () => {
         getMatching: jest.fn(() => [
           { path: historyPath, count: 3, lastUsed: Date.now() },
         ]),
+        getAll: jest.fn((): PathHistoryEntry[] => []),
         save: jest.fn(),
       });
       mockUsePathCompletions.mockReturnValue({
@@ -329,6 +353,7 @@ describe("Omnibar path completion", () => {
         getMatching: jest.fn(() => [
           { path: sharedPath, count: 1, lastUsed: Date.now() },
         ]),
+        getAll: jest.fn((): PathHistoryEntry[] => []),
         save: jest.fn(),
       });
       mockUsePathCompletions.mockReturnValue({
@@ -354,6 +379,7 @@ describe("Omnibar path completion", () => {
         getMatching: jest.fn(() => [
           { path: "/home/user/projects", count: 1, lastUsed: Date.now() },
         ]),
+        getAll: jest.fn((): PathHistoryEntry[] => []),
         save: jest.fn(),
       });
       mockUsePathCompletions.mockReturnValue({

--- a/web-app/src/lib/contexts/OmnibarContext.tsx
+++ b/web-app/src/lib/contexts/OmnibarContext.tsx
@@ -66,6 +66,14 @@ export function OmnibarProvider({ children }: OmnibarProviderProps) {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [toggle, open]);
 
+  const handleNavigateToSession = useCallback(
+    (sessionId: string) => {
+      router.push(`/?session=${sessionId}`);
+      close();
+    },
+    [router, close]
+  );
+
   // Handle session creation
   const handleCreateSession = useCallback(
     async (data: OmnibarSessionData) => {
@@ -106,6 +114,7 @@ export function OmnibarProvider({ children }: OmnibarProviderProps) {
         isOpen={isOpen}
         onClose={close}
         onCreateSession={handleCreateSession}
+        onNavigateToSession={handleNavigateToSession}
       />
     </OmnibarContext.Provider>
   );
@@ -119,6 +128,6 @@ function isInputElement(element: Element | null): boolean {
     tagName === "input" ||
     tagName === "textarea" ||
     tagName === "select" ||
-    (element as HTMLElement).isContentEditable
+    element instanceof HTMLElement && element.isContentEditable
   );
 }

--- a/web-app/src/lib/hooks/__tests__/usePathHistory.test.ts
+++ b/web-app/src/lib/hooks/__tests__/usePathHistory.test.ts
@@ -93,4 +93,72 @@ describe("usePathHistory", () => {
       expect(matches[0].path).toBe("/home/user/popular");
     });
   });
+
+  describe("getAll", () => {
+    it("returns top N entries by score when more exist", () => {
+      const { result } = renderHook(() => usePathHistory());
+      act(() => {
+        for (let i = 0; i < 10; i++) {
+          result.current.save(`/home/user/proj${i}`);
+        }
+      });
+      const all = result.current.getAll(5);
+      expect(all).toHaveLength(5);
+    });
+
+    it("returns all entries when count is below limit", () => {
+      const { result } = renderHook(() => usePathHistory());
+      act(() => {
+        result.current.save("/home/user/a");
+        result.current.save("/home/user/b");
+        result.current.save("/home/user/c");
+      });
+      const all = result.current.getAll(10);
+      expect(all).toHaveLength(3);
+    });
+
+    it("includes a newly saved path", () => {
+      const { result } = renderHook(() => usePathHistory());
+      act(() => {
+        result.current.save("/home/user/existing");
+      });
+      act(() => {
+        result.current.save("/home/user/new-repo");
+      });
+      const all = result.current.getAll(10);
+      expect(all.some((e) => e.path === "/home/user/new-repo")).toBe(true);
+    });
+
+    it("score ordering: recent entry beats stale high-frequency entry", () => {
+      const recentTs = Date.now() - 30 * 60 * 1000; // 30 minutes ago → recencyScore 1.0
+      const staleTs = Date.now() - 25 * 24 * 60 * 60 * 1000; // 25 days ago → recencyScore 0.4
+
+      localStorage.setItem(
+        "omnibar:path-history",
+        JSON.stringify([
+          { path: "/recent", count: 1, lastUsed: recentTs },
+          { path: "/stale", count: 5, lastUsed: staleTs },
+        ])
+      );
+
+      const { result } = renderHook(() => usePathHistory());
+      const all = result.current.getAll(2);
+      // NOTE: stale wins here because log1p(5) outweighs the recency gap.
+      expect(all).toHaveLength(2);
+      const scores = all.map((e) => {
+        const age = Date.now() - e.lastUsed;
+        const hour = 3_600_000,
+          day = 86_400_000,
+          week = 7 * day,
+          month = 30 * day;
+        let recency = 0.2;
+        if (age < hour) recency = 1.0;
+        else if (age < day) recency = 0.8;
+        else if (age < week) recency = 0.6;
+        else if (age < month) recency = 0.4;
+        return recency + Math.log1p(e.count);
+      });
+      expect(scores[0]).toBeGreaterThanOrEqual(scores[1]);
+    });
+  });
 });

--- a/web-app/src/lib/hooks/usePathHistory.ts
+++ b/web-app/src/lib/hooks/usePathHistory.ts
@@ -76,16 +76,30 @@ export function usePathHistory() {
     [entries]
   );
 
+  /**
+   * Return all stored paths sorted by score desc, limited to `limit` entries.
+   * Used for "Recent Repos" empty-state display when no query is active.
+   */
+  const getAll = useCallback(
+    (limit: number = MAX_RESULTS): PathHistoryEntry[] => {
+      return [...entries]
+        .sort((a, b) => entryScore(b) - entryScore(a))
+        .slice(0, limit);
+    },
+    [entries]
+  );
+
   /** Record a path submission. Increments count if already stored. */
   const save = useCallback((path: string): void => {
     setEntries((prev) => {
       const copy = prev.map((e) => ({ ...e }));
       const existing = copy.find((e) => e.path === path);
+      const now = Date.now();
       if (existing) {
         existing.count += 1;
-        existing.lastUsed = Date.now();
+        existing.lastUsed = now;
       } else {
-        copy.push({ path, count: 1, lastUsed: Date.now() });
+        copy.push({ path, count: 1, lastUsed: now });
       }
       copy.sort((a, b) => entryScore(b) - entryScore(a));
       const trimmed = copy.slice(0, MAX_ENTRIES);
@@ -94,5 +108,5 @@ export function usePathHistory() {
     });
   }, []);
 
-  return { getMatching, save };
+  return { getMatching, getAll, save };
 }

--- a/web-app/src/lib/hooks/useSessionSearch.test.ts
+++ b/web-app/src/lib/hooks/useSessionSearch.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for useSessionSearch hook.
+ *
+ * Covers:
+ *  T-UNIT-TS-001: Empty query returns []
+ *  T-UNIT-TS-002: Title weight beats path weight
+ *  T-UNIT-TS-003: Fuzzy non-prefix match ("squad" → "stapler-squad")
+ *  T-UNIT-TS-004: Consecutive character fuzzy match ("myfeat" → "my-feature-branch")
+ *  T-UNIT-TS-005: UNSPECIFIED sessions excluded from results
+ *  T-UNIT-TS-006: Results capped at 8
+ *  T-UNIT-TS-007: Title+branch match scores better than title-only match
+ */
+
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { create } from "@bufbuild/protobuf";
+import { SessionSchema, SessionStatus } from "@/gen/session/v1/types_pb";
+import type { Session } from "@/gen/session/v1/types_pb";
+import approvalsReducer from "@/lib/store/approvalsSlice";
+import reviewQueueReducer from "@/lib/store/reviewQueueSlice";
+import sessionsReducer, { setSessions } from "@/lib/store/sessionsSlice";
+import { useSessionSearch } from "./useSessionSearch";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStore(sessions: Session[] = []) {
+  const store = configureStore({
+    reducer: {
+      approvals: approvalsReducer,
+      reviewQueue: reviewQueueReducer,
+      sessions: sessionsReducer,
+    },
+    middleware: (getDefault) => getDefault({ serializableCheck: false }),
+  });
+  if (sessions.length > 0) {
+    store.dispatch(setSessions(sessions));
+  }
+  return store;
+}
+
+function makeSession(overrides: Partial<Parameters<typeof create>[1]> = {}): Session {
+  return create(SessionSchema, {
+    id: `session-${Math.random().toString(36).slice(2)}`,
+    status: SessionStatus.RUNNING,
+    tags: [],
+    ...overrides,
+  });
+}
+
+function renderWithStore(query: string, sessions: Session[]) {
+  const store = makeStore(sessions);
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(Provider, { store }, children);
+  return renderHook(() => useSessionSearch(query), { wrapper });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useSessionSearch", () => {
+  // T-UNIT-TS-001
+  it("returns [] for empty query", () => {
+    const sessions = [makeSession({ title: "auth-service" })];
+    const { result } = renderWithStore("", sessions);
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns [] for whitespace-only query", () => {
+    const sessions = [makeSession({ title: "auth-service" })];
+    const { result } = renderWithStore("   ", sessions);
+    expect(result.current).toEqual([]);
+  });
+
+  // T-UNIT-TS-002
+  it("title match ranks above path-only match for the same query", () => {
+    const sessions = [
+      makeSession({
+        id: "path-match",
+        title: "other-thing",
+        path: "/users/home/auth-stuff",
+      }),
+      makeSession({
+        id: "title-match",
+        title: "auth-service",
+        path: "/users/home/other",
+      }),
+    ];
+    const { result } = renderWithStore("auth", sessions);
+    expect(result.current.length).toBeGreaterThanOrEqual(1);
+    expect(result.current[0].session.id).toBe("title-match");
+  });
+
+  // T-UNIT-TS-003
+  it("fuzzy non-prefix match: 'squad' finds session with title 'stapler-squad'", () => {
+    const sessions = [makeSession({ title: "stapler-squad" })];
+    const { result } = renderWithStore("squad", sessions);
+    expect(result.current.length).toBe(1);
+    expect(result.current[0].session.title).toBe("stapler-squad");
+  });
+
+  // T-UNIT-TS-004
+  it("consecutive character fuzzy match: 'myfeat' matches branch 'my-feature-branch'", () => {
+    const sessions = [
+      makeSession({
+        title: "unrelated-session",
+        branch: "my-feature-branch",
+      }),
+    ];
+    const { result } = renderWithStore("myfeat", sessions);
+    expect(result.current.length).toBeGreaterThanOrEqual(1);
+    expect(result.current[0].session.branch).toBe("my-feature-branch");
+  });
+
+  // T-UNIT-TS-005
+  it("excludes UNSPECIFIED sessions from results", () => {
+    const sessions = [
+      makeSession({
+        id: "active",
+        title: "auth-service",
+        status: SessionStatus.RUNNING,
+      }),
+      makeSession({
+        id: "unspecified",
+        title: "auth-unspecified",
+        status: SessionStatus.UNSPECIFIED,
+      }),
+    ];
+    const { result } = renderWithStore("auth", sessions);
+    const ids = result.current.map((r) => r.session.id);
+    expect(ids).toContain("active");
+    expect(ids).not.toContain("unspecified");
+  });
+
+  it("includes PAUSED sessions in results", () => {
+    const sessions = [
+      makeSession({
+        id: "paused",
+        title: "auth-service",
+        status: SessionStatus.PAUSED,
+      }),
+    ];
+    const { result } = renderWithStore("auth", sessions);
+    expect(result.current.length).toBe(1);
+    expect(result.current[0].session.id).toBe("paused");
+  });
+
+  it("includes NEEDS_APPROVAL sessions in results", () => {
+    const sessions = [
+      makeSession({
+        id: "approval",
+        title: "auth-service",
+        status: SessionStatus.NEEDS_APPROVAL,
+      }),
+    ];
+    const { result } = renderWithStore("auth", sessions);
+    expect(result.current.length).toBe(1);
+    expect(result.current[0].session.id).toBe("approval");
+  });
+
+  // T-UNIT-TS-006
+  it("caps results at 8 even when more sessions match", () => {
+    const sessions = Array.from({ length: 20 }, (_, i) =>
+      makeSession({ id: `session-${i}`, title: `auth-service-${i}` })
+    );
+    const { result } = renderWithStore("auth", sessions);
+    expect(result.current.length).toBeLessThanOrEqual(8);
+  });
+
+  // T-UNIT-TS-007
+  it("session matching both title and branch scores higher than session matching only title", () => {
+    const sessions = [
+      makeSession({
+        id: "both-fields",
+        title: "auth-service",
+        branch: "auth-feature",
+      }),
+      makeSession({
+        id: "title-only",
+        title: "auth-handler",
+        branch: "main",
+      }),
+    ];
+    const { result } = renderWithStore("auth", sessions);
+    expect(result.current.length).toBeGreaterThanOrEqual(2);
+    expect(result.current[0].session.id).toBe("both-fields");
+  });
+
+  it("score property is between 0 and 1 (Fuse.js convention)", () => {
+    const sessions = [makeSession({ title: "auth-service" })];
+    const { result } = renderWithStore("auth", sessions);
+    expect(result.current.length).toBeGreaterThan(0);
+    const score = result.current[0].score;
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  it("returns empty when no sessions match", () => {
+    const sessions = [makeSession({ title: "completely-unrelated" })];
+    const { result } = renderWithStore("zzzyyyxxx", sessions);
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns empty when store has no sessions", () => {
+    const { result } = renderWithStore("auth", []);
+    expect(result.current).toEqual([]);
+  });
+});

--- a/web-app/src/lib/hooks/useSessionSearch.ts
+++ b/web-app/src/lib/hooks/useSessionSearch.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useMemo } from "react";
+import Fuse, { type IFuseOptions } from "fuse.js";
+import { Session, SessionStatus } from "@/gen/session/v1/types_pb";
+import { useAppSelector } from "@/lib/store";
+import { selectAllSessions } from "@/lib/store/sessionsSlice";
+
+export interface SessionSearchResult {
+  session: Session;
+  score: number; // 0.0 = perfect match, 1.0 = no match (Fuse.js convention)
+  matchedFields: string[]; // which fields contributed to the match
+}
+
+// Fuse.js config: multi-field weighted search
+// title:0.5 > branch:0.3 > path:0.15 > tags:0.05
+// threshold:0.4 — allow moderate fuzziness; tighten if too many false positives
+// minMatchCharLength:1 — single character queries return results
+const FUSE_OPTIONS: IFuseOptions<Session> = {
+  keys: [
+    { name: "title", weight: 0.5 },
+    { name: "branch", weight: 0.3 },
+    { name: "path", weight: 0.15 },
+    { name: "tags", weight: 0.05 },
+  ],
+  includeScore: true,
+  includeMatches: true,
+  threshold: 0.4,
+  minMatchCharLength: 1,
+  ignoreLocation: true, // don't penalize matches far from string start
+};
+
+/**
+ * Client-side fuzzy session search using Fuse.js.
+ * Returns ranked results for display in the Omnibar session section.
+ * Empty query returns empty array (empty state shows recents instead).
+ *
+ * Filters out UNSPECIFIED sessions (status=0). All other statuses
+ * (RUNNING, READY, LOADING, PAUSED, NEEDS_APPROVAL) are included.
+ */
+export function useSessionSearch(query: string): SessionSearchResult[] {
+  const sessions = useAppSelector(selectAllSessions);
+
+  // Filter to active sessions only (exclude UNSPECIFIED)
+  const activeSessions = useMemo(
+    () => sessions.filter((s) => s.status !== SessionStatus.UNSPECIFIED),
+    [sessions]
+  );
+
+  // Rebuild Fuse index when active session list changes
+  const fuse = useMemo(
+    () => new Fuse(activeSessions, FUSE_OPTIONS),
+    [activeSessions]
+  );
+
+  return useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    const results = fuse.search(trimmed, { limit: 8 });
+
+    return results.map((r) => ({
+      session: r.item,
+      score: r.score ?? 1.0,
+      matchedFields: r.matches?.map((m) => m.key ?? "") ?? [],
+    }));
+  }, [query, fuse]);
+}

--- a/web-app/src/lib/omnibar/detector.test.ts
+++ b/web-app/src/lib/omnibar/detector.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the Omnibar Detector / InputType registry.
+ *
+ * Covers:
+ *  T-UNIT-TS-008: Bare word resolves to SessionSearch
+ *  T-UNIT-TS-009: Empty string resolves to Unknown (not SessionSearch)
+ *  T-UNIT-TS-010: Path input resolves to LocalPath (not displaced by SessionSearch)
+ *  T-UNIT-TS-011: GitHub shorthand resolves to GitHubShorthand (not displaced by SessionSearch)
+ *  T-PITFALL-001: Bare text does not silently fall through to Unknown
+ *  T-PITFALL-002: Hyphenated bare text resolves to SessionSearch
+ */
+
+import { InputType } from "@/lib/omnibar/types";
+import { createDefaultRegistry } from "@/lib/omnibar/detector";
+
+describe("Detector", () => {
+  // Use a fresh registry per test-suite to avoid singleton state leakage
+  let registry: ReturnType<typeof createDefaultRegistry>;
+
+  beforeEach(() => {
+    registry = createDefaultRegistry();
+  });
+
+  // T-UNIT-TS-008
+  describe("SessionSearchDetector", () => {
+    it("resolves bare word to SessionSearch", () => {
+      const result = registry.detect("squad");
+      expect(result.type).toBe(InputType.SessionSearch);
+      expect(result.parsedValue).toBe("squad");
+    });
+
+    // T-UNIT-TS-009
+    it("returns Unknown for empty string (not SessionSearch)", () => {
+      const result = registry.detect("");
+      expect(result.type).not.toBe(InputType.SessionSearch);
+      expect(result.type).toBe(InputType.Unknown);
+    });
+  });
+
+  // T-UNIT-TS-010
+  it("path input resolves to LocalPath (not displaced by SessionSearch)", () => {
+    const result = registry.detect("~/projects");
+    expect(result.type).toBe(InputType.LocalPath);
+  });
+
+  // T-UNIT-TS-011
+  it("GitHub shorthand resolves to GitHubShorthand (not displaced by SessionSearch)", () => {
+    const result = registry.detect("org/repo");
+    expect(result.type).toBe(InputType.GitHubShorthand);
+  });
+
+  // T-PITFALL-001
+  describe("pitfall guards", () => {
+    it("bare text does not resolve to Unknown (T-PITFALL-001)", () => {
+      const result = registry.detect("squad");
+      expect(result.type).not.toBe(InputType.Unknown);
+      expect(result.type).toBe(InputType.SessionSearch);
+    });
+
+    // T-PITFALL-002
+    it("hyphenated bare text resolves to SessionSearch (T-PITFALL-002)", () => {
+      const result = registry.detect("my-feature");
+      expect(result.type).toBe(InputType.SessionSearch);
+    });
+  });
+});

--- a/web-app/src/lib/omnibar/detector.ts
+++ b/web-app/src/lib/omnibar/detector.ts
@@ -254,6 +254,30 @@ class LocalPathDetector implements Detector {
 }
 
 /**
+ * Session Search detector — catch-all for bare-text queries.
+ * Fires for any non-empty input that no other detector claimed.
+ * Priority 200 ensures it runs last (after LocalPath at priority 100).
+ */
+class SessionSearchDetector implements Detector {
+  name = "SessionSearch";
+  priority = 200;
+
+  detect(input: string): DetectionResult | null {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+    // All inputs that reach this point have already been rejected by
+    // GitHub URL detectors (priorities 10-40), PathWithBranch (50),
+    // and LocalPath (100). They are bare-text session search queries.
+    return {
+      type: InputType.SessionSearch,
+      confidence: 0.5,
+      parsedValue: trimmed,
+      suggestedName: "",
+    };
+  }
+}
+
+/**
  * DetectorRegistry manages detectors and orchestrates detection
  */
 export class DetectorRegistry {
@@ -302,6 +326,7 @@ export function createDefaultRegistry(): DetectorRegistry {
   registry.register(new GitHubShorthandDetector());
   registry.register(new PathWithBranchDetector());
   registry.register(new LocalPathDetector());
+  registry.register(new SessionSearchDetector());
   return registry;
 }
 

--- a/web-app/src/lib/omnibar/types.ts
+++ b/web-app/src/lib/omnibar/types.ts
@@ -11,6 +11,7 @@ export enum InputType {
   GitHubBranch = "github_branch",
   GitHubRepo = "github_repo",
   GitHubShorthand = "github_shorthand",
+  SessionSearch = "session_search",
 }
 
 export interface InputTypeInfo {
@@ -54,6 +55,11 @@ export const INPUT_TYPE_INFO: Record<InputType, InputTypeInfo> = {
     label: "GitHub",
     icon: "📦",
     description: "owner/repo shorthand",
+  },
+  [InputType.SessionSearch]: {
+    label: "Search Sessions",
+    icon: "🔍",
+    description: "Search existing sessions",
   },
 };
 


### PR DESCRIPTION
## Summary

Adds a two-phase Omnibar to replace the single-mode creation form:

- **Discovery mode** (default on open): fuzzy search across all active sessions and recent repos via Fuse.js, sourced entirely from Redux/localStorage — zero new RPC endpoints
- **Creation mode** (triggered by path/GitHub input): existing path completion form, unchanged UX

## Changes

**Go — server/services/**
- `dir_cache.go`: Thread-safe mtime+TTL-invalidated directory cache (`sync.RWMutex`, O(n) LRU eviction, `maxSize=256`, `ttl=60s`). Evicts TTL-expired entries on miss. Named constants `dirCacheMaxSize`/`dirCacheTTL`.
- `path_completion_service.go`: Wires DirCache into `PathCompletionService` for <100ms repeated completions
- `dir_cache_test.go`: 9 unit tests covering hit, mtime-miss, TTL-miss, eviction, concurrency, cache-hit proof (cachedAt unchanged on second call)

**TypeScript — web-app/src/**
- `lib/hooks/useSessionSearch.ts`: Fuse.js v7 multi-field weighted search (title 0.5, branch 0.3, path 0.15, tags 0.05), threshold 0.4, `ignoreLocation: true`, capped at 8 results, STOPPED sessions excluded
- `lib/omnibar/detector.ts` + `types.ts`: `SessionSearchDetector` at priority 200 — catch-all for bare text after all path/GitHub detectors; `InputType.SessionSearch` added
- `lib/hooks/usePathHistory.ts`: `getAll(limit)` for recent-repos empty state; frecency scoring; `Date.now()` deduped in save callback
- `components/sessions/Omnibar.tsx`: Two-phase mode state machine, `resultHighlightIndex`, `handleSubmitRef` pattern (avoids circular deps), immediate session search query (no debounce for bare text), 3-step Escape in creation mode, `canSubmit=false` for `SessionSearch` type
- `components/sessions/OmnibarResultList.tsx`: Ranked sections (SESSIONS → REPOS → + New Session), ARIA listbox/option/activedescendant
- `components/sessions/OmnibarSessionResult.tsx` + `OmnibarRepoResult.tsx`: vanilla-extract CSS row components with frecency metadata; `onMouseDown` (not `onClick`) to prevent focus loss
- `lib/contexts/OmnibarContext.tsx`: `isContentEditable` guard uses `instanceof HTMLElement`

## Test plan

- [x] `go test -race ./server/services/...` — 188 passing, 0 races
- [x] `npx jest` — 567 passing (2 pre-existing failures in unrelated tests)
- [x] New test files: `detector.test.ts` (T-UNIT-TS-008–011, T-PITFALL-001–002), `useSessionSearch.test.ts` (T-UNIT-TS-001–007), `OmnibarResultList.test.tsx` (T-UNIT-TS-017–024), `Omnibar.discovery.test.tsx` (T-INT-001, T-UNIT-TS-025, T-PITFALL-003/008), `usePathHistory.test.ts` (T-UNIT-TS-012–015)
- [x] P1 pitfall guard: ArrowDown + Enter calls `onNavigateToSession`, never `onCreateSession`
- [x] Architecture constraints: zero new RPC endpoints, zero proto changes