### PR TITLE
fix(vcs/files/logs): UUID session ID lookups, FileTree drill-down, UUID persistence

### DIFF
--- a/docs/tasks/fix-vcs-files-logs.md
+++ b/docs/tasks/fix-vcs-files-logs.md
@@ -1,0 +1,537 @@
+# Feature Plan: Fix VCS Diff, Files, and Logs Pages
+
+## Epic Overview
+
+Five regressions and gaps across the VCS Diff, Files, and Logs tabs in the session detail view. Three bugs share a single root cause (UUID session ID mismatch in backend lookup), one bug is a tree-toggle implementation issue in the FileTree component, and one is a configuration/path mismatch in the Logs tab.
+
+The work is organized as three stories:
+1. Fix UUID session ID mismatches in VCS, Files, and Diff backend lookups
+2. Fix folder drill-down in the Files tree
+3. Fix session logs page returning no results
+
+---
+
+## Root Cause Analysis
+
+### Bug 1 and 2: UUID ID Mismatch in VCS and Files Services
+
+**The migration:** When sessions were given UUIDs, `InstanceToProto` in `server/adapters/instance_adapter.go` was updated to set `proto.Id = inst.GetStableID()`. `GetStableID()` returns `inst.UUID` when present, otherwise falls back to `inst.Title`. The proto `Id` field is now a UUID for any session that has one.
+
+**The frontend:** `SessionDetail.tsx` passes `session.id` to all tabs — `VcsPanel` (via `SessionVcsProvider`), `FilesTab`, `SessionLogsTab`, and `DiffViewer`. Since `session.id` comes from the proto, it is now a UUID.
+
+**The backend lookups that broke:**
+
+| Service | Method | Lookup logic | Bug |
+|---|---|---|---|
+| `WorkspaceService` | `GetVCSStatus`, `GetWorkspaceInfo`, `GetWorkspace` | `inst.Title == id` | Title lookup — fails when id is UUID |
+| `WorkspaceService` | `GetWorkspace` (used by `FileService`) | `inst.Title == id` | Same |
+| `SessionService` | `GetSessionDiff` | `inst.Title == req.Msg.Id` | Title-only, does not check UUID |
+| `GitHubService` | `findInstance` | `inst.Title == id` | Title-only |
+
+**The `SessionService.findInstance`** (used for terminal, streaming, session updates) already does the right thing: it calls `reviewQueuePoller.FindInstance(id)`, which checks `inst.Title == sessionID || inst.GetStableID() == sessionID`. So terminal streaming works; the other services do not.
+
+**Files lookup chain:** `SessionService.ListFiles` / `GetFileContent` / `SearchFiles` all delegate to `FileService`, which calls `WorkspaceService.GetWorkspace(sessionId)`. That calls `findInstance(sessionID)` which only compares `inst.Title`. So all file operations fail when passed a UUID.
+
+**VCS lookup chain:** `useSessionVcs.ts` calls `getVCSStatus({ id: sessionId })` and `getSessionDiff({ id: sessionId })`. `GetVCSStatus` goes through `WorkspaceService.findInstance` (Title-only). `GetSessionDiff` does its own Title-only loop.
+
+### Bug 3: FileTree Folder Drill-Down Not Working
+
+The `FileTree.tsx` component uses `react-arborist` for the virtual tree. `react-arborist` v3 fires `onToggle` with the **node ID** (a string) when a node is toggled open/closed. The `handleToggle` callback in `FileTree` receives that ID and calls `loadDirectory(id)`.
+
+The issue is that `buildTreeData` gives every directory node `children: []` (an empty array, not `undefined`) as its initial state, because the code in `buildTreeData` does:
+
+```typescript
+if (loaded === undefined) {
+  // Directory not yet loaded — provide empty array so it's expandable.
+  return { ...node, children: [] };
+}
+```
+
+`react-arborist` uses the `childrenAccessor` to determine whether a node is a leaf. The accessor is:
+
+```typescript
+childrenAccessor={(node) => {
+  if (!node.isDir) return null;
+  return node.children ?? [];
+}}
+```
+
+Returning `[]` (empty array) for unloaded directories means arborist treats them as **empty leaf nodes, not expandable folders**. When a user clicks such a node, arborist may not fire `onToggle` at all, or it fires with no visual expand. The node appears collapsed with no children to show, even after `loadDirectory` stores results in `dirContents`.
+
+Additionally, `handleToggle` only loads the directory if `!dirContents.has(id)`. Once a failed or empty load is stored, re-clicking will not retry. This compounds the initial rendering issue.
+
+The correct pattern is to return `undefined` (not `[]`) for directories whose children have not been loaded, so arborist knows they are expandable-but-unloaded. Only return `[]` when the directory is confirmed empty.
+
+### Bug 4: Session Logs Tab Returns No Entries
+
+`SessionLogsTab.tsx` passes `sessionId` (a UUID) to `getLogs({ sessionId })`. The backend `GetLogs` in `utility_service.go` calls `log.GetSessionLogFilePath(cfg, sid)`. That builds `session_<sanitized-sid>.log`. For a UUID like `3f2a1b4c-...`, the path would be `session_3f2a1b4c----.log` (dashes preserved, since `-` is allowed in the sanitizer).
+
+The session log files are **written** using `inst.Title` as the session ID (see `review_queue_poller.go:660`: `log.LogForSession(inst.Title, ...)`). So log files are named `session_<title>.log`. When queried with a UUID, the backend opens a nonexistent file path and returns an empty result with no error.
+
+There are two sub-problems:
+1. `GetLogs` receives a UUID but log files are written with the Title as the key.
+2. Session logs may not be written at all for most activity — `LogForSession` is only called from a handful of places in the poller. Most session activity goes to the global log file, not per-session files.
+
+---
+
+## Story Breakdown
+
+### Story 1: Fix UUID Session ID References in Backend Services
+
+**Goal:** All VCS and file service backend lookups must resolve instances by both UUID and Title, matching the behavior already present in `ReviewQueuePoller.FindInstance`.
+
+**Acceptance Criteria:**
+- Opening the VCS tab for any session (old Title-ID or new UUID-ID) shows git status and file changes
+- Opening the Diff tab shows the unified diff
+- Opening the Files tab loads the root directory
+- File content can be read from any file in the tree
+- File search returns results
+
+**Files to modify:**
+- `server/services/workspace_service.go`
+- `server/services/session_service.go`
+
+---
+
+### Story 2: Fix Folder Drill-Down in Files View
+
+**Goal:** Clicking a folder in the Files tree expands it and loads its children from the server. Clicking again collapses it.
+
+**Acceptance Criteria:**
+- Clicking any directory expands it and shows children
+- Children load via the `listFiles` RPC with the directory path
+- Subdirectories within expanded folders are also expandable
+- "Collapse all" button collapses all open directories
+- Git status badges propagate up to parent directories
+
+**Files to modify:**
+- `web-app/src/components/sessions/FileTree.tsx`
+
+---
+
+### Story 3: Fix Logs Tab Showing No Results
+
+**Goal:** The Logs tab shows actual session-scoped log messages, correctly resolved by the session's UUID.
+
+**Acceptance Criteria:**
+- The Logs tab shows log entries when the session has log activity
+- The "No logs recorded" message only appears when there genuinely are no logs
+- Refresh and live-tail work correctly
+
+**Files to modify:**
+- `server/services/utility_service.go`
+- `server/services/workspace_service.go` (helper method, reused)
+
+---
+
+## Atomic Tasks
+
+### Task 1.1: Add UUID-aware instance resolution helper to WorkspaceService
+
+**Objective:** Replace the Title-only lookup in `WorkspaceService.findInstance` with one that also checks `inst.GetStableID()`, consistent with `ReviewQueuePoller.FindInstance`.
+
+**Files to modify:**
+- `server/services/workspace_service.go`
+
+**Implementation steps:**
+
+1. The current `findInstance` iterates `storage.LoadInstances()` and returns where `inst.Title == id`. Change the condition to also match on `inst.GetStableID() == id`:
+
+```go
+// Before (line 52):
+if inst.Title == id {
+
+// After:
+if inst.Title == id || inst.GetStableID() == id {
+```
+
+2. Update the comment on `findInstance` to document the dual-match behavior.
+
+**Validation:**
+- `go test ./server/services/ -run TestWorkspace` passes
+- Manual: open VCS tab for a session; status loads without error
+
+---
+
+### Task 1.2: Fix GetSessionDiff to resolve by UUID
+
+**Objective:** `GetSessionDiff` has its own inline Title-only lookup. It should use the same dual-match logic.
+
+**Files to modify:**
+- `server/services/session_service.go`
+
+**Implementation steps:**
+
+1. Locate the inline loop at line ~1242:
+
+```go
+for _, inst := range instances {
+    if inst.Title == req.Msg.Id {
+        instance = inst
+        break
+    }
+}
+```
+
+2. Change to also match `inst.GetStableID()`:
+
+```go
+for _, inst := range instances {
+    if inst.Title == req.Msg.Id || inst.GetStableID() == req.Msg.Id {
+        instance = inst
+        break
+    }
+}
+```
+
+3. Note: `GetSessionDiff` calls `s.loadInstancesWithWiring()` (storage-backed). Ideally, this should use the live in-memory poller like `GetSession` does, but that is a separate improvement. The minimal fix is the dual-match.
+
+**Validation:**
+- `go test ./server/services/ -run TestGetSessionDiff` passes (add test if missing)
+- Manual: open Diff tab for a session with uncommitted changes; diff renders
+
+---
+
+### Task 1.3: Fix GitHubService.findInstance to resolve by UUID
+
+**Objective:** `GitHubService.findInstance` also uses Title-only. Fix for completeness and future-proofing.
+
+**Files to modify:**
+- `server/services/github_service.go`
+
+**Implementation steps:**
+
+Change line 36:
+```go
+// Before:
+if inst.Title == id {
+
+// After:
+if inst.Title == id || inst.GetStableID() == id {
+```
+
+**Validation:**
+- `go test ./server/services/ -run TestGitHub` passes
+- No regression on PR info for sessions that have PRs
+
+---
+
+### Task 2.1: Fix FileTree lazy loading — return undefined for unloaded directories
+
+**Objective:** Directories that have not been loaded must return `undefined` from `childrenAccessor`, not `[]`, so `react-arborist` knows they are expandable. Returning `[]` marks them as empty leaves.
+
+**Files to modify:**
+- `web-app/src/components/sessions/FileTree.tsx`
+
+**Implementation steps:**
+
+1. In `buildTreeData`, the branch that handles unloaded directories currently returns `children: []`:
+
+```typescript
+// Line 89-91 — current code:
+if (loaded === undefined) {
+  // Directory not yet loaded — provide empty array so it's expandable.
+  return { ...node, children: [] };
+}
+```
+
+Change to return `undefined`, which signals react-arborist that children exist but are not yet loaded:
+
+```typescript
+if (loaded === undefined) {
+  // undefined signals react-arborist: expandable but children not yet fetched
+  return { ...node, children: undefined };
+}
+```
+
+2. In the `childrenAccessor` prop on `<Tree>`, the current code is:
+
+```typescript
+childrenAccessor={(node) => {
+  if (!node.isDir) return null;
+  return node.children ?? [];
+}}
+```
+
+`null` tells arborist it is a leaf. `[]` tells arborist it has zero children (collapsed leaf). `undefined` is not handled well by all versions. The safest approach is to return `null` explicitly for unloaded dirs to let arborist show the expand arrow, then trigger loading on toggle. However, different arborist versions handle this differently.
+
+The more reliable fix is to keep the pattern but ensure `handleToggle` is actually called. Confirm whether arborist fires `onToggle` for nodes with `children: []` vs `children: undefined` by examining the `handleToggle` flow. If `children: []` prevents the toggle, switch to `undefined`:
+
+```typescript
+childrenAccessor={(node) => {
+  if (!node.isDir) return null;
+  // null returned for dirs with no loaded children lets arborist show expand arrow
+  if (node.children === undefined) return null;
+  return node.children;
+}}
+```
+
+3. Update `TreeNode.children` type documentation to clarify: `undefined = not loaded (expandable)`, `[] = loaded and empty`.
+
+**Validation:**
+- Click a directory in the Files tab; a loading spinner shows and children appear
+- Subdirectories are also expandable
+- The root collapse button collapses all open dirs
+
+---
+
+### Task 2.2: Fix handleToggle to correctly load subdirectory paths
+
+**Objective:** Verify the path passed to `loadDirectory` matches what the backend expects. The `FileTree` stores node IDs as relative paths from the workspace root (e.g., `src/components`). The backend `ListFiles` accepts `path` as a relative path. These should already match, but the retry logic is worth hardening.
+
+**Files to modify:**
+- `web-app/src/components/sessions/FileTree.tsx`
+
+**Implementation steps:**
+
+1. In `handleToggle`, the current guard `if (node?.isDir && !dirContents.has(id))` prevents retry after any load (including failed loads). A failed load sets `errorPaths`, so the node cannot be retried. Add a check: if the path is in `errorPaths`, allow re-toggle to clear the error and retry:
+
+```typescript
+const handleToggle = useCallback(
+  (id: string) => {
+    if (searchResults !== null) return;
+    const allNodes = buildTreeData(rootNodes, dirContents);
+    const node = findNode(allNodes, id);
+    if (node?.isDir) {
+      // Load if not yet loaded, or if previous load errored (allow retry)
+      if (!dirContents.has(id) || errorPaths.has(id)) {
+        loadDirectory(id);
+      }
+    }
+  },
+  [rootNodes, dirContents, loadDirectory, searchResults, errorPaths]
+);
+```
+
+2. Confirm `node.id` for subdirectories is set to the full relative path from the root (e.g., `src/components/sessions`), not just the name. In `fileNodeToTreeNode`:
+
+```typescript
+id: fn.path || fn.name,
+```
+
+`fn.path` comes from the backend as `filepath.ToSlash(relPath)` — the relative path from the workspace root. This is correct. The `loadDirectory` call passes this path directly to `fetchDirectoryFiles`.
+
+**Validation:**
+- Expand `src`, then expand `src/components` within it — children load correctly
+- Expanding a directory that previously errored shows a retry attempt
+
+---
+
+### Task 3.1: Fix GetLogs to resolve session log path by Title when given UUID
+
+**Objective:** When `GetLogs` is called with a UUID, look up the session's Title and use that to find the log file, since logs are written keyed by Title.
+
+**Files to modify:**
+- `server/services/utility_service.go`
+- `server/services/workspace_service.go`
+
+**Implementation steps:**
+
+1. Add a `ResolveTitleByID` method to `WorkspaceService` (or a shared helper) that accepts either a UUID or Title and returns the session's Title:
+
+```go
+// ResolveTitleByID looks up an instance by UUID or Title and returns its Title.
+// Returns empty string if not found.
+func (ws *WorkspaceService) ResolveTitleByID(id string) string {
+    instances, err := ws.storage.LoadInstances()
+    if err != nil {
+        return ""
+    }
+    for _, inst := range instances {
+        if inst.Title == id || inst.GetStableID() == id {
+            return inst.Title
+        }
+    }
+    return ""
+}
+```
+
+2. Inject `WorkspaceService` (or a `TitleResolver` interface) into `UtilityService`:
+
+```go
+type TitleResolver interface {
+    ResolveTitleByID(id string) string
+}
+
+type UtilityService struct {
+    approvalStore     *ApprovalStore
+    reviewQueuePoller *session.ReviewQueuePoller
+    titleResolver     TitleResolver  // optional; nil = no resolution
+}
+```
+
+3. In `GetLogs`, when `sid` is non-empty, resolve it to a Title before building the log path:
+
+```go
+if sid := req.Msg.GetSessionId(); sid != "" {
+    // Resolve UUID to Title for log file naming (logs are written with Title as key)
+    resolvedID := sid
+    if us.titleResolver != nil {
+        if title := us.titleResolver.ResolveTitleByID(sid); title != "" {
+            resolvedID = title
+        }
+    }
+    logFilePath, err = log.GetSessionLogFilePath(cfg, resolvedID)
+}
+```
+
+4. Wire `WorkspaceService` as the `TitleResolver` in `server/server.go` (or wherever `UtilityService` is constructed).
+
+**Alternative simpler approach:** Since `UtilityService` already has access to `reviewQueuePoller`, use it directly instead of adding a new interface:
+
+```go
+if sid := req.Msg.GetSessionId(); sid != "" {
+    resolvedID := sid
+    if us.reviewQueuePoller != nil {
+        if inst := us.reviewQueuePoller.FindInstance(sid); inst != nil {
+            resolvedID = inst.Title  // log files always written with Title
+        }
+    }
+    logFilePath, err = log.GetSessionLogFilePath(cfg, resolvedID)
+}
+```
+
+The `reviewQueuePoller` is already set via `SetReviewQueuePoller`. This approach adds zero new dependencies and is the minimal change.
+
+**Validation:**
+- Open Logs tab for a session that has had git activity; log entries appear
+- `go test ./server/services/ -run TestGetLogs` passes with UUID input
+
+---
+
+### Task 3.2 (Optional Improvement): Write session logs using GetStableID
+
+**Objective:** If a future goal is to query logs by UUID directly (no Title resolution step), log files should be written using `GetStableID()` instead of `Title`. This is a follow-on improvement, not required for the current fix.
+
+**Note:** This would require migrating existing log files, which is out of scope for this plan. Document as a known technical debt item.
+
+---
+
+## Dependency Visualization
+
+```
+Task 1.1 (WorkspaceService.findInstance UUID fix)
+  |
+  +-- Task 1.3 (GitHubService.findInstance) [independent, same pattern]
+  |
+  +-- Task 1.2 (GetSessionDiff UUID fix) [independent, same pattern]
+
+Task 2.1 (FileTree children: undefined)
+  |
+  +-- Task 2.2 (handleToggle retry logic) [depends on 2.1 for toggle to fire]
+
+Task 3.1 (GetLogs UUID resolution)
+  -- independent, uses existing reviewQueuePoller
+```
+
+Tasks 1.x, 2.x, and 3.x are completely independent of each other and can be worked in parallel.
+
+---
+
+## Known Issues and Potential Bugs
+
+### Bug 1: GetSessionDiff Uses loadInstancesWithWiring — Potential Session Restart Side Effect [SEVERITY: Medium]
+
+**Description:** `GetSessionDiff` calls `s.loadInstancesWithWiring()` to find the instance. This method loads from storage and may call `Start()` on sessions that are not in the Paused state. For the diff fix, the correct approach is to use the live in-memory poller (`s.findInstance`), just as `GetSession` does. The current fix (Task 1.2) patches the matching condition but does not address the underlying `loadInstancesWithWiring` call.
+
+**Mitigation:**
+- File a follow-up task to refactor `GetSessionDiff` to use `s.findInstance` (poller-backed)
+- The `loadInstancesWithWiring` issue is pre-existing and not introduced by the UUID fix
+
+**Files Likely Affected:**
+- `server/services/session_service.go` (~line 1235)
+
+---
+
+### Bug 2: Session Logs May Be Sparse Even After Fix [SEVERITY: Low]
+
+**Description:** Even with the UUID-to-Title resolution fixed, the Logs tab may show very few entries. `LogForSession(inst.Title, ...)` is only called from `review_queue_poller.go` in one place (line 660, a git check warning). Most session activity is written to the global log file. The Logs tab UI implies per-session logs, but the actual logging coverage is minimal.
+
+**Mitigation:**
+- After Task 3.1, the Logs tab will correctly show what is there
+- A separate investigation should identify which events should be written to per-session logs and expand coverage
+- Consider adding log entries in `instance.go` at key lifecycle events (start, stop, prompt sent, response received)
+
+---
+
+### Bug 3: react-arborist onToggle May Not Fire for Empty Children Array [SEVERITY: High, for Task 2.1]
+
+**Description:** The exact behavior of `onToggle` when `childrenAccessor` returns `[]` depends on the react-arborist version (^3.4.3). In some versions, nodes with `children: []` are treated as collapsed leaves and no toggle fires. In others, the toggle fires but produces no visible change.
+
+**Mitigation:**
+- Test Task 2.1 change with the actual installed version before shipping
+- If `children: undefined` causes arborist to not render the expand arrow at all, the correct fix is to use `null` from `childrenAccessor` for unloaded dirs (which all arborist versions treat as "has children, not loaded"), and load on `onActivate` instead of `onToggle`
+- Add an explicit test in the browser for directory expand behavior
+
+---
+
+### Bug 4: WorkspaceService.findInstance Calls storage.LoadInstances — Performance Cost [SEVERITY: Low]
+
+**Description:** `WorkspaceService.findInstance` calls `storage.LoadInstances()` on every VCS status poll (every 10 seconds). This reads and parses the sessions JSON file each time. As the session count grows, this becomes noticeable. `SessionService.findInstance` correctly uses the in-memory poller.
+
+**Mitigation:**
+- For now, the fix in Task 1.1 maintains the existing storage-backed pattern
+- A follow-up task should inject the live poller into `WorkspaceService` and use it instead of `storage.LoadInstances()`
+
+---
+
+### Bug 5: File Content Cache Uses UUID as Key — Will Become Stale on Session Rename [SEVERITY: Low]
+
+**Description:** `useGetFileContent` in `useFileService.ts` caches results with key `${sessionId}:${filePath}`. Since `sessionId` is now the UUID (stable), this is actually better than using Title. No action needed.
+
+---
+
+## Files Modified Summary
+
+| File | Task | Change |
+|---|---|---|
+| `server/services/workspace_service.go` | 1.1, 3.1 | findInstance: add UUID match; add TitleResolver if taking that approach |
+| `server/services/session_service.go` | 1.2 | GetSessionDiff inline loop: add UUID match |
+| `server/services/github_service.go` | 1.3 | findInstance: add UUID match |
+| `server/services/utility_service.go` | 3.1 | GetLogs: resolve UUID to Title via poller |
+| `web-app/src/components/sessions/FileTree.tsx` | 2.1, 2.2 | buildTreeData: return undefined; handleToggle: retry on error |
+
+No proto changes required. No schema migrations required. No new dependencies required.
+
+---
+
+## Testing Validation
+
+### Manual Test Scenarios
+
+**VCS Diff Tab:**
+1. Open any session detail; click Diff tab
+2. Expected: unified diff renders (or "No changes" if clean)
+3. Failure before fix: "session not found" error or loading spinner never resolves
+
+**VCS Panel Tab:**
+1. Open any session detail; click VCS tab
+2. Expected: branch name, staged/unstaged file lists render
+3. Failure before fix: "No VCS information available" with underlying 404
+
+**Files Tab - Root Load:**
+1. Open any session detail; click Files tab
+2. Expected: root directory files and folders list
+3. Failure before fix: "Failed to load files" error
+
+**Files Tab - Folder Drill-Down:**
+1. Open Files tab; click a folder with children
+2. Expected: folder expands, children load, nested folders also expandable
+3. Failure before fix: folder does not expand on click
+
+**Files Tab - File Search:**
+1. Open Files tab; type 2+ characters in search box
+2. Expected: matching files highlighted in tree with count displayed
+3. Failure before fix: search errors or no results (depends on session ID resolution)
+
+**Logs Tab:**
+1. Open any session detail; click Logs tab
+2. Expected: log entries appear, or "No logs recorded" only if genuinely empty
+3. Failure before fix: always shows "No logs recorded" regardless of activity
+
+### Automated Test Coverage
+
+- `server/services/workspace_service_test.go` — add test for `findInstance` with UUID input
+- `server/services/session_service_test.go` — add test for `GetSessionDiff` with UUID input
+- `server/services/utility_service.go` — add test for `GetLogs` with UUID input resolving to Title
+- `web-app/src/components/sessions/__tests__/` — add test for FileTree toggle/expand behavior with unloaded dir nodes

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/project_plans/stapler-squad-mcp-server/decisions/ADR-005-mcp-injection-strategy.md
+++ b/project_plans/stapler-squad-mcp-server/decisions/ADR-005-mcp-injection-strategy.md
@@ -54,6 +54,7 @@ The binary path is resolved via `os.Executable()` at injection time, giving the 
 
 ## Alternatives Considered
 
+- **CLAUDE.md injection**: Considered writing MCP server instructions and configuration context into the session's `CLAUDE.md` file. Rejected — `CLAUDE.md` is a user-authored, repo-committed file that encodes project conventions and instructions; Stapler Squad should not modify it. Appending to it would pollute git history (unlike `settings.local.json`, which is `.gitignore`'d), risk overwriting or conflating user-written instructions, and create confusing diffs. MCP configuration is structured JSON, not natural language — it belongs in a config file, not an instruction file.
 - **Auto-inject into all new sessions regardless of source**: Rejected — modifies sessions the user did not explicitly opt in to. Violates the "don't affect existing ones unless the user explicitly wants it" requirement.
 - **Environment variable injection at tmux session start**: Considered (`CLAUDE_MCP_SERVERS=...`). Rejected — Claude Code does not support MCP configuration via environment variables as of 2026; only settings files are respected.
 - **Single global install automatically at stapler-squad startup**: Rejected — too broad; affects sessions outside Stapler Squad's scope and cannot be scoped to specific sessions.

--- a/server/mcp/tools_discovery.go
+++ b/server/mcp/tools_discovery.go
@@ -167,7 +167,7 @@ func (d *discoveryHandlers) getSession(ctx context.Context, req mcpgo.CallToolRe
 	}
 
 	for _, inst := range instances {
-		if inst.Title == sessionID {
+		if inst.MatchesID(sessionID) {
 			detail := instanceToDetail(inst)
 			return okResult(GetSessionResult{
 				MCPResult: MCPResult{Success: true},

--- a/server/mcp/tools_lifecycle.go
+++ b/server/mcp/tools_lifecycle.go
@@ -311,7 +311,7 @@ func (lh *lifecycleHandlers) stopSession(ctx context.Context, req mcpgo.CallTool
 	var inst *session.Instance
 	var idx int
 	for i, candidate := range instances {
-		if candidate.Title == sessionID {
+		if candidate.MatchesID(sessionID) {
 			inst = candidate
 			idx = i
 			break
@@ -356,7 +356,7 @@ func (lh *lifecycleHandlers) updateSession(ctx context.Context, req mcpgo.CallTo
 	var inst *session.Instance
 	var idx int
 	for i, candidate := range instances {
-		if candidate.Title == sessionID {
+		if candidate.MatchesID(sessionID) {
 			inst = candidate
 			idx = i
 			break
@@ -419,7 +419,7 @@ func (lh *lifecycleHandlers) findAndHydrate(sessionID string) (*session.Instance
 	}
 
 	for i, inst := range instances {
-		if inst.Title == sessionID {
+		if inst.MatchesID(sessionID) {
 			if !inst.Started() && inst.Status != session.Paused {
 				if startErr := inst.Start(false); startErr != nil {
 					return nil, nil, 0, errResult(ErrInternalError,

--- a/server/mcp/tools_terminal.go
+++ b/server/mcp/tools_terminal.go
@@ -170,7 +170,7 @@ func (th *terminalHandlers) readSessionOutput(_ context.Context, req mcpgo.CallT
 	}
 	found := false
 	for _, inst := range instances {
-		if inst.Title == sessionID {
+		if inst.MatchesID(sessionID) {
 			found = true
 			break
 		}
@@ -378,7 +378,7 @@ func (th *terminalHandlers) waitForOutput(_ context.Context, req mcpgo.CallToolR
 	}
 	found := false
 	for _, inst := range instances {
-		if inst.Title == sessionID {
+		if inst.MatchesID(sessionID) {
 			found = true
 			break
 		}
@@ -595,7 +595,7 @@ func (th *terminalHandlers) findInstance(sessionID string) (*session.Instance, *
 		return nil, errResult(ErrInternalError, "failed to load sessions", "")
 	}
 	for _, inst := range instances {
-		if inst.Title == sessionID {
+		if inst.MatchesID(sessionID) {
 			return inst, nil
 		}
 	}

--- a/server/mcp/tools_vcs.go
+++ b/server/mcp/tools_vcs.go
@@ -160,7 +160,7 @@ func (vh *vcsHandlers) findInstance(sessionID string) (*session.Instance, *mcpgo
 		return nil, errResult(ErrInternalError, "failed to load sessions", "")
 	}
 	for _, inst := range instances {
-		if inst.Title == sessionID {
+		if inst.MatchesID(sessionID) {
 			return inst, nil
 		}
 	}

--- a/server/services/connectrpc_websocket.go
+++ b/server/services/connectrpc_websocket.go
@@ -220,7 +220,7 @@ func (h *ConnectRPCWebSocketHandler) resolveSession(sessionID string) (*session.
 		// Try to find by session title/ID first
 		sessions := h.externalDiscovery.GetSessions()
 		for _, inst := range sessions {
-			if inst.Title == sessionID || inst.GetStableID() == sessionID {
+			if inst.MatchesID(sessionID) {
 				log.InfoLog.Printf("[resolveSession] Found external session '%s' via ExternalDiscovery", sessionID)
 				return inst, true // External session
 			}

--- a/server/services/connectrpc_websocket_test.go
+++ b/server/services/connectrpc_websocket_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/tstapler/stapler-squad/server/protocol"
 
@@ -159,5 +161,478 @@ func TestSendEndStreamSuccessEnvelopeFormat(t *testing.T) {
 	flags := raw[0]
 	if flags&protocol.EndStreamFlag == 0 {
 		t.Errorf("EndStream flag (0x%02x) not set in first byte; got 0x%02x", protocol.EndStreamFlag, flags)
+	}
+}
+
+// --- sanitizeInitialContent ---
+
+// TestSanitizeInitialContentStripsPositioningCodes verifies that the ANSI sequences
+// that cause garbled rendering on replay are stripped from tmux capture-pane output.
+func TestSanitizeInitialContentStripsPositioningCodes(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "absolute cursor home ESC[H",
+			input: "\x1b[Hhello",
+			want:  "hello",
+		},
+		{
+			name:  "absolute cursor with coordinates ESC[5;10H",
+			input: "\x1b[5;10Hhello",
+			want:  "hello",
+		},
+		{
+			name:  "absolute cursor f-variant ESC[5;10f",
+			input: "\x1b[5;10fhello",
+			want:  "hello",
+		},
+		{
+			name:  "screen clear ESC[J (erase to end of screen)",
+			input: "\x1b[Jhello",
+			want:  "hello",
+		},
+		{
+			name:  "screen clear ESC[2J (full screen)",
+			input: "\x1b[2Jhello",
+			want:  "hello",
+		},
+		{
+			name:  "screen clear ESC[3J (scrollback)",
+			input: "\x1b[3Jhello",
+			want:  "hello",
+		},
+		{
+			name:  "alternate screen enter ESC[?1049h",
+			input: "\x1b[?1049hhello",
+			want:  "hello",
+		},
+		{
+			name:  "cursor hide ESC[?25l",
+			input: "\x1b[?25lhello",
+			want:  "hello",
+		},
+		{
+			name:  "DEC save cursor ESC7",
+			input: "\x1b7hello",
+			want:  "hello",
+		},
+		{
+			name:  "DEC restore cursor ESC8",
+			input: "\x1b8hello",
+			want:  "hello",
+		},
+		{
+			name:  "CSI save cursor ESC[s",
+			input: "\x1b[shello",
+			want:  "hello",
+		},
+		{
+			name:  "CSI restore cursor ESC[u",
+			input: "\x1b[uhello",
+			want:  "hello",
+		},
+		{
+			name:  "multiple positioning codes stripped",
+			input: "\x1b[H\x1b[2J\x1b[?1049hhello\x1b[H",
+			want:  "hello",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeInitialContent(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeInitialContent(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeInitialContentPreservesSGRColors verifies that SGR color sequences
+// (which are safe for replay) are intentionally NOT stripped.
+func TestSanitizeInitialContentPreservesSGRColors(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "SGR reset", input: "\x1b[0m"},
+		{name: "SGR bold", input: "\x1b[1m"},
+		{name: "SGR green fg", input: "\x1b[32m"},
+		{name: "SGR bold green", input: "\x1b[1;32m"},
+		{name: "SGR 256-color fg", input: "\x1b[38;5;123m"},
+		{name: "SGR truecolor", input: "\x1b[38;2;255;128;0m"},
+		{name: "SGR bg color", input: "\x1b[41m"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeInitialContent(tc.input)
+			if got != tc.input {
+				t.Errorf("sanitizeInitialContent(%q) unexpectedly changed SGR code to %q", tc.input, got)
+			}
+		})
+	}
+}
+
+// TestSanitizeInitialContentPreservesPlainText verifies that printable text
+// and newlines pass through unchanged.
+func TestSanitizeInitialContentPreservesPlainText(t *testing.T) {
+	cases := []string{
+		"",
+		"hello world",
+		"line1\nline2\r\nline3",
+		"  spaces and\ttabs",
+		"unicode: 日本語",
+	}
+
+	for _, input := range cases {
+		got := sanitizeInitialContent(input)
+		if got != input {
+			t.Errorf("sanitizeInitialContent(%q) = %q; want unchanged", input, got)
+		}
+	}
+}
+
+// TestSanitizeInitialContentRealWorldCapture exercises a realistic tmux capture-pane
+// output with mixed SGR colors and cursor positioning codes. The test verifies that
+// colors are kept and positioning codes are removed.
+func TestSanitizeInitialContentRealWorldCapture(t *testing.T) {
+	// Simulate tmux capture-pane -e output: colored prompt with cursor positioning
+	input := "\x1b[?1049h\x1b[H\x1b[2J\x1b[1;32m$\x1b[0m \x1b[1mcommand\x1b[0m\x1b[H"
+	got := sanitizeInitialContent(input)
+
+	// Positioning codes must be absent
+	positioningCodes := []string{"\x1b[?1049h", "\x1b[H", "\x1b[2J"}
+	for _, code := range positioningCodes {
+		if strings.Contains(got, code) {
+			t.Errorf("sanitizeInitialContent: positioning code %q still present in output %q", code, got)
+		}
+	}
+
+	// SGR codes must be preserved
+	sgrCodes := []string{"\x1b[1;32m", "\x1b[0m", "\x1b[1m"}
+	for _, code := range sgrCodes {
+		if !strings.Contains(got, code) {
+			t.Errorf("sanitizeInitialContent: SGR code %q missing from output %q", code, got)
+		}
+	}
+}
+
+// --- waitForQuiescence ---
+
+// TestWaitForQuiescenceReturnsAfterQuietPeriod verifies that waitForQuiescence
+// returns once no updates arrive for the quietFor duration.
+func TestWaitForQuiescenceReturnsAfterQuietPeriod(t *testing.T) {
+	updates := make(chan struct{}, 1)
+	start := time.Now()
+
+	// Send one update, then stop; quiescence should be detected after quietFor.
+	updates <- struct{}{}
+
+	waitForQuiescence(updates, 200*time.Millisecond, 30*time.Millisecond)
+
+	elapsed := time.Since(start)
+	if elapsed < 30*time.Millisecond {
+		t.Errorf("waitForQuiescence returned too quickly (%v); expected >= 30ms quiet window", elapsed)
+	}
+	if elapsed > 150*time.Millisecond {
+		t.Errorf("waitForQuiescence took too long (%v); expected ~30ms quiet period after last update", elapsed)
+	}
+}
+
+// TestWaitForQuiescenceReturnsOnTimeout verifies that waitForQuiescence returns
+// at the timeout even when updates keep arriving continuously.
+func TestWaitForQuiescenceReturnsOnTimeout(t *testing.T) {
+	updates := make(chan struct{}, 64)
+
+	// Continuously send updates from a goroutine to prevent quiescence.
+	// stopSender is closed by the outer function; the goroutine exits when it sees the signal.
+	stopSender := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stopSender:
+				return
+			default:
+				// Fill the buffer; ignore if full.
+				select {
+				case updates <- struct{}{}:
+				default:
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	start := time.Now()
+	timeout := 60 * time.Millisecond
+	waitForQuiescence(updates, timeout, 500*time.Millisecond)
+	elapsed := time.Since(start)
+	close(stopSender) // signal the sender goroutine to stop
+
+	if elapsed < timeout {
+		t.Errorf("waitForQuiescence returned before timeout (%v < %v)", elapsed, timeout)
+	}
+	if elapsed > timeout+50*time.Millisecond {
+		t.Errorf("waitForQuiescence took too long after timeout (%v)", elapsed)
+	}
+}
+
+// TestWaitForQuiescenceReturnsOnChannelClose verifies that closing the updates
+// channel causes waitForQuiescence to return promptly.
+func TestWaitForQuiescenceReturnsOnChannelClose(t *testing.T) {
+	updates := make(chan struct{})
+	close(updates)
+
+	start := time.Now()
+	waitForQuiescence(updates, time.Second, time.Second)
+	elapsed := time.Since(start)
+
+	if elapsed > 20*time.Millisecond {
+		t.Errorf("waitForQuiescence did not return promptly on closed channel (took %v)", elapsed)
+	}
+}
+
+// TestWaitForQuiescenceResetsTimerOnUpdates verifies that each incoming update
+// resets the quiet timer, delaying the return.
+func TestWaitForQuiescenceResetsTimerOnUpdates(t *testing.T) {
+	updates := make(chan struct{}, 4)
+	quietFor := 40 * time.Millisecond
+
+	// Send 3 updates spread 20ms apart; each should reset the 40ms quiet timer.
+	go func() {
+		for i := 0; i < 3; i++ {
+			time.Sleep(20 * time.Millisecond)
+			updates <- struct{}{}
+		}
+	}()
+
+	start := time.Now()
+	waitForQuiescence(updates, time.Second, quietFor)
+	elapsed := time.Since(start)
+
+	// 3 updates × 20ms + final 40ms quiet = ~100ms
+	if elapsed < 80*time.Millisecond {
+		t.Errorf("waitForQuiescence returned too early (%v); timer not being reset on updates", elapsed)
+	}
+}
+
+// --- getOrRefreshSnapshot / markSnapshotDirty ---
+
+// TestGetOrRefreshSnapshotCallsCaptureFnOnMiss verifies that on a cache miss
+// captureFn is called and the result is cached.
+func TestGetOrRefreshSnapshotCallsCaptureFnOnMiss(t *testing.T) {
+	h := NewConnectRPCWebSocketHandler(nil, nil, nil, "raw")
+	calls := 0
+	captureFn := func() (string, error) {
+		calls++
+		return "fresh content", nil
+	}
+
+	got, err := h.getOrRefreshSnapshot("sess1", captureFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "fresh content" {
+		t.Errorf("got %q, want %q", got, "fresh content")
+	}
+	if calls != 1 {
+		t.Errorf("captureFn called %d times, want 1", calls)
+	}
+}
+
+// TestGetOrRefreshSnapshotReturnsCacheOnHit verifies that a second call returns
+// the cached result without invoking captureFn again.
+func TestGetOrRefreshSnapshotReturnsCacheOnHit(t *testing.T) {
+	h := NewConnectRPCWebSocketHandler(nil, nil, nil, "raw")
+	calls := 0
+	captureFn := func() (string, error) {
+		calls++
+		return "content", nil
+	}
+
+	_, _ = h.getOrRefreshSnapshot("sess1", captureFn)
+	got, err := h.getOrRefreshSnapshot("sess1", captureFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "content" {
+		t.Errorf("got %q, want cached %q", got, "content")
+	}
+	if calls != 1 {
+		t.Errorf("captureFn called %d times on second hit, want 1", calls)
+	}
+}
+
+// TestGetOrRefreshSnapshotRefreshesOnDirty verifies that marking a snapshot dirty
+// causes the next getOrRefreshSnapshot call to invoke captureFn again.
+func TestGetOrRefreshSnapshotRefreshesOnDirty(t *testing.T) {
+	h := NewConnectRPCWebSocketHandler(nil, nil, nil, "raw")
+	calls := 0
+	captureFn := func() (string, error) {
+		calls++
+		return fmt.Sprintf("content%d", calls), nil
+	}
+
+	// Populate cache
+	_, _ = h.getOrRefreshSnapshot("sess1", captureFn)
+
+	// Mark dirty
+	h.markSnapshotDirty("sess1")
+
+	// Should re-invoke captureFn
+	got, err := h.getOrRefreshSnapshot("sess1", captureFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("captureFn called %d times after dirty, want 2", calls)
+	}
+	if got != "content2" {
+		t.Errorf("got %q after refresh, want %q", got, "content2")
+	}
+}
+
+// TestMarkSnapshotDirtyOnUnknownSessionIsNoOp verifies that marking an absent
+// session dirty does not panic or create a cache entry.
+func TestMarkSnapshotDirtyOnUnknownSessionIsNoOp(t *testing.T) {
+	h := NewConnectRPCWebSocketHandler(nil, nil, nil, "raw")
+
+	// Should not panic
+	h.markSnapshotDirty("nonexistent-session")
+
+	// Should not create an entry
+	if _, ok := h.snapshotCache["nonexistent-session"]; ok {
+		t.Error("markSnapshotDirty created a cache entry for an unknown session")
+	}
+}
+
+// TestGetOrRefreshSnapshotPropagatesCaptureFnError verifies that captureFn errors
+// are returned to the caller and nothing is cached.
+func TestGetOrRefreshSnapshotPropagatesCaptureFnError(t *testing.T) {
+	h := NewConnectRPCWebSocketHandler(nil, nil, nil, "raw")
+	captureErr := fmt.Errorf("tmux: session not found")
+	captureFn := func() (string, error) { return "", captureErr }
+
+	_, err := h.getOrRefreshSnapshot("sess1", captureFn)
+	if err == nil {
+		t.Fatal("expected error from captureFn, got nil")
+	}
+	if !strings.Contains(err.Error(), captureErr.Error()) {
+		t.Errorf("error %q does not contain %q", err.Error(), captureErr.Error())
+	}
+	if _, ok := h.snapshotCache["sess1"]; ok {
+		t.Error("cache entry created despite captureFn error")
+	}
+}
+
+// TestSnapshotCacheConcurrentAccess verifies that concurrent reads and
+// dirty-marking do not cause data races. Run with -race to validate.
+func TestSnapshotCacheConcurrentAccess(t *testing.T) {
+	h := NewConnectRPCWebSocketHandler(nil, nil, nil, "raw")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		sessionID := fmt.Sprintf("sess%d", i)
+		go func(id string) {
+			defer wg.Done()
+			_, _ = h.getOrRefreshSnapshot(id, func() (string, error) {
+				return "content", nil
+			})
+		}(sessionID)
+		go func(id string) {
+			defer wg.Done()
+			h.markSnapshotDirty(id)
+		}(sessionID)
+	}
+	wg.Wait()
+}
+
+// --- isAllowedOrigin ---
+
+func newRequestWithOrigin(origin string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	return r
+}
+
+// TestIsAllowedOriginNoHeader verifies that requests without an Origin header
+// (e.g. CLI tools, server-side callers) are allowed unconditionally.
+func TestIsAllowedOriginNoHeader(t *testing.T) {
+	r := newRequestWithOrigin("")
+	if !isAllowedOrigin(r) {
+		t.Error("request with no Origin header should be allowed")
+	}
+}
+
+// TestIsAllowedOriginLocalhostVariants verifies that all localhost forms are accepted.
+func TestIsAllowedOriginLocalhostVariants(t *testing.T) {
+	cases := []struct {
+		name   string
+		origin string
+	}{
+		{"localhost name", "http://localhost:3000"},
+		{"127.0.0.1", "http://127.0.0.1:8543"},
+		{"IPv6 loopback", "http://[::1]:8543"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRequestWithOrigin(tc.origin)
+			if !isAllowedOrigin(r) {
+				t.Errorf("origin %q should be allowed", tc.origin)
+			}
+		})
+	}
+}
+
+// TestIsAllowedOriginHTTPS verifies that any HTTPS origin is accepted
+// (auth enforcement is left to middleware).
+func TestIsAllowedOriginHTTPS(t *testing.T) {
+	cases := []string{
+		"https://myapp.example.com",
+		"https://company.internal:8443",
+		"https://staging.myapp.io",
+	}
+	for _, origin := range cases {
+		t.Run(origin, func(t *testing.T) {
+			r := newRequestWithOrigin(origin)
+			if !isAllowedOrigin(r) {
+				t.Errorf("HTTPS origin %q should be allowed", origin)
+			}
+		})
+	}
+}
+
+// TestIsAllowedOriginHTTPNonLocalhostBlocked verifies that plaintext HTTP origins
+// from non-localhost hosts are rejected to prevent CSRF from remote pages.
+func TestIsAllowedOriginHTTPNonLocalhostBlocked(t *testing.T) {
+	cases := []string{
+		"http://attacker.example.com",
+		"http://evil.com",
+		"http://192.168.1.100:3000",
+	}
+	for _, origin := range cases {
+		t.Run(origin, func(t *testing.T) {
+			r := newRequestWithOrigin(origin)
+			if isAllowedOrigin(r) {
+				t.Errorf("HTTP non-localhost origin %q should be blocked", origin)
+			}
+		})
+	}
+}
+
+// TestIsAllowedOriginMalformed verifies that a malformed Origin header is rejected.
+func TestIsAllowedOriginMalformed(t *testing.T) {
+	r := newRequestWithOrigin("not-a-url")
+	// url.Parse("not-a-url") does not return an error (it parses as a relative URL with no scheme).
+	// A relative URL has no scheme → not https → host is "" → not localhost → should be blocked.
+	if isAllowedOrigin(r) {
+		t.Error("malformed Origin 'not-a-url' should be blocked (no scheme, not localhost)")
 	}
 }

--- a/server/services/github_service.go
+++ b/server/services/github_service.go
@@ -26,6 +26,7 @@ func NewGitHubService(storage *session.Storage) *GitHubService {
 }
 
 // findInstance loads all instances from storage and returns the one matching id.
+// id may be either the session UUID or the legacy Title; both are accepted.
 // Returns CodeNotFound if not found.
 func (gs *GitHubService) findInstance(id string) (*session.Instance, error) {
 	instances, err := gs.storage.LoadInstances()
@@ -33,7 +34,7 @@ func (gs *GitHubService) findInstance(id string) (*session.Instance, error) {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", err))
 	}
 	for _, inst := range instances {
-		if inst.Title == id {
+		if inst.MatchesID(id) {
 			return inst, nil
 		}
 	}

--- a/server/services/review_queue_service.go
+++ b/server/services/review_queue_service.go
@@ -153,7 +153,7 @@ func (rqs *ReviewQueueService) AcknowledgeSession(
 	var instance *session.Instance
 	var instanceIndex int
 	for i, inst := range instances {
-		if inst.Title == req.Msg.Id {
+		if inst.MatchesID(req.Msg.Id) {
 			instance = inst
 			instanceIndex = i
 			break

--- a/server/services/session_service.go
+++ b/server/services/session_service.go
@@ -474,9 +474,9 @@ func (s *SessionService) GetSession(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", err))
 	}
 
-	// Find instance by ID (using Title as ID)
+	// Find instance by ID (UUID or legacy Title).
 	for _, inst := range instances {
-		if inst.Title == req.Msg.Id {
+		if inst.MatchesID(req.Msg.Id) {
 			return connect.NewResponse(&sessionv1.GetSessionResponse{
 				Session: adapters.InstanceToProto(inst),
 			}), nil
@@ -669,7 +669,7 @@ func (s *SessionService) UpdateSession(
 	var instance *session.Instance
 	var instanceIndex int
 	for i, inst := range instances {
-		if inst.Title == req.Msg.Id {
+		if inst.MatchesID(req.Msg.Id) {
 			instance = inst
 			instanceIndex = i
 			break
@@ -803,7 +803,7 @@ func (s *SessionService) DeleteSession(
 	// Find the instance to delete
 	var instance *session.Instance
 	for _, inst := range instances {
-		if inst.Title == req.Msg.Id {
+		if inst.MatchesID(req.Msg.Id) {
 			instance = inst
 			break
 		}
@@ -964,7 +964,7 @@ func (s *SessionService) StreamTerminal(
 			return connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", err))
 		}
 		for _, inst := range instances {
-			if inst.Title == initialMsg.SessionId {
+			if inst.MatchesID(initialMsg.SessionId) {
 				instance = inst
 				break
 			}
@@ -1458,7 +1458,7 @@ func (s *SessionService) RenameSession(
 	var instance *session.Instance
 	var instanceIndex int
 	for i, inst := range instances {
-		if inst.Title == req.Msg.Id {
+		if inst.MatchesID(req.Msg.Id) {
 			instance = inst
 			instanceIndex = i
 			break
@@ -1529,7 +1529,7 @@ func (s *SessionService) RestartSession(
 	var instance *session.Instance
 	var instanceIndex int
 	for i, inst := range instances {
-		if inst.Title == req.Msg.Id {
+		if inst.MatchesID(req.Msg.Id) {
 			instance = inst
 			instanceIndex = i
 			break

--- a/server/services/session_service.go
+++ b/server/services/session_service.go
@@ -1232,20 +1232,7 @@ func (s *SessionService) GetSessionDiff(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("session id is required"))
 	}
 
-	instances, err := s.loadInstancesWithWiring()
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", err))
-	}
-
-	// Find instance by ID (UUID or legacy Title).
-	var instance *session.Instance
-	for _, inst := range instances {
-		if inst.MatchesID(req.Msg.Id) {
-			instance = inst
-			break
-		}
-	}
-
+	instance := s.findInstance(req.Msg.Id)
 	if instance == nil {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("session not found: %s", req.Msg.Id))
 	}

--- a/server/services/session_service.go
+++ b/server/services/session_service.go
@@ -1237,10 +1237,10 @@ func (s *SessionService) GetSessionDiff(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", err))
 	}
 
-	// Find instance by ID (using Title as ID)
+	// Find instance by ID (UUID or legacy Title).
 	var instance *session.Instance
 	for _, inst := range instances {
-		if inst.Title == req.Msg.Id {
+		if inst.MatchesID(req.Msg.Id) {
 			instance = inst
 			break
 		}

--- a/server/services/session_service_fork_test.go
+++ b/server/services/session_service_fork_test.go
@@ -208,3 +208,70 @@ func TestForkSession_Success(t *testing.T) {
 	require.NotNil(t, resp.Msg.Session)
 	assert.Equal(t, "forked", resp.Msg.Session.Title)
 }
+
+// --------------------------------------------------------------------------
+// GetSessionDiff – UUID ID lookup (regression: frontend passes UUIDs)
+// --------------------------------------------------------------------------
+
+// TestGetSessionDiff_FindsByUUID verifies that GetSessionDiff resolves the
+// incoming session ID via UUID using the ReviewQueuePoller's MatchesID check.
+// Before the fix, only Title was matched, so UUID callers got CodeNotFound.
+func TestGetSessionDiff_FindsByUUID(t *testing.T) {
+	fix := setupForkTestFixture(t)
+	t.Cleanup(fix.cleanup)
+
+	const testUUID = "22222222-2222-2222-2222-222222222222"
+	addInstanceToPoller(fix.poller, &session.Instance{
+		UUID:    testUUID,
+		Title:   "diff-session",
+		Path:    "/tmp/test-diff",
+		Status:  session.Running,
+		Program: "claude",
+	})
+
+	resp, err := fix.svc.GetSessionDiff(context.Background(), connect.NewRequest(&sessionv1.GetSessionDiffRequest{
+		Id: testUUID,
+	}))
+
+	// Must NOT return CodeNotFound. /tmp/test-diff is not a git repo, so the
+	// diff will be empty — but the session must be found by UUID.
+	require.NoError(t, err, "GetSessionDiff should find the session by UUID")
+	require.NotNil(t, resp)
+}
+
+// TestGetSessionDiff_FindsByTitle verifies that legacy Title-based lookups
+// still work after the UUID migration.
+func TestGetSessionDiff_FindsByTitle(t *testing.T) {
+	fix := setupForkTestFixture(t)
+	t.Cleanup(fix.cleanup)
+
+	addInstanceToPoller(fix.poller, &session.Instance{
+		Title:   "diff-by-title",
+		Path:    "/tmp/test-diff-title",
+		Status:  session.Running,
+		Program: "claude",
+	})
+
+	resp, err := fix.svc.GetSessionDiff(context.Background(), connect.NewRequest(&sessionv1.GetSessionDiffRequest{
+		Id: "diff-by-title",
+	}))
+
+	require.NoError(t, err, "GetSessionDiff should still find the session by Title")
+	require.NotNil(t, resp)
+}
+
+// TestGetSessionDiff_UnknownIDReturnsNotFound verifies that an ID matching no
+// session UUID or Title produces CodeNotFound.
+func TestGetSessionDiff_UnknownIDReturnsNotFound(t *testing.T) {
+	fix := setupForkTestFixture(t)
+	t.Cleanup(fix.cleanup)
+
+	_, err := fix.svc.GetSessionDiff(context.Background(), connect.NewRequest(&sessionv1.GetSessionDiffRequest{
+		Id: "no-such-session",
+	}))
+
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.ErrorAs(t, err, &connectErr)
+	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
+}

--- a/server/services/terminal_websocket.go
+++ b/server/services/terminal_websocket.go
@@ -56,7 +56,7 @@ func (h *TerminalWebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *htt
 
 	var instance *session.Instance
 	for _, inst := range instances {
-		if inst.Title == sessionID {
+		if inst.MatchesID(sessionID) {
 			instance = inst
 			break
 		}

--- a/server/services/utility_service.go
+++ b/server/services/utility_service.go
@@ -57,7 +57,16 @@ func (us *UtilityService) GetLogs(
 	var logFilePath string
 	var err error
 	if sid := req.Msg.GetSessionId(); sid != "" {
-		logFilePath, err = log.GetSessionLogFilePath(cfg, sid)
+		// Log files are written using inst.Title as the key (not UUID).
+		// Resolve the incoming ID (which may be a UUID) to the session Title
+		// before constructing the log file path.
+		resolvedID := sid
+		if us.reviewQueuePoller != nil {
+			if inst := us.reviewQueuePoller.FindInstance(sid); inst != nil {
+				resolvedID = inst.Title
+			}
+		}
+		logFilePath, err = log.GetSessionLogFilePath(cfg, resolvedID)
 	} else {
 		logFilePath, err = log.GetLogFilePath(cfg)
 	}

--- a/server/services/utility_service_test.go
+++ b/server/services/utility_service_test.go
@@ -1,0 +1,148 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sessionv1 "github.com/tstapler/stapler-squad/gen/proto/go/session/v1"
+	"github.com/tstapler/stapler-squad/session"
+)
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+func setupUtilityService() *UtilityService {
+	return NewUtilityService(NewApprovalStore(""))
+}
+
+func setupUtilityServiceWithPollerFixture() (*UtilityService, *session.ReviewQueuePoller) {
+	svc := setupUtilityService()
+
+	queue := session.NewReviewQueue()
+	statusMgr := session.NewInstanceStatusManager()
+	poller := session.NewReviewQueuePoller(queue, statusMgr, nil)
+	svc.SetReviewQueuePoller(poller)
+
+	return svc, poller
+}
+
+// strPtr returns a pointer to s; used to set optional proto string fields.
+func strPtr(s string) *string { return &s }
+
+// --------------------------------------------------------------------------
+// GetLogs – nil poller (no session ID resolution available)
+// --------------------------------------------------------------------------
+
+// TestGetLogs_NoSessionID_NilPoller verifies that GetLogs with no session ID
+// and no poller returns an empty log list rather than an error.
+// (The global app log file may or may not exist; both outcomes are valid.)
+func TestGetLogs_NoSessionID_NilPoller(t *testing.T) {
+	svc := setupUtilityService()
+
+	resp, err := svc.GetLogs(context.Background(), connect.NewRequest(&sessionv1.GetLogsRequest{}))
+
+	// Either returns empty logs or errors if the log file is inaccessible.
+	// The important invariant: no panic, and if it errors it's not CodeNotFound.
+	if err != nil {
+		var connectErr *connect.Error
+		require.ErrorAs(t, err, &connectErr)
+		assert.NotEqual(t, connect.CodeNotFound, connectErr.Code(),
+			"no-session-id call must not return CodeNotFound")
+	} else {
+		require.NotNil(t, resp)
+	}
+}
+
+// --------------------------------------------------------------------------
+// GetLogs – UUID resolution via ReviewQueuePoller
+// --------------------------------------------------------------------------
+
+// TestGetLogs_WithUUID_NilPoller verifies that GetLogs does not crash or
+// return an unexpected error when the poller is nil and a UUID is passed.
+// The log file for that UUID won't exist, so the response is empty.
+func TestGetLogs_WithUUID_NilPoller(t *testing.T) {
+	svc := setupUtilityService()
+	// No poller wired — UUID is used as-is to look up the log file.
+
+	sid := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	resp, err := svc.GetLogs(context.Background(), connect.NewRequest(&sessionv1.GetLogsRequest{
+		SessionId: &sid,
+	}))
+
+	// No log file exists for this UUID → empty response, not an error.
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Msg.Entries)
+}
+
+// TestGetLogs_WithUUID_MatchingInstance verifies that GetLogs exercices the
+// UUID→Title resolution path when the poller has a matching instance.
+// The session's log file does not exist on disk, so the response is empty —
+// but the call must succeed (no crash, no error from the resolution logic).
+func TestGetLogs_WithUUID_MatchingInstance(t *testing.T) {
+	svc, poller := setupUtilityServiceWithPollerFixture()
+
+	const testUUID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	poller.SetInstances([]*session.Instance{
+		{
+			UUID:    testUUID,
+			Title:   "my-resolved-session",
+			Path:    "/tmp/test",
+			Status:  session.Running,
+			Program: "claude",
+		},
+	})
+
+	// The log file for "my-resolved-session" does not exist → empty response.
+	// The call must succeed: UUID is resolved to Title before path lookup.
+	resp, err := svc.GetLogs(context.Background(), connect.NewRequest(&sessionv1.GetLogsRequest{
+		SessionId: strPtr(testUUID),
+	}))
+
+	require.NoError(t, err, "GetLogs should succeed when UUID resolves to a known instance")
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Msg.Entries)
+}
+
+// TestGetLogs_WithUUID_NoMatchingInstance verifies that when no instance in
+// the poller matches the UUID, GetLogs falls back gracefully (uses the UUID
+// as-is for the log file path, returning empty logs rather than an error).
+func TestGetLogs_WithUUID_NoMatchingInstance(t *testing.T) {
+	svc, _ := setupUtilityServiceWithPollerFixture()
+	// Poller is wired but has no instances.
+
+	resp, err := svc.GetLogs(context.Background(), connect.NewRequest(&sessionv1.GetLogsRequest{
+		SessionId: strPtr("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+	}))
+
+	require.NoError(t, err, "GetLogs should not error when UUID has no matching instance")
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Msg.Entries)
+}
+
+// TestGetLogs_WithTitle_FindsLogByTitle verifies the baseline: passing a Title
+// (legacy behaviour) still works correctly after the UUID migration.
+func TestGetLogs_WithTitle_FindsLogByTitle(t *testing.T) {
+	svc, poller := setupUtilityServiceWithPollerFixture()
+
+	poller.SetInstances([]*session.Instance{
+		{
+			Title:   "title-session",
+			Path:    "/tmp/test",
+			Status:  session.Running,
+			Program: "claude",
+		},
+	})
+
+	resp, err := svc.GetLogs(context.Background(), connect.NewRequest(&sessionv1.GetLogsRequest{
+		SessionId: strPtr("title-session"),
+	}))
+
+	require.NoError(t, err, "GetLogs should accept a Title as session ID")
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Msg.Entries)
+}

--- a/server/services/workspace_service.go
+++ b/server/services/workspace_service.go
@@ -41,15 +41,16 @@ func NewWorkspaceService(storage *session.Storage, eventBus *events.EventBus) *W
 	return &WorkspaceService{storage: storage, eventBus: eventBus}
 }
 
-// findInstance loads instances from storage and returns the one with the given title.
-// Returns CodeNotFound if the session does not exist.
+// findInstance loads instances from storage and returns the one matching id.
+// id may be either the session UUID or the legacy Title; both are accepted.
+// Returns CodeNotFound if no matching session exists.
 func (ws *WorkspaceService) findInstance(id string) ([]*session.Instance, *session.Instance, error) {
 	instances, err := ws.storage.LoadInstances()
 	if err != nil {
 		return nil, nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", err))
 	}
 	for _, inst := range instances {
-		if inst.Title == id {
+		if inst.MatchesID(id) {
 			return instances, inst, nil
 		}
 	}

--- a/server/services/workspace_service_test.go
+++ b/server/services/workspace_service_test.go
@@ -240,7 +240,7 @@ func TestWorkspaceService_GetVCSStatus_FindsByUUID(t *testing.T) {
 		UUID:    testUUID,
 		Title:   "my-uuid-session",
 		Path:    "/tmp/test-workspace",
-		Status:  session.Running,
+		Status:  session.Paused, // Paused avoids tmux setup in LoadInstances (no CI tmux)
 		Program: "claude",
 	}))
 
@@ -263,7 +263,7 @@ func TestWorkspaceService_GetVCSStatus_FindsByTitle(t *testing.T) {
 	require.NoError(t, fix.storage.AddInstance(&session.Instance{
 		Title:   "title-only-session",
 		Path:    "/tmp/test-workspace",
-		Status:  session.Running,
+		Status:  session.Paused, // Paused avoids tmux setup in LoadInstances (no CI tmux)
 		Program: "claude",
 	}))
 

--- a/server/services/workspace_service_test.go
+++ b/server/services/workspace_service_test.go
@@ -223,3 +223,69 @@ func TestWorkspaceService_SwitchGuardIsPerSession(t *testing.T) {
 	// err == nil also means the guard did not trigger, which is the desired
 	// outcome: session B proceeded past the guard independently.
 }
+
+// --------------------------------------------------------------------------
+// UUID ID lookup tests (regression: frontend now passes UUIDs, not Titles)
+// --------------------------------------------------------------------------
+
+// TestWorkspaceService_GetVCSStatus_FindsByUUID verifies that GetVCSStatus
+// accepts a session UUID as the ID parameter. Before the UUID migration, only
+// the Title was accepted; now MatchesID checks both UUID and Title.
+func TestWorkspaceService_GetVCSStatus_FindsByUUID(t *testing.T) {
+	fix := setupWorkspaceTestFixture(t)
+	t.Cleanup(fix.cleanup)
+
+	const testUUID = "11111111-1111-1111-1111-111111111111"
+	require.NoError(t, fix.storage.AddInstance(&session.Instance{
+		UUID:    testUUID,
+		Title:   "my-uuid-session",
+		Path:    "/tmp/test-workspace",
+		Status:  session.Running,
+		Program: "claude",
+	}))
+
+	_, err := fix.svc.GetVCSStatus(context.Background(), connect.NewRequest(&sessionv1.GetVCSStatusRequest{
+		Id: testUUID,
+	}))
+
+	// Must NOT return CodeNotFound — UUID lookup must succeed.
+	// /tmp/test-workspace is not a VCS dir, so the response body may carry
+	// an error string, but the RPC itself returns nil.
+	require.NoError(t, err, "GetVCSStatus should find the session by UUID")
+}
+
+// TestWorkspaceService_GetVCSStatus_FindsByTitle verifies that the legacy
+// Title-based lookup still works after the UUID migration.
+func TestWorkspaceService_GetVCSStatus_FindsByTitle(t *testing.T) {
+	fix := setupWorkspaceTestFixture(t)
+	t.Cleanup(fix.cleanup)
+
+	require.NoError(t, fix.storage.AddInstance(&session.Instance{
+		Title:   "title-only-session",
+		Path:    "/tmp/test-workspace",
+		Status:  session.Running,
+		Program: "claude",
+	}))
+
+	_, err := fix.svc.GetVCSStatus(context.Background(), connect.NewRequest(&sessionv1.GetVCSStatusRequest{
+		Id: "title-only-session",
+	}))
+
+	require.NoError(t, err, "GetVCSStatus should still find the session by Title")
+}
+
+// TestWorkspaceService_GetVCSStatus_UnknownIDReturnsNotFound verifies that an
+// ID that matches neither UUID nor Title of any session returns CodeNotFound.
+func TestWorkspaceService_GetVCSStatus_UnknownIDReturnsNotFound(t *testing.T) {
+	fix := setupWorkspaceTestFixture(t)
+	t.Cleanup(fix.cleanup)
+
+	_, err := fix.svc.GetVCSStatus(context.Background(), connect.NewRequest(&sessionv1.GetVCSStatusRequest{
+		Id: "no-such-session",
+	}))
+
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.ErrorAs(t, err, &connectErr)
+	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
+}

--- a/session/ent/hook/hook.go
+++ b/session/ent/hook/hook.go
@@ -18,7 +18,7 @@ func (f ApprovalRuleFunc) Mutate(ctx context.Context, m ent.Mutation) (ent.Value
 	if mv, ok := m.(*ent.ApprovalRuleMutation); ok {
 		return f(ctx, mv)
 	}
-	return nil, fmt.Errorf("unexpected mutation type %T. expected *ent.ApprovalRuleMutation", m)
+	return nil, fmt.Errorf("unexpected mutation type %T. expect *ent.ApprovalRuleMutation", m)
 }
 
 // The ClassificationAnalyticsFunc type is an adapter to allow the use of ordinary
@@ -30,7 +30,7 @@ func (f ClassificationAnalyticsFunc) Mutate(ctx context.Context, m ent.Mutation)
 	if mv, ok := m.(*ent.ClassificationAnalyticsMutation); ok {
 		return f(ctx, mv)
 	}
-	return nil, fmt.Errorf("unexpected mutation type %T. expected *ent.ClassificationAnalyticsMutation", m)
+	return nil, fmt.Errorf("unexpected mutation type %T. expect *ent.ClassificationAnalyticsMutation", m)
 }
 
 // The ClaudeMetadataFunc type is an adapter to allow the use of ordinary
@@ -42,7 +42,7 @@ func (f ClaudeMetadataFunc) Mutate(ctx context.Context, m ent.Mutation) (ent.Val
 	if mv, ok := m.(*ent.ClaudeMetadataMutation); ok {
 		return f(ctx, mv)
 	}
-	return nil, fmt.Errorf("unexpected mutation type %T. expected *ent.ClaudeMetadataMutation", m)
+	return nil, fmt.Errorf("unexpected mutation type %T. expect *ent.ClaudeMetadataMutation", m)
 }
 
 // The ClaudeSessionFunc type is an adapter to allow the use of ordinary
@@ -54,7 +54,7 @@ func (f ClaudeSessionFunc) Mutate(ctx context.Context, m ent.Mutation) (ent.Valu
 	if mv, ok := m.(*ent.ClaudeSessionMutation); ok {
 		return f(ctx, mv)
 	}
-	return nil, fmt.Errorf("unexpected mutation type %T. expected *ent.ClaudeSessionMutation", m)
+	return nil, fmt.Errorf("unexpected mutation type %T. expect *ent.ClaudeSessionMutation", m)
 }
 
 // The DiffStatsFunc type is an adapter to allow the use of ordinary
@@ -66,7 +66,7 @@ func (f DiffStatsFunc) Mutate(ctx context.Context, m ent.Mutation) (ent.Value, e
 	if mv, ok := m.(*ent.DiffStatsMutation); ok {
 		return f(ctx, mv)
 	}
-	return nil, fmt.Errorf("unexpected mutation type %T. expected *ent.DiffStatsMutation", m)
+	return nil, fmt.Errorf("unexpected mutation type %T. expect *ent.DiffStatsMutation", m)
 }
 
 // The SessionFunc type is an adapter to allow the use of ordinary
@@ -78,7 +78,7 @@ func (f SessionFunc) Mutate(ctx context.Context, m ent.Mutation) (ent.Value, err
 	if mv, ok := m.(*ent.SessionMutation); ok {
 		return f(ctx, mv)
 	}
-	return nil, fmt.Errorf("unexpected mutation type %T. expected *ent.SessionMutation", m)
+	return nil, fmt.Errorf("unexpected mutation type %T. expect *ent.SessionMutation", m)
 }
 
 // The TagFunc type is an adapter to allow the use of ordinary
@@ -90,7 +90,7 @@ func (f TagFunc) Mutate(ctx context.Context, m ent.Mutation) (ent.Value, error) 
 	if mv, ok := m.(*ent.TagMutation); ok {
 		return f(ctx, mv)
 	}
-	return nil, fmt.Errorf("unexpected mutation type %T. expected *ent.TagMutation", m)
+	return nil, fmt.Errorf("unexpected mutation type %T. expect *ent.TagMutation", m)
 }
 
 // The WorktreeFunc type is an adapter to allow the use of ordinary
@@ -102,7 +102,7 @@ func (f WorktreeFunc) Mutate(ctx context.Context, m ent.Mutation) (ent.Value, er
 	if mv, ok := m.(*ent.WorktreeMutation); ok {
 		return f(ctx, mv)
 	}
-	return nil, fmt.Errorf("unexpected mutation type %T. expected *ent.WorktreeMutation", m)
+	return nil, fmt.Errorf("unexpected mutation type %T. expect *ent.WorktreeMutation", m)
 }
 
 // Condition is a hook condition function.

--- a/session/ent/migrate/schema.go
+++ b/session/ent/migrate/schema.go
@@ -181,6 +181,7 @@ var (
 	SessionsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "title", Type: field.TypeString, Unique: true},
+		{Name: "uuid", Type: field.TypeString, Nullable: true},
 		{Name: "path", Type: field.TypeString},
 		{Name: "working_dir", Type: field.TypeString, Nullable: true},
 		{Name: "branch", Type: field.TypeString, Nullable: true},
@@ -218,27 +219,27 @@ var (
 			{
 				Name:    "session_status",
 				Unique:  false,
-				Columns: []*schema.Column{SessionsColumns[5]},
+				Columns: []*schema.Column{SessionsColumns[6]},
 			},
 			{
 				Name:    "session_category",
 				Unique:  false,
-				Columns: []*schema.Column{SessionsColumns[14]},
+				Columns: []*schema.Column{SessionsColumns[15]},
 			},
 			{
 				Name:    "session_last_meaningful_output",
 				Unique:  false,
-				Columns: []*schema.Column{SessionsColumns[19]},
+				Columns: []*schema.Column{SessionsColumns[20]},
 			},
 			{
 				Name:    "session_last_acknowledged",
 				Unique:  false,
-				Columns: []*schema.Column{SessionsColumns[23]},
+				Columns: []*schema.Column{SessionsColumns[24]},
 			},
 			{
 				Name:    "session_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{SessionsColumns[8]},
+				Columns: []*schema.Column{SessionsColumns[9]},
 			},
 		},
 	}

--- a/session/ent/mutation.go
+++ b/session/ent/mutation.go
@@ -5014,6 +5014,7 @@ type SessionMutation struct {
 	typ                    string
 	id                     *int
 	title                  *string
+	uuid                   *string
 	_path                  *string
 	working_dir            *string
 	branch                 *string
@@ -5186,6 +5187,55 @@ func (m *SessionMutation) OldTitle(ctx context.Context) (v string, err error) {
 // ResetTitle resets all changes to the "title" field.
 func (m *SessionMutation) ResetTitle() {
 	m.title = nil
+}
+
+// SetUUID sets the "uuid" field.
+func (m *SessionMutation) SetUUID(s string) {
+	m.uuid = &s
+}
+
+// UUID returns the value of the "uuid" field in the mutation.
+func (m *SessionMutation) UUID() (r string, exists bool) {
+	v := m.uuid
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUUID returns the old "uuid" field's value of the Session entity.
+// If the Session object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SessionMutation) OldUUID(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUUID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUUID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUUID: %w", err)
+	}
+	return oldValue.UUID, nil
+}
+
+// ClearUUID clears the value of the "uuid" field.
+func (m *SessionMutation) ClearUUID() {
+	m.uuid = nil
+	m.clearedFields[session.FieldUUID] = struct{}{}
+}
+
+// UUIDCleared returns if the "uuid" field was cleared in this mutation.
+func (m *SessionMutation) UUIDCleared() bool {
+	_, ok := m.clearedFields[session.FieldUUID]
+	return ok
+}
+
+// ResetUUID resets all changes to the "uuid" field.
+func (m *SessionMutation) ResetUUID() {
+	m.uuid = nil
+	delete(m.clearedFields, session.FieldUUID)
 }
 
 // SetPath sets the "path" field.
@@ -6442,9 +6492,12 @@ func (m *SessionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SessionMutation) Fields() []string {
-	fields := make([]string, 0, 23)
+	fields := make([]string, 0, 24)
 	if m.title != nil {
 		fields = append(fields, session.FieldTitle)
+	}
+	if m.uuid != nil {
+		fields = append(fields, session.FieldUUID)
 	}
 	if m._path != nil {
 		fields = append(fields, session.FieldPath)
@@ -6522,6 +6575,8 @@ func (m *SessionMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case session.FieldTitle:
 		return m.Title()
+	case session.FieldUUID:
+		return m.UUID()
 	case session.FieldPath:
 		return m.Path()
 	case session.FieldWorkingDir:
@@ -6577,6 +6632,8 @@ func (m *SessionMutation) OldField(ctx context.Context, name string) (ent.Value,
 	switch name {
 	case session.FieldTitle:
 		return m.OldTitle(ctx)
+	case session.FieldUUID:
+		return m.OldUUID(ctx)
 	case session.FieldPath:
 		return m.OldPath(ctx)
 	case session.FieldWorkingDir:
@@ -6636,6 +6693,13 @@ func (m *SessionMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetTitle(v)
+		return nil
+	case session.FieldUUID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUUID(v)
 		return nil
 	case session.FieldPath:
 		v, ok := value.(string)
@@ -6860,6 +6924,9 @@ func (m *SessionMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *SessionMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(session.FieldUUID) {
+		fields = append(fields, session.FieldUUID)
+	}
 	if m.FieldCleared(session.FieldWorkingDir) {
 		fields = append(fields, session.FieldWorkingDir)
 	}
@@ -6919,6 +6986,9 @@ func (m *SessionMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *SessionMutation) ClearField(name string) error {
 	switch name {
+	case session.FieldUUID:
+		m.ClearUUID()
+		return nil
 	case session.FieldWorkingDir:
 		m.ClearWorkingDir()
 		return nil
@@ -6974,6 +7044,9 @@ func (m *SessionMutation) ResetField(name string) error {
 	switch name {
 	case session.FieldTitle:
 		m.ResetTitle()
+		return nil
+	case session.FieldUUID:
+		m.ResetUUID()
 		return nil
 	case session.FieldPath:
 		m.ResetPath()

--- a/session/ent/runtime.go
+++ b/session/ent/runtime.go
@@ -127,29 +127,29 @@ func init() {
 	// session.TitleValidator is a validator for the "title" field. It is called by the builders before save.
 	session.TitleValidator = sessionDescTitle.Validators[0].(func(string) error)
 	// sessionDescPath is the schema descriptor for path field.
-	sessionDescPath := sessionFields[1].Descriptor()
+	sessionDescPath := sessionFields[2].Descriptor()
 	// session.PathValidator is a validator for the "path" field. It is called by the builders before save.
 	session.PathValidator = sessionDescPath.Validators[0].(func(string) error)
 	// sessionDescCreatedAt is the schema descriptor for created_at field.
-	sessionDescCreatedAt := sessionFields[7].Descriptor()
+	sessionDescCreatedAt := sessionFields[8].Descriptor()
 	// session.DefaultCreatedAt holds the default value on creation for the created_at field.
 	session.DefaultCreatedAt = sessionDescCreatedAt.Default.(func() time.Time)
 	// sessionDescUpdatedAt is the schema descriptor for updated_at field.
-	sessionDescUpdatedAt := sessionFields[8].Descriptor()
+	sessionDescUpdatedAt := sessionFields[9].Descriptor()
 	// session.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	session.DefaultUpdatedAt = sessionDescUpdatedAt.Default.(func() time.Time)
 	// session.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	session.UpdateDefaultUpdatedAt = sessionDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// sessionDescAutoYes is the schema descriptor for auto_yes field.
-	sessionDescAutoYes := sessionFields[9].Descriptor()
+	sessionDescAutoYes := sessionFields[10].Descriptor()
 	// session.DefaultAutoYes holds the default value on creation for the auto_yes field.
 	session.DefaultAutoYes = sessionDescAutoYes.Default.(bool)
 	// sessionDescProgram is the schema descriptor for program field.
-	sessionDescProgram := sessionFields[11].Descriptor()
+	sessionDescProgram := sessionFields[12].Descriptor()
 	// session.ProgramValidator is a validator for the "program" field. It is called by the builders before save.
 	session.ProgramValidator = sessionDescProgram.Validators[0].(func(string) error)
 	// sessionDescIsExpanded is the schema descriptor for is_expanded field.
-	sessionDescIsExpanded := sessionFields[14].Descriptor()
+	sessionDescIsExpanded := sessionFields[15].Descriptor()
 	// session.DefaultIsExpanded holds the default value on creation for the is_expanded field.
 	session.DefaultIsExpanded = sessionDescIsExpanded.Default.(bool)
 	tagFields := schema.Tag{}.Fields()

--- a/session/ent/schema/session.go
+++ b/session/ent/schema/session.go
@@ -20,6 +20,9 @@ func (Session) Fields() []ent.Field {
 		field.String("title").
 			Unique().
 			NotEmpty(),
+		field.String("uuid").
+			Optional().
+			Comment("Stable unique identifier. Assigned at creation and preserved across restarts."),
 		field.String("path").
 			NotEmpty(),
 		field.String("working_dir").

--- a/session/ent/session.go
+++ b/session/ent/session.go
@@ -22,6 +22,8 @@ type Session struct {
 	ID int `json:"id,omitempty"`
 	// Title holds the value of the "title" field.
 	Title string `json:"title,omitempty"`
+	// Stable unique identifier. Assigned at creation and preserved across restarts.
+	UUID string `json:"uuid,omitempty"`
 	// Path holds the value of the "path" field.
 	Path string `json:"path,omitempty"`
 	// WorkingDir holds the value of the "working_dir" field.
@@ -138,7 +140,7 @@ func (*Session) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case session.FieldID, session.FieldStatus, session.FieldHeight, session.FieldWidth:
 			values[i] = new(sql.NullInt64)
-		case session.FieldTitle, session.FieldPath, session.FieldWorkingDir, session.FieldBranch, session.FieldPrompt, session.FieldProgram, session.FieldExistingWorktree, session.FieldCategory, session.FieldSessionType, session.FieldTmuxPrefix, session.FieldLastOutputSignature:
+		case session.FieldTitle, session.FieldUUID, session.FieldPath, session.FieldWorkingDir, session.FieldBranch, session.FieldPrompt, session.FieldProgram, session.FieldExistingWorktree, session.FieldCategory, session.FieldSessionType, session.FieldTmuxPrefix, session.FieldLastOutputSignature:
 			values[i] = new(sql.NullString)
 		case session.FieldCreatedAt, session.FieldUpdatedAt, session.FieldLastTerminalUpdate, session.FieldLastMeaningfulOutput, session.FieldLastAddedToQueue, session.FieldLastViewed, session.FieldLastAcknowledged:
 			values[i] = new(sql.NullTime)
@@ -168,6 +170,12 @@ func (_m *Session) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field title", values[i])
 			} else if value.Valid {
 				_m.Title = value.String
+			}
+		case session.FieldUUID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field uuid", values[i])
+			} else if value.Valid {
+				_m.UUID = value.String
 			}
 		case session.FieldPath:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -364,6 +372,9 @@ func (_m *Session) String() string {
 	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
 	builder.WriteString("title=")
 	builder.WriteString(_m.Title)
+	builder.WriteString(", ")
+	builder.WriteString("uuid=")
+	builder.WriteString(_m.UUID)
 	builder.WriteString(", ")
 	builder.WriteString("path=")
 	builder.WriteString(_m.Path)

--- a/session/ent/session/session.go
+++ b/session/ent/session/session.go
@@ -16,6 +16,8 @@ const (
 	FieldID = "id"
 	// FieldTitle holds the string denoting the title field in the database.
 	FieldTitle = "title"
+	// FieldUUID holds the string denoting the uuid field in the database.
+	FieldUUID = "uuid"
 	// FieldPath holds the string denoting the path field in the database.
 	FieldPath = "path"
 	// FieldWorkingDir holds the string denoting the working_dir field in the database.
@@ -102,6 +104,7 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldTitle,
+	FieldUUID,
 	FieldPath,
 	FieldWorkingDir,
 	FieldBranch,
@@ -172,6 +175,11 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 // ByTitle orders the results by the title field.
 func ByTitle(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTitle, opts...).ToFunc()
+}
+
+// ByUUID orders the results by the uuid field.
+func ByUUID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUUID, opts...).ToFunc()
 }
 
 // ByPath orders the results by the path field.

--- a/session/ent/session/where.go
+++ b/session/ent/session/where.go
@@ -60,6 +60,11 @@ func Title(v string) predicate.Session {
 	return predicate.Session(sql.FieldEQ(FieldTitle, v))
 }
 
+// UUID applies equality check predicate on the "uuid" field. It's identical to UUIDEQ.
+func UUID(v string) predicate.Session {
+	return predicate.Session(sql.FieldEQ(FieldUUID, v))
+}
+
 // Path applies equality check predicate on the "path" field. It's identical to PathEQ.
 func Path(v string) predicate.Session {
 	return predicate.Session(sql.FieldEQ(FieldPath, v))
@@ -233,6 +238,81 @@ func TitleEqualFold(v string) predicate.Session {
 // TitleContainsFold applies the ContainsFold predicate on the "title" field.
 func TitleContainsFold(v string) predicate.Session {
 	return predicate.Session(sql.FieldContainsFold(FieldTitle, v))
+}
+
+// UUIDEQ applies the EQ predicate on the "uuid" field.
+func UUIDEQ(v string) predicate.Session {
+	return predicate.Session(sql.FieldEQ(FieldUUID, v))
+}
+
+// UUIDNEQ applies the NEQ predicate on the "uuid" field.
+func UUIDNEQ(v string) predicate.Session {
+	return predicate.Session(sql.FieldNEQ(FieldUUID, v))
+}
+
+// UUIDIn applies the In predicate on the "uuid" field.
+func UUIDIn(vs ...string) predicate.Session {
+	return predicate.Session(sql.FieldIn(FieldUUID, vs...))
+}
+
+// UUIDNotIn applies the NotIn predicate on the "uuid" field.
+func UUIDNotIn(vs ...string) predicate.Session {
+	return predicate.Session(sql.FieldNotIn(FieldUUID, vs...))
+}
+
+// UUIDGT applies the GT predicate on the "uuid" field.
+func UUIDGT(v string) predicate.Session {
+	return predicate.Session(sql.FieldGT(FieldUUID, v))
+}
+
+// UUIDGTE applies the GTE predicate on the "uuid" field.
+func UUIDGTE(v string) predicate.Session {
+	return predicate.Session(sql.FieldGTE(FieldUUID, v))
+}
+
+// UUIDLT applies the LT predicate on the "uuid" field.
+func UUIDLT(v string) predicate.Session {
+	return predicate.Session(sql.FieldLT(FieldUUID, v))
+}
+
+// UUIDLTE applies the LTE predicate on the "uuid" field.
+func UUIDLTE(v string) predicate.Session {
+	return predicate.Session(sql.FieldLTE(FieldUUID, v))
+}
+
+// UUIDContains applies the Contains predicate on the "uuid" field.
+func UUIDContains(v string) predicate.Session {
+	return predicate.Session(sql.FieldContains(FieldUUID, v))
+}
+
+// UUIDHasPrefix applies the HasPrefix predicate on the "uuid" field.
+func UUIDHasPrefix(v string) predicate.Session {
+	return predicate.Session(sql.FieldHasPrefix(FieldUUID, v))
+}
+
+// UUIDHasSuffix applies the HasSuffix predicate on the "uuid" field.
+func UUIDHasSuffix(v string) predicate.Session {
+	return predicate.Session(sql.FieldHasSuffix(FieldUUID, v))
+}
+
+// UUIDIsNil applies the IsNil predicate on the "uuid" field.
+func UUIDIsNil() predicate.Session {
+	return predicate.Session(sql.FieldIsNull(FieldUUID))
+}
+
+// UUIDNotNil applies the NotNil predicate on the "uuid" field.
+func UUIDNotNil() predicate.Session {
+	return predicate.Session(sql.FieldNotNull(FieldUUID))
+}
+
+// UUIDEqualFold applies the EqualFold predicate on the "uuid" field.
+func UUIDEqualFold(v string) predicate.Session {
+	return predicate.Session(sql.FieldEqualFold(FieldUUID, v))
+}
+
+// UUIDContainsFold applies the ContainsFold predicate on the "uuid" field.
+func UUIDContainsFold(v string) predicate.Session {
+	return predicate.Session(sql.FieldContainsFold(FieldUUID, v))
 }
 
 // PathEQ applies the EQ predicate on the "path" field.

--- a/session/ent/session_create.go
+++ b/session/ent/session_create.go
@@ -32,6 +32,20 @@ func (_c *SessionCreate) SetTitle(v string) *SessionCreate {
 	return _c
 }
 
+// SetUUID sets the "uuid" field.
+func (_c *SessionCreate) SetUUID(v string) *SessionCreate {
+	_c.mutation.SetUUID(v)
+	return _c
+}
+
+// SetNillableUUID sets the "uuid" field if the given value is not nil.
+func (_c *SessionCreate) SetNillableUUID(v *string) *SessionCreate {
+	if v != nil {
+		_c.SetUUID(*v)
+	}
+	return _c
+}
+
 // SetPath sets the "path" field.
 func (_c *SessionCreate) SetPath(v string) *SessionCreate {
 	_c.mutation.SetPath(v)
@@ -513,6 +527,10 @@ func (_c *SessionCreate) createSpec() (*Session, *sqlgraph.CreateSpec) {
 		_spec.SetField(session.FieldTitle, field.TypeString, value)
 		_node.Title = value
 	}
+	if value, ok := _c.mutation.UUID(); ok {
+		_spec.SetField(session.FieldUUID, field.TypeString, value)
+		_node.UUID = value
+	}
 	if value, ok := _c.mutation.Path(); ok {
 		_spec.SetField(session.FieldPath, field.TypeString, value)
 		_node.Path = value
@@ -726,6 +744,24 @@ func (u *SessionUpsert) SetTitle(v string) *SessionUpsert {
 // UpdateTitle sets the "title" field to the value that was provided on create.
 func (u *SessionUpsert) UpdateTitle() *SessionUpsert {
 	u.SetExcluded(session.FieldTitle)
+	return u
+}
+
+// SetUUID sets the "uuid" field.
+func (u *SessionUpsert) SetUUID(v string) *SessionUpsert {
+	u.Set(session.FieldUUID, v)
+	return u
+}
+
+// UpdateUUID sets the "uuid" field to the value that was provided on create.
+func (u *SessionUpsert) UpdateUUID() *SessionUpsert {
+	u.SetExcluded(session.FieldUUID)
+	return u
+}
+
+// ClearUUID clears the value of the "uuid" field.
+func (u *SessionUpsert) ClearUUID() *SessionUpsert {
+	u.SetNull(session.FieldUUID)
 	return u
 }
 
@@ -1145,6 +1181,27 @@ func (u *SessionUpsertOne) SetTitle(v string) *SessionUpsertOne {
 func (u *SessionUpsertOne) UpdateTitle() *SessionUpsertOne {
 	return u.Update(func(s *SessionUpsert) {
 		s.UpdateTitle()
+	})
+}
+
+// SetUUID sets the "uuid" field.
+func (u *SessionUpsertOne) SetUUID(v string) *SessionUpsertOne {
+	return u.Update(func(s *SessionUpsert) {
+		s.SetUUID(v)
+	})
+}
+
+// UpdateUUID sets the "uuid" field to the value that was provided on create.
+func (u *SessionUpsertOne) UpdateUUID() *SessionUpsertOne {
+	return u.Update(func(s *SessionUpsert) {
+		s.UpdateUUID()
+	})
+}
+
+// ClearUUID clears the value of the "uuid" field.
+func (u *SessionUpsertOne) ClearUUID() *SessionUpsertOne {
+	return u.Update(func(s *SessionUpsert) {
+		s.ClearUUID()
 	})
 }
 
@@ -1790,6 +1847,27 @@ func (u *SessionUpsertBulk) SetTitle(v string) *SessionUpsertBulk {
 func (u *SessionUpsertBulk) UpdateTitle() *SessionUpsertBulk {
 	return u.Update(func(s *SessionUpsert) {
 		s.UpdateTitle()
+	})
+}
+
+// SetUUID sets the "uuid" field.
+func (u *SessionUpsertBulk) SetUUID(v string) *SessionUpsertBulk {
+	return u.Update(func(s *SessionUpsert) {
+		s.SetUUID(v)
+	})
+}
+
+// UpdateUUID sets the "uuid" field to the value that was provided on create.
+func (u *SessionUpsertBulk) UpdateUUID() *SessionUpsertBulk {
+	return u.Update(func(s *SessionUpsert) {
+		s.UpdateUUID()
+	})
+}
+
+// ClearUUID clears the value of the "uuid" field.
+func (u *SessionUpsertBulk) ClearUUID() *SessionUpsertBulk {
+	return u.Update(func(s *SessionUpsert) {
+		s.ClearUUID()
 	})
 }
 

--- a/session/ent/session_update.go
+++ b/session/ent/session_update.go
@@ -46,6 +46,26 @@ func (_u *SessionUpdate) SetNillableTitle(v *string) *SessionUpdate {
 	return _u
 }
 
+// SetUUID sets the "uuid" field.
+func (_u *SessionUpdate) SetUUID(v string) *SessionUpdate {
+	_u.mutation.SetUUID(v)
+	return _u
+}
+
+// SetNillableUUID sets the "uuid" field if the given value is not nil.
+func (_u *SessionUpdate) SetNillableUUID(v *string) *SessionUpdate {
+	if v != nil {
+		_u.SetUUID(*v)
+	}
+	return _u
+}
+
+// ClearUUID clears the value of the "uuid" field.
+func (_u *SessionUpdate) ClearUUID() *SessionUpdate {
+	_u.mutation.ClearUUID()
+	return _u
+}
+
 // SetPath sets the "path" field.
 func (_u *SessionUpdate) SetPath(v string) *SessionUpdate {
 	_u.mutation.SetPath(v)
@@ -630,6 +650,12 @@ func (_u *SessionUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.Title(); ok {
 		_spec.SetField(session.FieldTitle, field.TypeString, value)
 	}
+	if value, ok := _u.mutation.UUID(); ok {
+		_spec.SetField(session.FieldUUID, field.TypeString, value)
+	}
+	if _u.mutation.UUIDCleared() {
+		_spec.ClearField(session.FieldUUID, field.TypeString)
+	}
 	if value, ok := _u.mutation.Path(); ok {
 		_spec.SetField(session.FieldPath, field.TypeString, value)
 	}
@@ -910,6 +936,26 @@ func (_u *SessionUpdateOne) SetNillableTitle(v *string) *SessionUpdateOne {
 	if v != nil {
 		_u.SetTitle(*v)
 	}
+	return _u
+}
+
+// SetUUID sets the "uuid" field.
+func (_u *SessionUpdateOne) SetUUID(v string) *SessionUpdateOne {
+	_u.mutation.SetUUID(v)
+	return _u
+}
+
+// SetNillableUUID sets the "uuid" field if the given value is not nil.
+func (_u *SessionUpdateOne) SetNillableUUID(v *string) *SessionUpdateOne {
+	if v != nil {
+		_u.SetUUID(*v)
+	}
+	return _u
+}
+
+// ClearUUID clears the value of the "uuid" field.
+func (_u *SessionUpdateOne) ClearUUID() *SessionUpdateOne {
+	_u.mutation.ClearUUID()
 	return _u
 }
 
@@ -1526,6 +1572,12 @@ func (_u *SessionUpdateOne) sqlSave(ctx context.Context) (_node *Session, err er
 	}
 	if value, ok := _u.mutation.Title(); ok {
 		_spec.SetField(session.FieldTitle, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.UUID(); ok {
+		_spec.SetField(session.FieldUUID, field.TypeString, value)
+	}
+	if _u.mutation.UUIDCleared() {
+		_spec.ClearField(session.FieldUUID, field.TypeString)
 	}
 	if value, ok := _u.mutation.Path(); ok {
 		_spec.SetField(session.FieldPath, field.TypeString, value)

--- a/session/ent_repository.go
+++ b/session/ent_repository.go
@@ -108,7 +108,8 @@ func (r *EntRepository) Create(ctx context.Context, data InstanceData) error {
 		SetUpdatedAt(data.UpdatedAt).
 		SetAutoYes(data.AutoYes).
 		SetProgram(data.Program).
-		SetIsExpanded(data.IsExpanded)
+		SetIsExpanded(data.IsExpanded).
+		SetNillableUUID(nilIfEmpty(data.UUID))
 
 	// Set optional fields
 	if data.WorkingDir != "" {
@@ -284,7 +285,8 @@ func (r *EntRepository) Update(ctx context.Context, data InstanceData) error {
 		SetUpdatedAt(data.UpdatedAt).
 		SetAutoYes(data.AutoYes).
 		SetProgram(data.Program).
-		SetIsExpanded(data.IsExpanded)
+		SetIsExpanded(data.IsExpanded).
+		SetNillableUUID(nilIfEmpty(data.UUID))
 
 	// Update optional fields
 	if data.WorkingDir != "" {
@@ -709,10 +711,20 @@ func (r *EntRepository) Close() error {
 	return nil
 }
 
+// nilIfEmpty returns nil if s is empty, otherwise a pointer to s.
+// Used to pass optional string fields to Ent's SetNillable* builders.
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
 // sessionToInstanceData converts an Ent Session entity to InstanceData
 func (r *EntRepository) sessionToInstanceData(sess *ent.Session) *InstanceData {
 	data := &InstanceData{
 		Title:               sess.Title,
+		UUID:                sess.UUID,
 		Path:                sess.Path,
 		WorkingDir:          sess.WorkingDir,
 		Branch:              sess.Branch,

--- a/session/instance.go
+++ b/session/instance.go
@@ -874,6 +874,7 @@ func (i *Instance) start(firstTimeSetup bool, setupCleanup bool, cleanup *tmux.C
 	i.tmuxManager.ResetExitOnce()
 	i.tmuxManager.SetOnExitCallback(func(reason string) {
 		log.InfoLog.Printf("Instance '%s': unexpected exit detected via control mode (%s)", i.Title, reason)
+		log.ForSession(i.Title).Info("Session exited unexpectedly (reason: %s)", reason)
 		i.stateMutex.Lock()
 		if i.Status == Running || i.Status == Ready {
 			if err := i.transitionTo(Stopped); err != nil {
@@ -985,6 +986,7 @@ func (i *Instance) start(firstTimeSetup bool, setupCleanup bool, cleanup *tmux.C
 	i.stateMutex.Unlock()
 	i.started = true
 	i.fireLifecycleEvent(EventStarted, "")
+	log.ForSession(i.Title).Info("Session started (firstTimeSetup: %v)", firstTimeSetup)
 
 	// Start controller for new sessions only; loaded sessions are wired later by server.go.
 	if firstTimeSetup {
@@ -1378,6 +1380,7 @@ func (i *Instance) Pause() error {
 		return fmt.Errorf("failed to transition to Paused: %w", err)
 	}
 	i.stateMutex.Unlock()
+	log.ForSession(i.Title).Info("Session paused")
 	_ = clipboard.WriteAll(i.gitManager.GetBranchName())
 	return nil
 }
@@ -1460,6 +1463,7 @@ func (i *Instance) Resume() error {
 		return fmt.Errorf("failed to transition to Running on resume: %w", err)
 	}
 	i.stateMutex.Unlock()
+	log.ForSession(i.Title).Info("Session resumed")
 
 	// Start ClaudeController for idle detection and automation
 	// This is non-critical - we log errors but don't fail the resume

--- a/session/instance.go
+++ b/session/instance.go
@@ -785,6 +785,13 @@ func (i *Instance) GetStableID() string {
 	return i.Title
 }
 
+// MatchesID reports whether id refers to this instance.
+// Accepts both the stable UUID and the legacy Title identifier so that all
+// service lookups work correctly regardless of which form the caller has.
+func (i *Instance) MatchesID(id string) bool {
+	return i.Title == id || i.GetStableID() == id
+}
+
 // GetTmuxSessionName returns the sanitized tmux session name for reconciliation.
 // Returns empty string for external or uninitialized sessions.
 func (i *Instance) GetTmuxSessionName() string {

--- a/session/instance.go
+++ b/session/instance.go
@@ -196,7 +196,6 @@ type Instance struct {
 	// first start and updated on restart. Empty for external (mux-discovered) sessions.
 	LaunchCommand string `json:"launch_command,omitempty"`
 
-
 	// historyDetector is used by tryExtractConversationUUID. When nil the
 	// production inspector is used. Set in tests to inject a fake home dir.
 	historyDetector *HistoryFileDetector

--- a/session/review_queue_poller.go
+++ b/session/review_queue_poller.go
@@ -1049,7 +1049,7 @@ func (rqp *ReviewQueuePoller) FindInstance(sessionID string) *Instance {
 	defer rqp.mu.RUnlock()
 
 	for _, inst := range rqp.instances {
-		if inst.Title == sessionID || inst.GetStableID() == sessionID {
+		if inst.MatchesID(sessionID) {
 			return inst
 		}
 	}

--- a/web-app/src/components/sessions/FileTree.tsx
+++ b/web-app/src/components/sessions/FileTree.tsx
@@ -77,8 +77,9 @@ function fileNodeToTreeNode(fn: FileNode): TreeNode {
 /**
  * Build tree data from the directory contents map.
  * Recursively attaches loaded children to each directory node.
+ * Exported for unit testing.
  */
-function buildTreeData(
+export function buildTreeData(
   nodes: TreeNode[],
   dirContents: Map<string, TreeNode[]>
 ): TreeNode[] {
@@ -86,8 +87,9 @@ function buildTreeData(
     if (!node.isDir) return node;
     const loaded = dirContents.get(node.id);
     if (loaded === undefined) {
-      // [] signals react-arborist: expandable branch (fires onToggle when opened).
-      // Children will be loaded lazily in handleToggle.
+      // children: [] makes isLeaf=false (react-arborist checks Array.isArray).
+      // This allows node.toggle() to fire, which triggers onToggle → handleToggle → loadDirectory.
+      // Children will be populated lazily after the first toggle.
       return { ...node, children: [] };
     }
     return {
@@ -247,7 +249,12 @@ function NodeRenderer({
     <div
       style={style}
       className={`${nodeClass} ${isSelected ? selected : ""} ${data.isIgnored ? ignored : ""}`}
-      onClick={() => node.activate()}
+      onClick={() => {
+        // Directories toggle open/close (fires onToggle → handleToggle → loadDirectory).
+        // Files/symlinks activate (fires onActivate → onFileSelect).
+        if (data.isDir) node.toggle();
+        else node.activate();
+      }}
     >
       <div
         className={nodeInner}
@@ -620,7 +627,8 @@ export function FileTree({
         idAccessor={(node) => node.id}
         childrenAccessor={(node) => {
           if (!node.isDir) return null;
-          // [] = expandable (unloaded or empty); actual children once loaded.
+          // Returning [] (not null) for all dirs keeps isLeaf=false so node.toggle() works.
+          // Returning null would make the node a leaf and prevent any toggle from firing.
           return node.children ?? [];
         }}
         disableDrag={true}

--- a/web-app/src/components/sessions/FileTree.tsx
+++ b/web-app/src/components/sessions/FileTree.tsx
@@ -86,7 +86,8 @@ function buildTreeData(
     if (!node.isDir) return node;
     const loaded = dirContents.get(node.id);
     if (loaded === undefined) {
-      // Directory not yet loaded — provide empty array so it's expandable.
+      // [] signals react-arborist: expandable branch (fires onToggle when opened).
+      // Children will be loaded lazily in handleToggle.
       return { ...node, children: [] };
     }
     return {
@@ -530,11 +531,12 @@ export function FileTree({
 
       const allNodes = buildTreeData(rootNodes, dirContents);
       const node = findNode(allNodes);
-      if (node?.isDir && !dirContents.has(id)) {
+      // Load if not yet fetched, or retry if a previous load errored.
+      if (node?.isDir && (!dirContents.has(id) || errorPaths.has(id))) {
         loadDirectory(id);
       }
     },
-    [rootNodes, dirContents, loadDirectory, searchResults]
+    [rootNodes, dirContents, loadDirectory, searchResults, errorPaths]
   );
 
   if (rootLoading) {
@@ -618,6 +620,7 @@ export function FileTree({
         idAccessor={(node) => node.id}
         childrenAccessor={(node) => {
           if (!node.isDir) return null;
+          // [] = expandable (unloaded or empty); actual children once loaded.
           return node.children ?? [];
         }}
         disableDrag={true}

--- a/web-app/src/components/sessions/__tests__/FileTree.test.tsx
+++ b/web-app/src/components/sessions/__tests__/FileTree.test.tsx
@@ -1,0 +1,449 @@
+/**
+ * Tests for FileTree component and its helpers.
+ *
+ * Covers:
+ *  - buildTreeData: unloaded dirs get children:[], loaded dirs get actual children
+ *  - handleToggle: fires loadDirectory when onToggle receives a dir ID
+ *  - handleToggle: retries on previously errored directory
+ *  - handleToggle: ignores non-directory IDs
+ *  - NodeRenderer onClick: dirs call node.toggle(), files call node.activate()
+ *  - Root load on mount calls fetchDirectoryFiles with "."
+ *  - After toggle fires, fetchDirectoryFiles is called with the dir path
+ *  - childrenAccessor: returns null for files, [] for dirs (keeps isLeaf=false)
+ */
+
+import React from "react";
+import { render, fireEvent, act, waitFor } from "@testing-library/react";
+import { FileTree, buildTreeData } from "../FileTree";
+import type { TreeNode } from "../FileTree";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Capture Tree props so tests can inspect data and manually trigger callbacks.
+let capturedOnToggle: ((id: string) => void) | undefined;
+let capturedChildren:
+  | ((props: { node: MockNodeApi; style: React.CSSProperties; dragHandle?: unknown }) => React.ReactNode)
+  | undefined;
+let capturedData: TreeNode[] = [];
+
+interface MockNodeApi {
+  id: string;
+  data: TreeNode;
+  isOpen: boolean;
+  level: number;
+  toggle: jest.Mock;
+  activate: jest.Mock;
+}
+
+jest.mock("react-arborist", () => ({
+  Tree: jest.fn(
+    (props: {
+      data: TreeNode[];
+      onToggle?: (id: string) => void;
+      onActivate?: (node: unknown) => void;
+      children: (props: { node: MockNodeApi; style: React.CSSProperties; dragHandle?: unknown }) => React.ReactNode;
+      idAccessor?: (node: TreeNode) => string;
+      childrenAccessor?: (node: TreeNode) => TreeNode[] | null;
+      ref?: unknown;
+    }) => {
+      capturedOnToggle = props.onToggle;
+      capturedChildren = props.children;
+      capturedData = props.data;
+      return <div data-testid="mock-tree" />;
+    }
+  ),
+}));
+
+const mockFetchDirectoryFiles = jest.fn();
+const mockSearchFiles = jest.fn();
+
+jest.mock("@/lib/hooks/useFileService", () => ({
+  fetchDirectoryFiles: (...args: unknown[]) => mockFetchDirectoryFiles(...args),
+  searchFiles: (...args: unknown[]) => mockSearchFiles(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFileNode(path: string, isDir: boolean, children?: TreeNode[]): TreeNode {
+  return {
+    id: path,
+    name: path.split("/").pop() ?? path,
+    isDir,
+    size: BigInt(0),
+    gitStatus: "",
+    isSymlink: false,
+    symlinkTarget: "",
+    isIgnored: false,
+    children,
+  };
+}
+
+/** Build a mock fetchDirectoryFiles response from a list of entries. */
+function makeFileResponse(entries: { path: string; isDir: boolean }[]) {
+  return {
+    files: entries.map((e) => ({
+      path: e.path,
+      name: e.path.split("/").pop() ?? e.path,
+      isDir: e.isDir,
+      size: BigInt(0),
+      gitStatus: "",
+      isSymlink: false,
+      symlinkTarget: "",
+      isIgnored: false,
+    })),
+  };
+}
+
+function makeMockNode(data: TreeNode, overrides: Partial<MockNodeApi> = {}): MockNodeApi {
+  return {
+    id: data.id,
+    data,
+    isOpen: false,
+    level: 0,
+    toggle: jest.fn(),
+    activate: jest.fn(),
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  sessionId: "test-session-uuid",
+  baseUrl: "http://localhost:8543",
+  onFileSelect: jest.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// buildTreeData pure function
+// ---------------------------------------------------------------------------
+
+describe("buildTreeData", () => {
+  it("returns non-dir nodes unchanged", () => {
+    const file = makeFileNode("README.md", false);
+    const result = buildTreeData([file], new Map());
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(file);
+  });
+
+  it("gives unloaded dirs children: [] so arborist isLeaf=false (toggleable)", () => {
+    const dir = makeFileNode("src", true, undefined);
+    const result = buildTreeData([dir], new Map());
+    expect(Array.isArray(result[0].children)).toBe(true);
+    expect(result[0].children).toEqual([]);
+  });
+
+  it("gives loaded empty dirs children: [] (confirmed empty)", () => {
+    const dir = makeFileNode("empty-dir", true, undefined);
+    const contents = new Map([["empty-dir", [] as TreeNode[]]]);
+    const result = buildTreeData([dir], contents);
+    expect(result[0].children).toEqual([]);
+  });
+
+  it("attaches loaded children for loaded dirs", () => {
+    const dir = makeFileNode("src", true, undefined);
+    const child = makeFileNode("src/main.go", false);
+    const contents = new Map([["src", [child]]]);
+    const result = buildTreeData([dir], contents);
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children![0].id).toBe("src/main.go");
+  });
+
+  it("recursively attaches nested loaded children", () => {
+    const root = makeFileNode("src", true, undefined);
+    const sub = makeFileNode("src/components", true, undefined);
+    const file = makeFileNode("src/components/Button.tsx", false);
+    const contents = new Map<string, TreeNode[]>([
+      ["src", [sub]],
+      ["src/components", [file]],
+    ]);
+    const result = buildTreeData([root], contents);
+    const srcNode = result[0];
+    expect(srcNode.children).toHaveLength(1);
+    const subNode = srcNode.children![0];
+    expect(subNode.id).toBe("src/components");
+    expect(subNode.children).toHaveLength(1);
+    expect(subNode.children![0].id).toBe("src/components/Button.tsx");
+  });
+
+  it("mixes loaded and unloaded dirs correctly", () => {
+    const loaded = makeFileNode("loaded", true, undefined);
+    const unloaded = makeFileNode("unloaded", true, undefined);
+    const file = makeFileNode("loaded/file.go", false);
+    const contents = new Map<string, TreeNode[]>([["loaded", [file]]]);
+
+    const result = buildTreeData([loaded, unloaded], contents);
+    expect(result[0].children).toHaveLength(1);
+    expect(result[1].children).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// childrenAccessor contract (inline logic test — no component render needed)
+// ---------------------------------------------------------------------------
+
+describe("childrenAccessor logic", () => {
+  // The actual childrenAccessor used in FileTree is:
+  //   (node) => { if (!node.isDir) return null; return node.children ?? []; }
+  // We test this logic directly to ensure the isLeaf contract is preserved.
+
+  const accessor = (node: TreeNode): TreeNode[] | null => {
+    if (!node.isDir) return null;
+    return node.children ?? [];
+  };
+
+  it("returns null for a file node (makes it a leaf)", () => {
+    expect(accessor(makeFileNode("main.go", false))).toBeNull();
+  });
+
+  it("returns [] for an unloaded directory (children: undefined)", () => {
+    const result = accessor(makeFileNode("src", true, undefined));
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] for a confirmed empty directory (children: [])", () => {
+    const result = accessor(makeFileNode("empty", true, []));
+    expect(result).toEqual([]);
+  });
+
+  it("returns loaded children for a dir with children", () => {
+    const child = makeFileNode("src/main.go", false);
+    const result = accessor(makeFileNode("src", true, [child]));
+    expect(result).toHaveLength(1);
+    expect(result![0].id).toBe("src/main.go");
+  });
+
+  it("[] from accessor means isLeaf=false (Array.isArray([]) is true)", () => {
+    const children = accessor(makeFileNode("src", true, undefined));
+    // react-arborist's isLeaf check: !Array.isArray(this.children)
+    expect(Array.isArray(children)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FileTree – root loading
+// ---------------------------------------------------------------------------
+
+describe("FileTree – root loading", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOnToggle = undefined;
+    capturedChildren = undefined;
+    capturedData = [];
+  });
+
+  it("calls fetchDirectoryFiles with '.' on mount", async () => {
+    mockFetchDirectoryFiles.mockResolvedValue(
+      makeFileResponse([{ path: "src", isDir: true }])
+    );
+
+    render(<FileTree {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(mockFetchDirectoryFiles).toHaveBeenCalledWith(
+        "test-session-uuid",
+        ".",
+        false,
+        "http://localhost:8543"
+      );
+    });
+  });
+
+  it("passes root nodes to Tree after successful load", async () => {
+    mockFetchDirectoryFiles.mockResolvedValue(
+      makeFileResponse([
+        { path: "README.md", isDir: false },
+        { path: "src", isDir: true },
+      ])
+    );
+
+    render(<FileTree {...defaultProps} />);
+
+    await waitFor(() => {
+      const srcNode = capturedData.find((n) => n.id === "src");
+      expect(srcNode).toBeDefined();
+      expect(srcNode!.isDir).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FileTree – handleToggle loads directories
+// ---------------------------------------------------------------------------
+
+describe("FileTree – handleToggle loads directories", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOnToggle = undefined;
+    capturedData = [];
+  });
+
+  /** Wait for Tree to be rendered with at least one node containing the given id. */
+  async function waitForTreeWithNode(id: string) {
+    await waitFor(() => {
+      expect(capturedOnToggle).toBeDefined();
+      const node = capturedData.find((n) => n.id === id);
+      expect(node).toBeDefined();
+    });
+  }
+
+  it("calls fetchDirectoryFiles for a dir ID when onToggle fires", async () => {
+    // Both root useEffects fire on mount; use mockImplementation to handle all calls.
+    mockFetchDirectoryFiles.mockImplementation((_session: string, path: string) => {
+      if (path === ".") return Promise.resolve(makeFileResponse([{ path: "src", isDir: true }]));
+      if (path === "src") return Promise.resolve(makeFileResponse([{ path: "src/main.go", isDir: false }]));
+      return Promise.resolve(makeFileResponse([]));
+    });
+
+    render(<FileTree {...defaultProps} />);
+    await waitForTreeWithNode("src");
+
+    // Simulate user toggling "src" directory.
+    await act(async () => {
+      capturedOnToggle!("src");
+    });
+
+    await waitFor(() => {
+      expect(mockFetchDirectoryFiles).toHaveBeenCalledWith(
+        "test-session-uuid",
+        "src",
+        false,
+        "http://localhost:8543"
+      );
+    });
+  });
+
+  it("does not reload a directory that is already loaded", async () => {
+    let srcLoadCount = 0;
+    mockFetchDirectoryFiles.mockImplementation((_session: string, path: string) => {
+      if (path === ".") return Promise.resolve(makeFileResponse([{ path: "src", isDir: true }]));
+      if (path === "src") {
+        srcLoadCount++;
+        return Promise.resolve(makeFileResponse([{ path: "src/main.go", isDir: false }]));
+      }
+      return Promise.resolve(makeFileResponse([]));
+    });
+
+    render(<FileTree {...defaultProps} />);
+    await waitForTreeWithNode("src");
+
+    // First toggle loads src.
+    await act(async () => { capturedOnToggle!("src"); });
+    await waitFor(() => expect(srcLoadCount).toBe(1));
+
+    // Second toggle should NOT reload (already in dirContents).
+    await act(async () => { capturedOnToggle!("src"); });
+    expect(srcLoadCount).toBe(1);
+  });
+
+  it("retries a directory that previously errored", async () => {
+    let srcLoadCount = 0;
+    mockFetchDirectoryFiles.mockImplementation((_session: string, path: string) => {
+      if (path === ".") return Promise.resolve(makeFileResponse([{ path: "src", isDir: true }]));
+      if (path === "src") {
+        srcLoadCount++;
+        if (srcLoadCount === 1) return Promise.reject(new Error("network error"));
+        return Promise.resolve(makeFileResponse([{ path: "src/main.go", isDir: false }]));
+      }
+      return Promise.resolve(makeFileResponse([]));
+    });
+
+    render(<FileTree {...defaultProps} />);
+    await waitForTreeWithNode("src");
+
+    // First toggle — fails.
+    await act(async () => { capturedOnToggle!("src"); });
+    await waitFor(() => expect(srcLoadCount).toBe(1));
+
+    // Second toggle — should retry because errorPaths contains "src".
+    await act(async () => { capturedOnToggle!("src"); });
+    await waitFor(() => expect(srcLoadCount).toBe(2));
+  });
+
+  it("ignores toggles for non-directory IDs", async () => {
+    let nonDirLoadCount = 0;
+    mockFetchDirectoryFiles.mockImplementation((_session: string, path: string) => {
+      if (path === ".") return Promise.resolve(makeFileResponse([{ path: "README.md", isDir: false }]));
+      nonDirLoadCount++;
+      return Promise.resolve(makeFileResponse([]));
+    });
+
+    render(<FileTree {...defaultProps} />);
+    await waitFor(() => expect(capturedOnToggle).toBeDefined());
+
+    // Toggle a file node — should not trigger any directory fetch.
+    await act(async () => { capturedOnToggle!("README.md"); });
+
+    // No fetch beyond root should have happened.
+    expect(nonDirLoadCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NodeRenderer onClick – dirs call toggle, files call activate
+// ---------------------------------------------------------------------------
+
+describe("FileTree – NodeRenderer click behavior", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOnToggle = undefined;
+    capturedChildren = undefined;
+  });
+
+  async function setupWithRootNodes(entries: { path: string; isDir: boolean }[]) {
+    mockFetchDirectoryFiles.mockResolvedValue(makeFileResponse(entries));
+    render(<FileTree {...defaultProps} />);
+    await waitFor(() => expect(capturedChildren).toBeDefined());
+  }
+
+  it("clicking a closed directory node calls node.toggle() not node.activate()", async () => {
+    await setupWithRootNodes([{ path: "src", isDir: true }]);
+
+    const dirData = makeFileNode("src", true, []);
+    const mockNode = makeMockNode(dirData, { isOpen: false });
+
+    const { container } = render(
+      <>{capturedChildren!({ node: mockNode, style: {} })}</>
+    );
+
+    fireEvent.click(container.querySelector("div")!);
+
+    expect(mockNode.toggle).toHaveBeenCalledTimes(1);
+    expect(mockNode.activate).not.toHaveBeenCalled();
+  });
+
+  it("clicking a file node calls node.activate() not node.toggle()", async () => {
+    await setupWithRootNodes([{ path: "main.go", isDir: false }]);
+
+    const fileData = makeFileNode("main.go", false);
+    const mockNode = makeMockNode(fileData);
+
+    const { container } = render(
+      <>{capturedChildren!({ node: mockNode, style: {} })}</>
+    );
+
+    fireEvent.click(container.querySelector("div")!);
+
+    expect(mockNode.activate).toHaveBeenCalledTimes(1);
+    expect(mockNode.toggle).not.toHaveBeenCalled();
+  });
+
+  it("clicking an open directory node also calls node.toggle() to collapse it", async () => {
+    await setupWithRootNodes([{ path: "src", isDir: true }]);
+
+    const dirData = makeFileNode("src", true, []);
+    const mockNode = makeMockNode(dirData, { isOpen: true });
+
+    const { container } = render(
+      <>{capturedChildren!({ node: mockNode, style: {} })}</>
+    );
+
+    fireEvent.click(container.querySelector("div")!);
+
+    expect(mockNode.toggle).toHaveBeenCalledTimes(1);
+    expect(mockNode.activate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **FileTree folder drill-down**: `NodeRenderer.onClick` was calling `node.activate()` for all nodes — for directories, `activate()` is a no-op in react-arborist. Fixed to call `node.toggle()` for dirs (fires `onToggle` → `handleToggle` → `loadDirectory`) and `node.activate()` for files.
- **UUID persistence in ent schema**: Added `uuid` column to the Session ent schema so UUIDs survive server restarts. Previously, `FromInstanceData` assigned a fresh random UUID on every `LoadInstances()` call, making `WorkspaceService.findInstance` UUID lookups always fail.
- **UUID-aware lookups everywhere**: All backend service lookups (`GetVCSStatus`, `GetSessionDiff`, `GetLogs`, `SwitchWorkspace`, MCP lifecycle tools) now use `MatchesID(id)` which checks both UUID and Title.
- **Session lifecycle logs**: Added log entries at start/pause/resume/exit so the Logs tab captures session-scoped events.

## Test plan

- [ ] 20 Jest tests: `FileTree` — buildTreeData, childrenAccessor, root loading, handleToggle retry, NodeRenderer click behavior (dirs→toggle, files→activate)
- [ ] 3 Go tests: `WorkspaceService.GetVCSStatus` — finds by UUID, finds by Title, unknown ID → CodeNotFound
- [ ] 3 Go tests: `SessionService.GetSessionDiff` — finds by UUID, finds by Title, unknown ID → CodeNotFound
- [ ] 5 Go tests: `UtilityService.GetLogs` — nil poller, UUID with matching instance, UUID with no match, Title lookup
- [ ] All existing `./server/services/...` tests pass