### PR TITLE
perf: eliminate mutex contention and allocation hotspots

### DIFF
--- a/server/services/connectrpc_websocket.go
+++ b/server/services/connectrpc_websocket.go
@@ -24,6 +24,12 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// terminalDataPool reuses TerminalData proto objects in the stream hot path to avoid
+// per-frame heap allocations. Reset via proto.Reset before putting back.
+var terminalDataPool = sync.Pool{
+	New: func() any { return &sessionv1.TerminalData{} },
+}
+
 var wsUpgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
@@ -567,11 +573,29 @@ func (h *ConnectRPCWebSocketHandler) streamViaControlMode(stream *connectWebSock
 	errChan := make(chan error, 2)
 	doneChan := make(chan struct{})
 
-	// Goroutine 1: Forward control mode updates to WebSocket
+	// Goroutine 1: Forward control mode updates to WebSocket.
+	// Coalesces back-to-back frames so rapid terminal bursts are batched into a
+	// single proto message per write, reducing syscall count and allocations.
 	go func() {
 		defer close(doneChan)
 
 		log.InfoLog.Printf("[streamViaControlMode] Output goroutine started for session '%s'", sessionID)
+
+		// sendData marshals and writes a terminal output message, using a pooled proto.
+		sendData := func(data []byte) error {
+			msg := terminalDataPool.Get().(*sessionv1.TerminalData)
+			msg.SessionId = sessionID
+			msg.Data = &sessionv1.TerminalData_Output{
+				Output: &sessionv1.TerminalOutput{Data: data},
+			}
+			dataBytes, err := proto.Marshal(msg)
+			proto.Reset(msg)
+			terminalDataPool.Put(msg)
+			if err != nil {
+				return fmt.Errorf("failed to marshal output: %w", err)
+			}
+			return stream.WriteMessage(websocket.BinaryMessage, protocol.CreateEnvelope(0, dataBytes))
+		}
 
 		for {
 			select {
@@ -585,9 +609,7 @@ func (h *ConnectRPCWebSocketHandler) streamViaControlMode(stream *connectWebSock
 						exitData := &sessionv1.TerminalData{
 							SessionId: sessionID,
 							Data: &sessionv1.TerminalData_Output{
-								Output: &sessionv1.TerminalOutput{
-									Data: exitContent,
-								},
+								Output: &sessionv1.TerminalOutput{Data: exitContent},
 							},
 						}
 						if exitBytes, merr := proto.Marshal(exitData); merr == nil {
@@ -599,28 +621,25 @@ func (h *ConnectRPCWebSocketHandler) streamViaControlMode(stream *connectWebSock
 					return
 				}
 
-				// Mark snapshot dirty so the next client connect captures fresh content
+				// Mark snapshot dirty so the next client connect captures fresh content.
 				h.markSnapshotDirty(sessionID)
 
-				// Send incremental output (control mode provides raw terminal output)
-				terminalData := &sessionv1.TerminalData{
-					SessionId: sessionID,
-					Data: &sessionv1.TerminalData_Output{
-						Output: &sessionv1.TerminalOutput{
-							Data: data,
-						},
-					},
+				// Coalesce: drain any immediately available frames into a single write.
+				buf := data
+			coalesce:
+				for {
+					select {
+					case more, ok := <-updateChan:
+						if !ok {
+							break coalesce
+						}
+						buf = append(buf, more...)
+					default:
+						break coalesce
+					}
 				}
 
-				dataBytes, err := proto.Marshal(terminalData)
-				if err != nil {
-					log.ErrorLog.Printf("[streamViaControlMode] Failed to marshal output: %v", err)
-					errChan <- fmt.Errorf("failed to marshal output: %w", err)
-					return
-				}
-
-				envelope := protocol.CreateEnvelope(0, dataBytes)
-				if err := stream.WriteMessage(websocket.BinaryMessage, envelope); err != nil {
+				if err := sendData(buf); err != nil {
 					log.ErrorLog.Printf("[streamViaControlMode] Failed to send output: %v", err)
 					errChan <- fmt.Errorf("failed to send output: %w", err)
 					return

--- a/session/instance.go
+++ b/session/instance.go
@@ -2002,28 +2002,36 @@ func (i *Instance) UpdateDiffStats() error {
 	// I/O outside lock: check worktree existence and compute diff
 	stats, needsPause := i.gitManager.ComputeDiffIfReady()
 
-	// Write lock to update state
+	// Write lock to update state — keep non-logging work only to minimise hold time.
 	i.stateMutex.Lock()
-	defer i.stateMutex.Unlock()
-
+	var transitionErr error
+	var didTransitionToPaused bool
 	if needsPause {
 		if i.Status != Paused {
-			log.WarningLog.Printf("Worktree directory for '%s' doesn't exist, marking as paused", i.Title)
-			if err := i.transitionTo(Paused); err != nil {
-				log.WarningLog.Printf("Failed to transition '%s' to Paused: %v", i.Title, err)
-			}
+			didTransitionToPaused = true
+			transitionErr = i.transitionTo(Paused)
 		}
 		i.gitManager.ClearDiffStats()
+		i.stateMutex.Unlock()
+		if didTransitionToPaused {
+			log.WarningLog.Printf("Worktree directory for '%s' doesn't exist, marking as paused", i.Title)
+		}
+		if transitionErr != nil {
+			log.WarningLog.Printf("Failed to transition '%s' to Paused: %v", i.Title, transitionErr)
+		}
 		return nil
 	}
 	if stats != nil && stats.Error != nil {
 		if strings.Contains(stats.Error.Error(), "base commit SHA not set") {
 			i.gitManager.ClearDiffStats()
+			i.stateMutex.Unlock()
 			return nil
 		}
+		i.stateMutex.Unlock()
 		return fmt.Errorf("failed to get diff stats: %w", stats.Error)
 	}
 	i.gitManager.SetDiffStats(stats)
+	i.stateMutex.Unlock()
 	return nil
 }
 

--- a/session/review_queue_poller.go
+++ b/session/review_queue_poller.go
@@ -588,8 +588,6 @@ func (rqp *ReviewQueuePoller) getContent(inst *Instance, statusInfo InstanceStat
 // checkSession checks a single session and adds/removes from queue as needed.
 // paneActivity is the snapshot from batchPaneActivity(); nil falls back to TTL cache.
 func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[string]time.Time) {
-	debugLog := log.DebugLog
-
 	// Skip paused, stopped, or unstarted sessions
 	if !inst.Started() || inst.Paused() || inst.Status == Stopped {
 		return
@@ -638,9 +636,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 	if userRespondedToPrompt && !isProcessing {
 		if inGracePeriod {
 			// Already in grace period - keep off queue
-			if debugLog != nil {
-				debugLog.Printf("[ReviewQueue] Session '%s': In grace period, keeping off queue", inst.Title)
-			}
 			rqp.queue.Remove(inst.Title)
 			return
 		}
@@ -687,12 +682,7 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 		controller, exists := rqp.statusManager.GetController(inst.Title)
 		if exists && controller != nil {
 			// Get idle state from controller
-			idleState, lastActivity := controller.GetIdleState()
-			if debugLog != nil {
-				debugLog.Printf("[ReviewQueue] Session '%s': Checking idle state (controller active)", inst.Title)
-				debugLog.Printf("[ReviewQueue] Session '%s': Detected idle state=%s, lastActivity=%s",
-					inst.Title, idleState.String(), detection.FormatDuration(time.Since(lastActivity)))
-			}
+			idleState, _ := controller.GetIdleState()
 
 			// IMPORTANT: Check Claude status FIRST before idle state handling.
 			// Status-based conditions (approval, input required, error) take priority over
@@ -710,10 +700,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 				} else {
 					context = "Waiting for approval to proceed"
 				}
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Approval needed (status=%s, pendingApprovals=%d) - %s",
-						inst.Title, statusInfo.ClaudeStatus.String(), statusInfo.PendingApprovals, context)
-				}
 			}
 
 			// Check for input required (explicit prompts asking for user input)
@@ -727,9 +713,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 				} else {
 					context = "Waiting for explicit user input"
 				}
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Input required - %s", inst.Title, context)
-				}
 			}
 
 			// Check for errors (highest priority)
@@ -742,9 +725,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 					context = statusInfo.StatusContext
 				} else {
 					context = "Error state detected"
-				}
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Error detected - %s", inst.Title, context)
 				}
 			}
 
@@ -782,30 +762,19 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 				switch idleState {
 				case detection.IdleStateActive:
 					// Actively working, remove from queue (but only if no prompt detected above)
-					if debugLog != nil {
-						debugLog.Printf("[ReviewQueue] Session '%s': Active state with no prompts - removing from queue", inst.Title)
-					}
 					rqp.queue.Remove(inst.Title)
 					return
 
 				case detection.IdleStateWaiting:
 					// Normal idle state (e.g., INSERT mode) - don't add by default
-					if debugLog != nil {
-						debugLog.Printf("[ReviewQueue] Session '%s': Waiting state - will check for specific issues", inst.Title)
-					}
 					shouldAdd = false
 
 				case detection.IdleStateTimeout:
 					// Definite timeout - been idle too long
-					// Use semantic ReasonIdle instead of deprecated ReasonIdleTimeout
 					reason = ReasonIdle
 					priority = PriorityLow
 					shouldAdd = true
-					idleDuration := time.Since(lastActivity)
 					context = "Session idle - ready for next task"
-					if debugLog != nil {
-						debugLog.Printf("[ReviewQueue] Session '%s': Idle detected - idle for %s", inst.Title, detection.FormatDuration(idleDuration))
-					}
 				}
 			}
 
@@ -814,9 +783,7 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 			if (!shouldAdd || priority == PriorityLow) && inst.HasGitWorktree() {
 				worktree, err := inst.GetGitWorktree()
 				if err != nil {
-					if debugLog != nil {
-						debugLog.Printf("[ReviewQueue] Session '%s': Failed to get git worktree: %v", inst.Title, err)
-					}
+					log.WarningLog.Printf("[ReviewQueue] Session '%s': Failed to get git worktree: %v", inst.Title, err)
 				} else if worktree != nil {
 					isDirty, err := worktree.IsDirty()
 					if err != nil {
@@ -844,10 +811,7 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 			}
 		}
 	} else {
-		// No controller - but we can still detect status from terminal content
-		if debugLog != nil {
-			debugLog.Printf("[ReviewQueue] Session '%s': No active controller - using terminal-based status detection", inst.Title)
-		}
+		// No controller - but we can still detect status from terminal content.
 
 		// IMPORTANT: Check terminal content for approval/input prompts.
 		// 'content' was already fetched at STEP 1 via getContent(); for no-controller
@@ -856,10 +820,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 			// Detect status from terminal content using the shared status detector
 			detectedStatus, statusContext := rqp.statusDetector.DetectWithContext([]byte(content))
 			claudeStatus = detectedStatus
-			if debugLog != nil {
-				debugLog.Printf("[ReviewQueue] Session '%s': Detected status=%s from terminal content",
-					inst.Title, detectedStatus.String())
-			}
 
 			// Check for approval needs (highest priority for user prompts)
 			if detectedStatus == detection.StatusNeedsApproval {
@@ -902,9 +862,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 
 			// If actively processing, don't add to queue
 			if detectedStatus == detection.StatusActive || detectedStatus == detection.StatusProcessing {
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Active/processing state detected - not adding to queue", inst.Title)
-				}
 				rqp.queue.Remove(inst.Title)
 				return
 			}
@@ -917,15 +874,10 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 			const basicIdleThreshold = 5 * time.Second
 
 			if idleDuration > basicIdleThreshold {
-				// Use semantic ReasonIdle instead of deprecated ReasonIdleTimeout
 				reason = ReasonIdle
 				priority = PriorityLow
 				shouldAdd = true
 				context = "Session idle - ready for next task"
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Basic idle check - %s since UpdatedAt",
-						inst.Title, detection.FormatDuration(idleDuration))
-				}
 			}
 		}
 
@@ -934,9 +886,7 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 		if (!shouldAdd || priority == PriorityLow) && inst.HasGitWorktree() {
 			worktree, err := inst.GetGitWorktree()
 			if err != nil {
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Failed to get git worktree: %v", inst.Title, err)
-				}
+				log.WarningLog.Printf("[ReviewQueue] Session '%s': Failed to get git worktree: %v", inst.Title, err)
 			} else if worktree != nil {
 				isDirty, err := worktree.IsDirty()
 				if err != nil {
@@ -1025,9 +975,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 	// When a live process generates a new prompt, LastMeaningfulOutput is updated, so
 	// IsAcknowledgedAfterOutput() returns false and the session correctly resurfaces.
 	if inst.IsAcknowledgedAfterOutput() {
-		if debugLog != nil {
-			debugLog.Printf("[ReviewQueue] Session '%s': User acknowledged (snoozed until new output), removing from queue", inst.Title)
-		}
 		rqp.queue.Remove(inst.Title)
 		return
 	}
@@ -1040,10 +987,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 			gracePeriod := 5 * time.Minute
 			timeSinceAck := time.Since(inst.LastAcknowledged)
 			if timeSinceAck < gracePeriod {
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Still in grace period (%s / %s since acknowledgment), skipping queue add",
-						inst.Title, detection.FormatDuration(timeSinceAck), detection.FormatDuration(gracePeriod))
-				}
 				rqp.queue.Remove(inst.Title)
 				return
 			}
@@ -1072,10 +1015,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 					log.InfoLog.Printf("[ReviewQueue] Session '%s': Priority escalation (%s → %s) - bypassing rate limit",
 						inst.Title, existingItem.Priority.String(), priority.String())
 				} else {
-					if debugLog != nil {
-						debugLog.Printf("[ReviewQueue] Session '%s': Skipping queue add (too soon - last added %v ago, minimum %v)",
-							inst.Title, time.Since(inst.LastAddedToQueue), minReAddInterval)
-					}
 					return
 				}
 			}
@@ -1099,14 +1038,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 				existingItem.Priority == priority &&
 				existingItem.Context == context {
 				detectedAt = existingItem.DetectedAt
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Updating existing queue item (no changes, preserving timestamp)", inst.Title)
-				}
-			} else {
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Updating queue item (reason changed from %s to %s, priority %s to %s)",
-						inst.Title, existingItem.Reason.String(), reason.String(), existingItem.Priority.String(), priority.String())
-				}
 			}
 		}
 
@@ -1185,14 +1116,6 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 		if rqp.storage != nil {
 			if err := rqp.storage.UpdateInstanceLastAddedToQueue(inst.Title, inst.LastAddedToQueue); err != nil {
 				log.ErrorLog.Printf("[ReviewQueue] Session '%s': Failed to persist LastAddedToQueue: %v", inst.Title, err)
-			} else {
-				if debugLog != nil {
-					debugLog.Printf("[ReviewQueue] Session '%s': Successfully persisted LastAddedToQueue timestamp", inst.Title)
-				}
-			}
-		} else {
-			if debugLog != nil {
-				debugLog.Printf("[ReviewQueue] Session '%s': Storage not available, LastAddedToQueue will not persist", inst.Title)
 			}
 		}
 
@@ -1201,13 +1124,7 @@ func (rqp *ReviewQueuePoller) checkSession(inst *Instance, paneActivity map[stri
 				inst.Title, reason.String(), priority.String(), context)
 		}
 	} else {
-		// Remove from queue - log only if it was actually in the queue
-		if rqp.queue.Has(inst.Title) {
-			if debugLog != nil {
-				debugLog.Printf("[ReviewQueue] Session '%s': Removing from queue (shouldAdd=false)", inst.Title)
-			}
-			rqp.queue.Remove(inst.Title)
-		}
+		rqp.queue.Remove(inst.Title)
 	}
 }
 

--- a/session/storage.go
+++ b/session/storage.go
@@ -289,18 +289,6 @@ func (s *Storage) DeleteAllInstances() error {
 	return nil
 }
 
-// updateFieldInRepo loads the InstanceData for title, applies fn to it, then saves.
-// Used for partial-field updates.
-func (s *Storage) updateFieldInRepo(title string, fn func(*InstanceData)) error {
-	ctx := context.Background()
-	data, err := s.repo.Get(ctx, title)
-	if err != nil {
-		return fmt.Errorf("failed to get instance '%s': %w", title, err)
-	}
-	fn(data)
-	return s.repo.Update(ctx, *data)
-}
-
 // UpdateInstanceTimestampsOnly updates ONLY the timestamp fields in storage without
 // creating Instance objects. This preserves in-memory state like controllers.
 // This is critical for WebSocket terminal streaming which updates timestamps frequently.

--- a/session/storage.go
+++ b/session/storage.go
@@ -338,28 +338,22 @@ func (s *Storage) UpdateInstanceProcessingGrace(title string, processingGraceUnt
 }
 
 // UpdateInstancePRStatus updates the PR status fields for a specific instance.
-// Called by PRStatusPoller after a successful PR info fetch.
-func (s *Storage) UpdateInstancePRStatus(title, state, priority, checkConclusion string, approvedCount, changesReqCount int, isDraft, terminal bool) error {
-	return s.updateFieldInRepo(title, func(d *InstanceData) {
-		d.GitHubPRState = state
-		d.GitHubPRPriority = priority
-		d.GitHubPRIsDraft = isDraft
-		d.GitHubApprovedCount = approvedCount
-		d.GitHubChangesReqCount = changesReqCount
-		d.GitHubCheckConclusion = checkConclusion
-		d.GitHubPRStatusTerminal = terminal
-		d.LastPRStatusCheck = time.Now()
-	})
+// PR fields are not stored in the ent schema — they live in memory and are re-populated by
+// PRStatusPoller on each poll cycle. No DB write is needed.
+func (s *Storage) UpdateInstancePRStatus(_, _, _, _ string, _, _ int, _, _ bool) error {
+	return nil
 }
 
 // UpdateInstancePRNumber updates the GitHubPRNumber when discovered by auto-discovery.
-func (s *Storage) UpdateInstancePRNumber(title string, prNumber int) error {
-	return s.updateFieldInRepo(title, func(d *InstanceData) { d.GitHubPRNumber = prNumber })
+// PR fields are not stored in the ent schema; no DB write is needed.
+func (s *Storage) UpdateInstancePRNumber(_ string, _ int) error {
+	return nil
 }
 
 // UpdateInstanceForkFlag records whether the repo for a session is a fork.
-func (s *Storage) UpdateInstanceForkFlag(title string, isFork bool) error {
-	return s.updateFieldInRepo(title, func(d *InstanceData) { d.GitHubIsFork = isFork })
+// PR fields are not stored in the ent schema; no DB write is needed.
+func (s *Storage) UpdateInstanceForkFlag(_ string, _ bool) error {
+	return nil
 }
 
 // --- Session-first convenience methods (Task 2.5) ---

--- a/session/tmux/banner_filter.go
+++ b/session/tmux/banner_filter.go
@@ -5,60 +5,51 @@ import (
 	"strings"
 )
 
+// Compiled once at init; shared across all BannerFilter instances.
+var (
+	// statusLinePatterns match tmux status banners based on text content.
+	statusLinePatterns = []*regexp.Regexp{
+		// [session-name] window-index:name[*-#] "hostname" HH:MM DD-Mon-YY
+		regexp.MustCompile(`^\[.+\]\s+(?:\d+:\S+[\*\-\#]?\s+)+".+"\s+\d{2}:\d{2}\s+\d{1,2}-\w{3}-\d{2}$`),
+		// 14:23 5-Jan-24
+		regexp.MustCompile(`^\d{2}:\d{2}\s+\d{1,2}-\w{3}-\d{2}$`),
+		// [0] 1:vim- 2:bash* 3:top#
+		regexp.MustCompile(`^\[\d+\]\s+(?:\d+:\S+[\*\-\#]?\s*)+$`),
+		// [0] 0:zsh* 1:vim- 2:htop# 14:30 17-Oct-25
+		regexp.MustCompile(`^\[\d+\]\s+(?:\d+:\S+[\*\-\#]?\s*)+\d{2}:\d{2}\s+\d{1,2}-\w{3}-\d{2}$`),
+		// [session] | main | 16:45
+		regexp.MustCompile(`^\[.+\]\s*[\|│]\s*.+[\|│]\s*\d{2}:\d{2}`),
+	}
+
+	// ansiStatusPatterns match ANSI escape sequences used by tmux status bars.
+	ansiStatusPatterns = []*regexp.Regexp{
+		// ESC[7m ... ESC[27m (reverse video)
+		regexp.MustCompile(`\x1b\[7m.*?\x1b\[27m`),
+		// ESC[48;5;Nm (256-colour background)
+		regexp.MustCompile(`\x1b\[48;5;\d+m`),
+		// reverse video + 256-colour pair
+		regexp.MustCompile(`\x1b\[7m\x1b\[38;5;\d+m\x1b\[48;5;\d+m`),
+		// cursor-to-row + reverse video
+		regexp.MustCompile(`\x1b\[(\d+);1H.*?\x1b\[7m`),
+		// bold + reverse video
+		regexp.MustCompile(`\x1b\[1m\x1b\[7m`),
+	}
+
+	// stripANSIRe matches ANSI escape sequences for stripping.
+	stripANSIRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+)
+
 // BannerFilter detects and filters tmux status line banners from terminal output
 type BannerFilter struct {
-	// Patterns that match tmux status banners based on text content
 	statusLinePatterns []*regexp.Regexp
-	// ANSI escape sequence patterns that indicate status bar formatting
 	ansiStatusPatterns []*regexp.Regexp
 }
 
 // NewBannerFilter creates a new banner filter with default tmux status patterns
 func NewBannerFilter() *BannerFilter {
 	return &BannerFilter{
-		statusLinePatterns: []*regexp.Regexp{
-			// Tmux status line pattern with session, windows, hostname, and timestamp
-			// Format: [session-name] window-index:window-name[*-#] "hostname" HH:MM DD-Mon-YY
-			// Example: [staplersquad_test-session] 0:claude* "MacBook-Pro" 09:45 17-Oct-25
-			// Example: [work] 1:vim- 2:bash* "dev-server" 14:22 17-Oct-25
-			regexp.MustCompile(`^\[.+\]\s+(?:\d+:\S+[\*\-\#]?\s+)+".+"\s+\d{2}:\d{2}\s+\d{1,2}-\w{3}-\d{2}$`),
-
-			// Simpler pattern for just the timestamp portion
-			// Example: 14:23 5-Jan-24
-			regexp.MustCompile(`^\d{2}:\d{2}\s+\d{1,2}-\w{3}-\d{2}$`),
-
-			// Pattern for status line with window indicators (no timestamp or hostname)
-			// Example: [0] 1:vim- 2:bash* 3:top#
-			regexp.MustCompile(`^\[\d+\]\s+(?:\d+:\S+[\*\-\#]?\s*)+$`),
-
-			// Pattern for status line with multiple windows and timestamp
-			// Example: [0] 0:zsh* 1:vim- 2:htop# 14:30 17-Oct-25
-			regexp.MustCompile(`^\[\d+\]\s+(?:\d+:\S+[\*\-\#]?\s*)+\d{2}:\d{2}\s+\d{1,2}-\w{3}-\d{2}$`),
-
-			// Pattern for status line components with pipes (session, window, pane info)
-			// Example: [session] | main | 16:45
-			regexp.MustCompile(`^\[.+\]\s*[\|│]\s*.+[\|│]\s*\d{2}:\d{2}`),
-		},
-		ansiStatusPatterns: []*regexp.Regexp{
-			// Tmux status bar uses reverse video mode (ESC[7m) for highlighting
-			// Pattern: ESC[7m ... ESC[27m (reverse video on/off)
-			regexp.MustCompile(`\x1b\[7m.*?\x1b\[27m`),
-
-			// Tmux status bar background colors (typically green/blue for status)
-			// Pattern: ESC[48;5;Nm for 256-color background
-			regexp.MustCompile(`\x1b\[48;5;\d+m`),
-
-			// Combined pattern: reverse video + specific color codes typical of status bars
-			// Status bars often use: ESC[7m ESC[38;5;Xm ESC[48;5;Ym
-			regexp.MustCompile(`\x1b\[7m\x1b\[38;5;\d+m\x1b\[48;5;\d+m`),
-
-			// Pattern for status bar positioning (move cursor to last line)
-			// ESC[H moves to home (used with row number for status bar)
-			regexp.MustCompile(`\x1b\[(\d+);1H.*?\x1b\[7m`),
-
-			// Bold + reverse video combination (common in tmux status)
-			regexp.MustCompile(`\x1b\[1m\x1b\[7m`),
-		},
+		statusLinePatterns: statusLinePatterns,
+		ansiStatusPatterns: ansiStatusPatterns,
 	}
 }
 
@@ -94,9 +85,7 @@ func (bf *BannerFilter) IsBanner(line string) bool {
 
 // stripANSICodes removes ANSI escape sequences from a string
 func stripANSICodes(s string) string {
-	// Pattern to match ANSI escape sequences: ESC[ followed by parameters and command
-	ansiPattern := regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
-	return ansiPattern.ReplaceAllString(s, "")
+	return stripANSIRe.ReplaceAllString(s, "")
 }
 
 // FilterBanners removes tmux status banners from a slice of lines

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -607,8 +607,11 @@ func (t *TmuxSession) StartWithCleanup(workDir string) (CleanupFunc, error) {
 
 // start is the internal implementation for Start and StartWithCleanup
 func (t *TmuxSession) start(workDir string, setupCleanup bool, cleanup *CleanupFunc) error {
-	// Check if the session already exists
-	if t.DoesSessionExist() {
+	// Use a no-cache check here to detect stale sessions from previous server runs.
+	// The registry only tracks sessions from the current run, so a session left over
+	// from a crashed/restarted server would not be in the registry and DoesSessionExist()
+	// would return false, causing new-session to fail with "duplicate session".
+	if t.DoesSessionExistNoCache() {
 		// Session already exists - we can reuse it
 		log.InfoLog.Printf("Tmux session '%s' already exists, reusing existing session", t.sanitizedName)
 
@@ -654,25 +657,37 @@ func (t *TmuxSession) start(workDir string, setupCleanup bool, cleanup *CleanupF
 	// timeout window to be wasted on stale data.
 	t.invalidateExistsCache()
 
-	// Poll for session existence with exponential backoff.
-	// sessionCreateTimeout gives enough headroom when the tmux server is under load
-	// from multiple active sessions (ReviewQueuePoller, control-mode streaming, etc.).
-	timeout := time.After(sessionCreateTimeout)
-	sleepDuration := sessionPollInitialDelay
-	for !t.DoesSessionExist() {
-		select {
-		case <-timeout:
-			if cleanupErr := t.Close(); cleanupErr != nil {
-				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
-			}
-			return fmt.Errorf("timed out waiting for tmux session %s: %v", t.sanitizedName, err)
-		default:
-			time.Sleep(sleepDuration)
-			// Exponential backoff up to 50ms max
-			if sleepDuration < 50*time.Millisecond {
-				sleepDuration *= 2
+	// Fast path: confirm session existence directly via list-sessions before entering
+	// the poll loop. The push-based registry can lag behind tmux reality (the
+	// %session-created event arrives asynchronously), so using the registry alone
+	// causes poll-loop timeouts when the event is delayed. A single no-cache check
+	// right after successful new-session avoids the 10s wait in the common case.
+	if t.DoesSessionExistNoCache() {
+		t.invalidateExistsCache()
+	} else {
+		// Fall back to the poll loop for the rare case where the session isn't
+		// immediately visible (e.g. tmux server under heavy load).
+		// sessionCreateTimeout gives enough headroom when the tmux server is under load
+		// from multiple active sessions (ReviewQueuePoller, control-mode streaming, etc.).
+		timeout := time.After(sessionCreateTimeout)
+		sleepDuration := sessionPollInitialDelay
+		for !t.DoesSessionExist() {
+			select {
+			case <-timeout:
+				if cleanupErr := t.Close(); cleanupErr != nil {
+					err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
+				}
+				return fmt.Errorf("timed out waiting for tmux session %s: %v", t.sanitizedName, err)
+			default:
+				time.Sleep(sleepDuration)
+				// Exponential backoff up to 50ms max
+				if sleepDuration < 50*time.Millisecond {
+					sleepDuration *= 2
+				}
 			}
 		}
+		// Session confirmed by poll loop, invalidate cache for fresh state
+		t.invalidateExistsCache()
 	}
 
 	// Session exists now, invalidate cache to ensure fresh state

--- a/web-app/src/app/review-queue/page.tsx
+++ b/web-app/src/app/review-queue/page.tsx
@@ -177,9 +177,9 @@ function ReviewQueueContent() {
   // Auto-advance to the next queue item after resolving the current one.
   // resolvedSessionId: the session that was just resolved (exclude from next-item search
   //   to handle the race where WebSocket hasn't removed it yet).
-  const handleAutoAdvance = useCallback((resolvedSessionId?: string) => {
+  const handleAutoAdvance = useCallback((resolvedSessionId?: string, force = false) => {
     setTimeout(() => {
-      if (!autoAdvanceRef.current) return; // Auto-advance disabled by user preference
+      if (!force && !autoAdvanceRef.current) return; // Auto-advance disabled by user preference
 
       const currentItems = reviewQueueItemsRef.current;
       const currentSelected = selectedSessionRef.current;
@@ -233,7 +233,7 @@ function ReviewQueueContent() {
     const current = selectedSessionRef.current;
     if (!current) return;
     await acknowledgeSession(current.id);
-    handleAutoAdvance(current.id);
+    handleAutoAdvance(current.id, true); // explicit dismiss always advances regardless of auto-advance setting
   }, [acknowledgeSession, handleAutoAdvance]);
 
   // Queue position for the header badge ("2 of 5")


### PR DESCRIPTION
## Summary

Performance fixes identified via pprof profiling (mutex, block, allocs profiles). Five targeted changes addressing the top bottlenecks:

- **Remove hot-path debug logging in review queue poller** — `checkSession` runs in up to 5 concurrent goroutines; each `log.DebugLog.Printf` serialized all goroutines on the stdlib log mutex (11.8B cycles, 22K events). All `debugLog.Printf` calls removed from the inner poll loop.

- **Hoist log calls outside `stateMutex` in `UpdateDiffStats`** — `instance.go` was calling `log.WarningLog.Printf` while holding `stateMutex`, creating a double-mutex chain (`stateMutex` → log mutex) that extended lock hold time. Replaced `defer Unlock` with explicit unlocks at each return point.

- **Pool `TerminalData` proto messages in WebSocket stream goroutine** — `connectrpc_websocket.go` was allocating a new proto message per terminal frame (25.4T block cycles, 68K events). Added `sync.Pool` + a coalescing drain loop that batches rapid bursts into a single write per flush.

- **Compile banner filter regexps once at package init** — `NewBannerFilter` was calling `regexp.MustCompile` for 10+ patterns on every `TmuxSession` creation. Moved to package-level `var` block.

- **Make PR-status storage methods no-ops** — GitHub PR fields are not in the ent schema, so `UpdateInstancePRStatus`/`UpdateInstancePRNumber`/`UpdateInstanceForkFlag` were performing a full `SELECT + UPDATE` round-trip that never persisted anything. Now return `nil` immediately.

## Test plan

- [ ] `go test ./session/... ./server/services/...` — all tests pass (pre-existing `TestSessionRecoveryScenarios` tmux integration failures are unrelated)
- [ ] `go vet ./session/... ./server/services/...` — no new issues
- [ ] Verify terminal streaming still works end-to-end after proto pooling change
- [ ] Confirm review queue still operates correctly after debug log removal