### PR TITLE
feat(omnibar): auto-populate session name, first prompt injection, inline shorthand

### DIFF
--- a/docs/registry/features/backend/session/create.json
+++ b/docs/registry/features/backend/session/create.json
@@ -11,5 +11,5 @@
     "TestCreateSession_MissingTitle",
     "TestCreateSession_MissingPath"
   ],
-  "lastModified": "2026-05-03T00:47:14.017894405-07:00"
+  "lastModified": "2026-05-05T00:00:00.000000000-07:00"
 }

--- a/docs/tasks/omnibar-session-name-ux.md
+++ b/docs/tasks/omnibar-session-name-ux.md
@@ -1,0 +1,606 @@
+# omnibar-session-name-ux — Implementation Plan
+
+Status: Ready for implementation
+Phase: 5 — Implementation
+Created: 2026-05-05
+Spec: `project_plans/omnibar-session-name-ux/`
+ADR: `project_plans/omnibar-session-name-ux/decisions/ADR-001-omnibar-inline-shorthand-language.md`
+
+---
+
+## Epic Overview
+
+Users who type a name or description into the omnibar must currently re-type that
+text into the session name field. There is no way to provide an initial Claude
+prompt at creation time, and switching session types requires reaching for the
+mouse. This epic removes all three friction points through a layered set of
+keyboard-first features.
+
+### Success Metrics
+
+1. Session name field is pre-populated from omnibar input in every creation mode
+   with no manual re-entry required.
+2. User can optionally attach a first prompt inline (via `>` separator) or via
+   an expandable textarea — no extra navigation needed.
+3. Tab key cycles session types without triggering browser autocomplete or path
+   completion dropdowns.
+4. `/oneoff`, `/worktree`, `/dir`, `/existing` prefix commands switch session
+   type and strip themselves from the resolved name.
+
+### Scope Boundary
+
+- In scope: TypeScript/React changes, one proto field thread-through, one ADR.
+- Out of scope: new session types, persistent prompt templates, new
+  DetectorRegistry entries for the slash commands themselves.
+
+### Architecture Decision Record
+
+ADR-001 (Omnibar Inline Shorthand Language) is filed in the project plans store,
+not in `docs/adr/` — it governs the planning-layer decision, not a persistent
+repo ADR. If the team decides to promote it to the repo ADR canon, assign the
+next number (012).
+
+---
+
+## Dependency Map
+
+```
+Story 1A: toSessionSlug()
+    └─> Story 1B: SessionSearchDetector fix (suggestedName)
+            └─> Story 2A: > separator parsing (depends on slug + detection type)
+            └─> Story 2B: /command prefix parsing (depends on slug)
+Story 1C: firstPrompt field in OmnibarFormState
+    └─> Story 1D: firstPrompt textarea in OmnibarCreationPanel
+            └─> Story 1E: firstPrompt thread-through (OmnibarContext + useSessionService)
+                    └─> Story 2A: > separator populates firstPrompt
+Story 3A: Tab cycling (independent, no blockers)
+```
+
+Stories 1A-1E are fully independent of Story 3A. Story 2 requires both Story 1
+chains to be complete. Run Stories 1 and 3 in parallel.
+
+---
+
+## Story 1 — Core Auto-fill and First Prompt
+
+**Goal:** Typing in the omnibar populates the session name automatically. A
+collapsible textarea lets users attach an optional initial Claude prompt.
+
+### Task 1.1 — `toSessionSlug` pure function
+
+**Files:** `web-app/src/lib/omnibar/slugify.ts` (new file)
+
+Implement a zero-dependency slug generator as a named export. The function must:
+
+- Strip leading/trailing whitespace.
+- Normalize Unicode to NFC, then replace non-ASCII with their closest ASCII
+  equivalent where possible (e.g. `é` → `e`), then drop anything remaining
+  outside `[a-zA-Z0-9]`.
+- Convert spaces and underscores to hyphens.
+- Collapse multiple consecutive hyphens to one.
+- Lowercase the result.
+- Trim leading and trailing hyphens.
+- Return `""` for degenerate inputs (empty string, emoji-only, CJK-only).
+  **Never** return a hardcoded fallback like `"session"` — the caller decides
+  the fallback.
+
+```ts
+export function toSessionSlug(input: string): string { ... }
+```
+
+Test file: `web-app/src/lib/omnibar/slugify.test.ts`
+
+Required test cases (add as `it` blocks under `describe("toSessionSlug")`):
+
+| Input | Expected output |
+|---|---|
+| `"my feature branch"` | `"my-feature-branch"` |
+| `"Fix: Auth / Login"` | `"fix-auth-login"` |
+| `"  leading spaces  "` | `"leading-spaces"` |
+| `"café au lait"` | `"cafe-au-lait"` |
+| `"emoji 🎉 party"` | `"emoji-party"` |
+| `"中文"` | `""` |
+| `""` | `""` |
+| `"---"` | `""` |
+| `"a".repeat(120)` | string with length <= 60 (truncate at 60 chars) |
+
+Add a max-length truncation of 60 characters (trim at word boundary if
+possible; hard-truncate otherwise) and strip trailing hyphens after truncation.
+
+Effort estimate: 2-3h
+
+### Task 1.2 — Wire `toSessionSlug` into `SessionSearchDetector`
+
+**Files:** `web-app/src/lib/omnibar/detector.ts`
+
+In `SessionSearchDetector.detect()`, change:
+
+```ts
+// Before
+suggestedName: "",
+```
+
+to:
+
+```ts
+// After — import { toSessionSlug } from "./slugify";
+suggestedName: toSessionSlug(trimmed),
+```
+
+The `lastSuggestedNameRef` guard in `Omnibar.tsx` (lines 361-366) already
+handles the "don't overwrite manually edited names" invariant. This change
+makes session name auto-fill work for free-text input for the first time.
+
+Verify: open the omnibar, type `"auth service refactor"`, switch to creation
+mode — session name field should read `"auth-service-refactor"`.
+
+Effort estimate: 30m (plus verifying existing guard logic still applies)
+
+### Task 1.3 — Add `firstPrompt` to `OmnibarFormState`
+
+**Files:** `web-app/src/components/sessions/Omnibar.tsx`
+
+Extend `OmnibarFormState` (line 36-50):
+
+```ts
+export interface OmnibarFormState {
+  // ... existing fields ...
+  firstPrompt: string;
+}
+```
+
+Extend `INITIAL_FORM_STATE` (line 52-66):
+
+```ts
+const INITIAL_FORM_STATE: OmnibarFormState = {
+  // ... existing fields ...
+  firstPrompt: "",
+};
+```
+
+No other logic changes in this task — that comes in Task 1.4 and 1.5.
+
+Effort estimate: 30m
+
+### Task 1.4 — `firstPrompt` textarea in `OmnibarCreationPanel`
+
+**Files:** `web-app/src/components/sessions/OmnibarCreationPanel.tsx`,
+`web-app/src/components/sessions/OmnibarCreationPanel.css.ts` (new or extend)
+
+Add a collapsible "First prompt (optional)" section below the session name
+field. Use the existing `collapsible`, `collapsibleHeader`, `collapsibleTitle`,
+`collapsibleIcon`, `expanded`, `collapsibleContent` style tokens already
+imported from `Omnibar.css` — do NOT add a new CSS module.
+
+UI behavior:
+- Collapsed by default. Disclosure triangle on click.
+- When `formState.firstPrompt` is non-empty (e.g. populated by the `>`
+  separator in Task 2.1), auto-expand on render.
+- Textarea: `rows={3}`, `placeholder="Claude will receive this as its first
+  message"`, `maxLength={4000}`.
+- onChange wires to `onFormChange({ firstPrompt: e.target.value })`.
+
+The `OmnibarCreationPanel` already receives `formState` and `onFormChange` as
+props. No new props are needed.
+
+If any local CSS needs to be added for the textarea specifically (e.g. full
+width, resize vertical only), add it to a `OmnibarCreationPanel.css.ts` file
+using vanilla-extract `style()`. Import from `web-app/src/styles/theme.css.ts`
+vars — never hardcode values.
+
+Effort estimate: 2h
+
+### Task 1.5 — Thread `firstPrompt` through the submission pipeline
+
+**Files:** `web-app/src/components/sessions/Omnibar.tsx`,
+`web-app/src/lib/contexts/OmnibarContext.tsx`,
+`web-app/src/lib/hooks/useSessionService.ts`
+
+**Step A — Fix the critical data loss bug in `handleSubmit` (Omnibar.tsx line 641):**
+
+Current code (BUGGY — silently drops firstPrompt):
+```ts
+const finalPrompt = imagePaths.length > 0 ? imagePaths.join(" ") : undefined;
+```
+
+Correct code:
+```ts
+const firstPromptText = formState.firstPrompt?.trim() || "";
+const finalPrompt =
+  [firstPromptText, ...imagePaths].filter(Boolean).join("\n") || undefined;
+```
+
+This fix must land before `firstPrompt` is wired anywhere else. Without it,
+firstPrompt data is silently dropped on submit regardless of what the UI shows.
+
+**Step B — Add `initialPrompt` to `OmnibarSessionData` (Omnibar.tsx line 76-97):**
+
+```ts
+export interface OmnibarSessionData {
+  // ... existing fields ...
+  initialPrompt?: string;
+}
+```
+
+**Step C — Pass `firstPrompt` through `handleSubmit`:**
+
+In both the `new_project` and else branch of `handleSubmit`, add:
+```ts
+prompt: finalPrompt,
+```
+(This field already exists in the data object; the fix in Step A is what makes
+it correct. No structural change to sessionData is needed here.)
+
+**Step D — Thread `initialPrompt` in `OmnibarContext.tsx`:**
+
+The `handleCreateSession` callback currently passes `prompt: data.prompt`.
+Confirm this maps correctly to `initial_prompt` field 15 in the proto after
+Step E. If `data.prompt` already maps to `prompt` in `createSession`, no
+structural change is needed — only the fix in Step A matters.
+
+Check `proto/session/v1/session.proto` field 15 (`initial_prompt`). Confirm
+`useSessionService.ts` `createSession` passes `prompt: request.prompt` to the
+RPC. If `initial_prompt` maps to `prompt` in the proto-generated types, no new
+field is needed. If there is a name mismatch, add `initialPrompt` to the
+`CreateSessionRequest` partial and thread it explicitly.
+
+**Step E — Confirm `useSessionService.ts` passes the field:**
+
+Current line 169: `prompt: request.prompt`. Verify this sends to
+`initial_prompt = 15` in the proto. If the generated field name differs from
+`prompt`, update both the context and the service hook.
+
+Effort estimate: 2-3h (the Step A bug fix is the highest-risk change; test
+carefully with image attachment + firstPrompt simultaneously)
+
+---
+
+## Story 2 — Separator Shorthand and Slash Commands
+
+**Prerequisite:** Story 1 complete (Tasks 1.1-1.5 merged and green).
+
+**Goal:** `my session > do something` splits on `>`. `/oneoff my task` switches
+session type and slugifies `my task` as the name.
+
+### Task 2.1 — `parseInputWithSeparator` pure function
+
+**Files:** `web-app/src/lib/omnibar/parseInput.ts` (new file)
+
+```ts
+export interface ParsedInput {
+  name: string;       // raw text before separator (trimmed)
+  prompt: string;     // raw text after separator (trimmed), or ""
+}
+
+export function parseInputWithSeparator(input: string): ParsedInput {
+  // Split on first '>' only
+  const idx = input.indexOf(">");
+  if (idx === -1) return { name: input.trim(), prompt: "" };
+  return {
+    name: input.slice(0, idx).trim(),
+    prompt: input.slice(idx + 1).trim(),
+  };
+}
+```
+
+Gating rule: this function is invoked only when
+`detection?.type === InputType.SessionSearch`. For all other detection types
+(LocalPath, GitHub URLs, etc.) the `>` character is treated as literal input.
+
+Apply in `Omnibar.tsx` at the points where `canSubmit` is computed and where
+`handleSubmit` builds the session data:
+
+In `canSubmit` (around line 610): derive `parsedName` from
+`parseInputWithSeparator(input)` when `detection?.type === InputType.SessionSearch`,
+then check `parsedName.name` for the session name validity test rather than
+raw `sessionName`.
+
+In `handleSubmit`: when `detection?.type === InputType.SessionSearch`, use
+`parsedName.name` as `title` and prepend `parsedName.prompt` to `finalPrompt`.
+
+In the detection debounce effect: when detection is `SessionSearch` and
+`parseInputWithSeparator` finds a prompt part, also auto-expand the firstPrompt
+textarea by setting `formState.firstPrompt` to the prompt part (so the user
+sees the split visually).
+
+Test file: `web-app/src/lib/omnibar/parseInput.test.ts`
+
+Required test cases:
+
+| Input | name | prompt |
+|---|---|---|
+| `"auth service"` | `"auth service"` | `""` |
+| `"auth service > fix login bug"` | `"auth service"` | `"fix login bug"` |
+| `" > only prompt"` | `""` | `"only prompt"` |
+| `"name > "` | `"name"` | `""` |
+| `"a > b > c"` | `"a"` | `"b > c"` |
+| `""` | `""` | `""` |
+
+Effort estimate: 2h
+
+### Task 2.2 — `parseSlashCommand` pure function
+
+**Files:** `web-app/src/lib/omnibar/parseSlashCommand.ts` (new file)
+
+```ts
+export interface SlashCommandResult {
+  matched: boolean;
+  sessionType: OmnibarFormState["sessionType"] | null;
+  remainder: string;  // input with prefix stripped, trimmed
+}
+
+// KNOWN_SLASH_COMMANDS is the sole extension point.
+// To add a new slash command: add one entry here. Nothing else changes.
+const KNOWN_SLASH_COMMANDS: Record<string, OmnibarFormState["sessionType"]> = {
+  "/oneoff":    "one_off",
+  "/one-off":   "one_off",
+  "/worktree":  "new_worktree",
+  "/dir":       "directory",
+  "/directory": "directory",
+  "/existing":  "existing_worktree",
+};
+
+export function parseSlashCommand(input: string): SlashCommandResult {
+  const trimmed = input.trimStart();
+  if (!trimmed.startsWith("/")) return { matched: false, sessionType: null, remainder: trimmed };
+
+  for (const [prefix, sessionType] of Object.entries(KNOWN_SLASH_COMMANDS)) {
+    if (trimmed.toLowerCase().startsWith(prefix + " ") || trimmed.toLowerCase() === prefix) {
+      const remainder = trimmed.slice(prefix.length).trimStart();
+      return { matched: true, sessionType, remainder };
+    }
+  }
+
+  // Starts with "/" but not a known command — do not consume
+  return { matched: false, sessionType: null, remainder: trimmed };
+}
+```
+
+Wire into `Omnibar.tsx` detection debounce (the `useEffect` at line 377):
+Pre-process the raw `input` string through `parseSlashCommand` before calling
+`detect(remainder)`. If `matched`, update `formState.sessionType` via
+`setFormState` and pass `remainder` to `detect()`. The session type change must
+be visible in the radio group immediately.
+
+Important: this pre-processing happens at the top of the debounce callback,
+before `detect()` is called. This is why slash commands are not a new Detector
+— the Detector receives the cleaned remainder, never the raw `/oneoff` prefix.
+
+This also resolves the HIGH bug: `/oneoff` currently matches `LocalPathDetector`
+(which fires on leading `/`). Because pre-processing runs first, `detector.detect()`
+never sees the `/oneoff` prefix.
+
+Test file: `web-app/src/lib/omnibar/parseSlashCommand.test.ts`
+
+Required test cases:
+
+| Input | matched | sessionType | remainder |
+|---|---|---|---|
+| `"/oneoff auth service"` | true | `"one_off"` | `"auth service"` |
+| `"/ONEOFF auth"` | true | `"one_off"` | `"auth"` |
+| `"/worktree"` | true | `"new_worktree"` | `""` |
+| `"/dir my project"` | true | `"directory"` | `"my project"` |
+| `"/existing"` | true | `"existing_worktree"` | `""` |
+| `"/unknown command"` | false | null | `"/unknown command"` |
+| `"normal input"` | false | null | `"normal input"` |
+| `"/oneofftogether"` | false | null | `"/oneofftogether"` |
+
+Effort estimate: 2h
+
+### Task 2.3 — Input preview label for separator
+
+**Files:** `web-app/src/components/sessions/Omnibar.tsx` (display only)
+
+When `detection?.type === InputType.SessionSearch` and the `>` separator is
+present, display a visual preview below the input showing how the input was
+split. This is informational only — no new state is introduced. Derive from
+the existing `input` string at render time.
+
+Format:
+```
+Name: "auth-service"  |  Prompt: "fix login bug"
+```
+
+Use an existing CSS class (e.g. `detectionInfo`) for the container. The name
+portion should show the slugified form (apply `toSessionSlug` inline).
+
+Gate: only render when `detection?.type === InputType.SessionSearch` AND
+`input.includes(">")`.
+
+Effort estimate: 1h
+
+---
+
+## Story 3 — Tab Cycling and Polish
+
+**Goal:** Tab key cycles session types. Empty slug shows validation hint.
+Both stories in this epic are independent of Story 2.
+
+### Task 3.1 — Tab session-type cycling
+
+**Files:** `web-app/src/components/sessions/Omnibar.tsx`
+
+Add a keydown handler on the main omnibar input element. When `key === "Tab"`
+and `!isDropdownVisible` (the boolean is already computed in Omnibar.tsx):
+
+1. `e.preventDefault()` — suppress browser tab navigation.
+2. Read current `formState.sessionType`.
+3. Find its index in `SESSION_TYPES` (imported from `OmnibarCreationPanel.tsx`
+   or duplicated locally — prefer a single source of truth via export).
+4. Advance to `(index + 1) % SESSION_TYPES.length`.
+5. `setFormState(prev => ({ ...prev, sessionType: next }))`.
+
+Gate enforcement: if `isDropdownVisible` is true, do NOT preventDefault and
+allow the Tab to interact with the dropdown normally. This resolves the HIGH
+bug where Tab cycles session type while the path completion dropdown is open.
+
+Do NOT implement Ctrl+Tab — Chrome intercepts this key combination at the
+browser level and it cannot be reliably prevented.
+
+Where to attach: the existing `handleKeyDown` function on the main `<input>`
+element (search for `onKeyDown` usage in Omnibar.tsx). Add the Tab case before
+the existing cases.
+
+Test: add a Jest/RTL test that fires a Tab keydown event and asserts the
+session type cycles. Assert no-op when dropdown is visible.
+
+Effort estimate: 2h
+
+### Task 3.2 — Empty slug validation hint
+
+**Files:** `web-app/src/components/sessions/OmnibarCreationPanel.tsx`
+
+When `formState.sessionName === ""` and `formState.sessionType !== "one_off"`
+and the user has typed something in the omnibar (i.e. the parent has non-empty
+`input`), display an inline hint below the session name input:
+
+```
+Session name could not be generated from this input — please enter a name.
+```
+
+Use the existing `errorClass` style token (imported from `Omnibar.css`). This
+is a hint, not a hard error — it should not block the submit button (submit is
+already blocked by `!sessionName.trim()`).
+
+This resolves the MEDIUM bug: when input is emoji-only or CJK-only,
+`toSessionSlug` returns `""` and the user sees a blank name field with no
+explanation. The hint makes the silent disable visible.
+
+The hint requires a new prop: `hasTypedInput: boolean` (true when
+`input.trim().length > 0`). Add this prop to `OmnibarCreationPanel`'s
+interface.
+
+Effort estimate: 1h
+
+---
+
+## Known Issues
+
+### CRITICAL: `handleSubmit` silently drops `firstPrompt` (data loss)
+
+**Location:** `web-app/src/components/sessions/Omnibar.tsx`, line 641
+
+**Description:** The current implementation builds `finalPrompt` exclusively
+from `imagePaths`. Any value in `formState.firstPrompt` is never included. If
+Task 1.3-1.4 are shipped without the Task 1.5 fix, users who enter a first
+prompt will see no error but their prompt will not reach Claude.
+
+**Fix:** Task 1.5 Step A. Must be the first change landed in Task 1.5.
+
+**Mitigation:** Implement Task 1.5 before or simultaneously with Task 1.4 so
+the UI and the wiring ship together. Never ship the textarea (Task 1.4) without
+the fix (Task 1.5).
+
+---
+
+### HIGH: `/oneoff` prefix matched as `LocalPathDetector` input
+
+**Location:** `web-app/src/lib/omnibar/detector.ts`, `LocalPathDetector.detect()`
+
+**Description:** `LocalPathDetector` fires on any input starting with `/` (line
+222). If a user types `/oneoff`, it is currently classified as a local path,
+causing incorrect UX (path completion attempts, wrong mode). Task 2.2
+pre-processes the input before `detect()` is called, which prevents the
+detector from ever seeing the `/oneoff` prefix.
+
+**Fix:** Task 2.2. Pre-processing in the debounce effect resolves this
+completely. No change to `LocalPathDetector` is required.
+
+**Risk if unaddressed:** `/oneoff` triggers path completion dropdown and shows
+an invalid-path indicator instead of switching session type.
+
+---
+
+### HIGH: Tab cycles session type while path-completion dropdown is open
+
+**Location:** `web-app/src/components/sessions/Omnibar.tsx` (Tab handler to be
+added in Task 3.1)
+
+**Description:** The existing `isDropdownVisible` boolean tracks whether the
+path-completion dropdown is open. Without gating the Tab handler on this
+boolean, pressing Tab while the dropdown is open would simultaneously dismiss
+the dropdown AND advance the session type — a confusing two-action side effect.
+
+**Fix:** Task 3.1 explicitly gates `e.preventDefault()` and type cycling on
+`!isDropdownVisible`. When dropdown is visible, Tab falls through to default
+browser behavior (dropdown interaction).
+
+---
+
+### MEDIUM: Degenerate slug silently disables submit with no user feedback
+
+**Location:** `web-app/src/components/sessions/OmnibarCreationPanel.tsx`
+
+**Description:** When `toSessionSlug` returns `""` (e.g. user typed `"中文"`
+or `"🎉🎉🎉"`), the session name field is empty, `canSubmit` returns false, and
+the submit button is disabled — but there is no message explaining why. The
+user's only recourse is to clear the field and type something else.
+
+**Fix:** Task 3.2 adds an inline validation hint that surfaces when the slug
+degenerates. The hint is visible only when the user has typed something and the
+name field is empty, making the causality clear.
+
+---
+
+## Integration Checkpoints
+
+After Task 1.2 is merged: manually verify auto-fill for free-text input in
+the omnibar. Type `"auth service refactor"` → switch to creation mode →
+session name must show `"auth-service-refactor"`.
+
+After Task 1.5 is merged: create a session with both `firstPrompt` text and an
+attached image. Verify the submitted prompt contains both, separated by `\n`.
+Verify with an empty `firstPrompt` that no extra `\n` appears.
+
+After Task 2.1 is merged: type `"my feature > fix the auth bug"` in the omnibar.
+Verify: session name shows `"my-feature"`, firstPrompt textarea expands with
+`"fix the auth bug"`.
+
+After Task 2.2 is merged: type `/oneoff build the thing` in the omnibar. Verify:
+session type radio jumps to "One-off", session name shows `"build-the-thing"`,
+no path completion dropdown appears.
+
+After Task 3.1 is merged: press Tab in the creation panel input. Verify session
+type advances through the list. Open path-completion dropdown, press Tab, verify
+no session type change occurs.
+
+---
+
+## Implementation Order (Critical Path)
+
+Run in this order, Stories 1 and 3 in parallel:
+
+1. Task 1.1 — `toSessionSlug` (unblocks 1.2, 2.1, 2.2)
+2. Task 1.3 — `firstPrompt` field in `OmnibarFormState` (unblocks 1.4, 1.5)
+3. Task 1.2 — Wire slug into `SessionSearchDetector`
+4. Task 1.4 + 1.5 simultaneously — textarea UI + submission fix (ship together)
+5. Task 3.1 — Tab cycling (independent, can run in parallel with 1.x)
+6. Task 2.1 — `parseInputWithSeparator` (requires 1.1 + 1.5 complete)
+7. Task 2.2 — `parseSlashCommand` (requires 1.1 + 1.2 complete)
+8. Task 2.3 — Preview label (requires 2.1)
+9. Task 3.2 — Empty slug hint (requires 1.1)
+
+---
+
+## Registry Checklist
+
+Slash commands alias existing session creation modes — they do NOT constitute a
+new session creation mode. The 7-touchpoint session-creation-registry checklist
+does NOT apply to Tasks 2.2 or 3.1.
+
+The `firstPrompt` field added in Task 1.3 threads through `OmnibarFormState`
+→ `OmnibarSessionData` → `handleCreateSession` → `createSession` RPC. Confirm
+`initial_prompt` (field 15) exists in `proto/session/v1/session.proto` before
+starting Task 1.5. If `initial_prompt` is already wired in `useSessionService`,
+no proto change is needed.
+
+The OmnibarAction union (`types.ts`) does NOT need a new action type. The
+`create_session` action already handles all new parameters via existing fields.
+The dispatch test suite does not need new describe blocks unless `dispatch.ts`
+logic changes.
+
+Run after each story:
+```bash
+cd web-app && npx jest --no-coverage --testPathPatterns="slugify|parseInput|parseSlashCommand|dispatch|detector"
+make quick-check
+```

--- a/project_plans/omnibar-session-name-ux/decisions/ADR-001-omnibar-inline-shorthand-language.md
+++ b/project_plans/omnibar-session-name-ux/decisions/ADR-001-omnibar-inline-shorthand-language.md
@@ -1,0 +1,189 @@
+# ADR-001: Omnibar Inline Shorthand Language
+
+Status: Accepted
+Date: 2026-05-05
+Deciders: Tyler Stapler
+
+---
+
+## Context
+
+The Stapler Squad omnibar is a keyboard-first launcher for creating and
+navigating AI agent sessions. As the omnibar gains more creation modes and
+configuration options (session type, branch, first prompt, program), there is
+pressure to surface these options without adding form fields that increase visual
+complexity and require mouse interaction.
+
+Comparable tools have solved this with inline shorthand syntax:
+
+- **Todoist** uses `>` to denote projects and `:` for labels inline in the task
+  name field. Users learn one input surface rather than two.
+- **Linear** uses `!priority` and `@assignee` prefixes inline in issue creation.
+- **Raycast** uses space-separated command extensions on its command bar.
+
+The principle behind these designs: the primary input field is the expert
+interface. Modal pickers and form fields are the discoverable fallback. Users
+who invest in learning the inline syntax get zero mouse friction.
+
+The question this ADR answers: what shorthand language should the Stapler Squad
+omnibar speak, and how should it be architecturally wired so that future
+additions are low-cost and low-risk?
+
+---
+
+## Decision
+
+The omnibar will support a minimal inline shorthand language with two
+constructs:
+
+### Construct 1: `>` Separator
+
+```
+<session name> > <first prompt>
+```
+
+The `>` character (first occurrence only) splits the input into a session name
+part and a first-prompt part. This is only active when the detection type is
+`SessionSearch` (free-text input, not a path or GitHub URL). For all other
+detection types, `>` is treated as a literal character in the input.
+
+Implementation: a pure function `parseInputWithSeparator(input)` that returns
+`{ name, prompt }`. Called at `canSubmit` evaluation and at `handleSubmit` —
+never as a Detector.
+
+### Construct 2: Slash-Command Prefix
+
+```
+/<command> <remainder>
+```
+
+A leading slash followed by a known keyword switches the active session type
+and strips itself from the input before detection. The remainder is passed to
+the normal detection pipeline.
+
+Known commands are defined in a single allowlist map:
+
+```ts
+const KNOWN_SLASH_COMMANDS: Record<string, SessionType> = {
+  "/oneoff":    "one_off",
+  "/one-off":   "one_off",
+  "/worktree":  "new_worktree",
+  "/dir":       "directory",
+  "/directory": "directory",
+  "/existing":  "existing_worktree",
+};
+```
+
+Unknown slash prefixes (e.g. `/foobar`) are passed through unchanged. The
+allowlist is the sole extension point — adding a new command requires editing
+only this map.
+
+Implementation: a pure function `parseSlashCommand(input)` that returns
+`{ matched, sessionType, remainder }`. Called before `detect()` in the 150ms
+debounce effect — never as a Detector.
+
+### Extension Contract
+
+To add a new slash command in the future:
+
+1. Add one entry to `KNOWN_SLASH_COMMANDS` in
+   `web-app/src/lib/omnibar/parseSlashCommand.ts`.
+2. Add test cases for the new prefix to
+   `web-app/src/lib/omnibar/parseSlashCommand.test.ts`.
+3. No other files change.
+
+Slash commands that alias an **existing** session type do not trigger the
+7-touchpoint session-creation-registry checklist. They simply set the session
+type in `OmnibarFormState`. If a slash command needs to enable a **new** session
+type that does not exist yet, that new type must go through the full 7-touchpoint
+checklist independently — the slash command is added after the type exists.
+
+To add a new separator construct (e.g. `@category`):
+
+1. Decide whether it is gated on detection type (like `>`) or unconditional.
+2. Add a new pure function in `web-app/src/lib/omnibar/parseInput.ts` or a
+   new file if the logic is substantially different.
+3. Wire it at the debounce effect level, not in the Detector layer.
+4. Document it in this ADR under "Construct N".
+
+---
+
+## Consequences
+
+### Positive
+
+- **Zero form fields added.** Both constructs are parsed from the primary input
+  field. The creation panel remains as compact as it is today.
+- **Low coupling.** Both constructs are pure functions with no external
+  dependencies. They are easy to test in isolation and easy to delete or modify.
+- **Discovery via the separator.** When the `>` separator is detected, the UI
+  auto-expands the firstPrompt textarea and shows a split preview below the
+  input. Users discover the shorthand through its effect, not through
+  documentation.
+- **LocalPath collision resolved.** By pre-processing slash commands before
+  `detect()`, the `LocalPathDetector` (which fires on any leading `/`) never
+  sees a valid slash command. No change to `LocalPathDetector` is required.
+- **Minimal footprint.** Two new files (`slugify.ts`, `parseSlashCommand.ts`),
+  one extended file (`parseInput.ts`), and a one-line change in `detector.ts`.
+
+### Negative / Trade-offs
+
+- **`>` is not universal.** The `>` separator is active only for `SessionSearch`
+  detection. Users who type a local path (e.g. `~/code/myapp`) cannot use `>`
+  to attach a first prompt inline — they must use the textarea. This is
+  acceptable because the `>` character appears legitimately in path contexts.
+- **Slash commands are not discoverable without documentation.** Unlike the `>`
+  separator (which shows a visual split preview), slash commands have no inline
+  affordance. Users must know the commands exist. This is consistent with how
+  power-user shortcuts work in Todoist and Linear.
+- **The allowlist is hard-coded.** Commands cannot be registered dynamically.
+  This is a deliberate choice — the allowlist is the contract, and unknown
+  slashes fall through unchanged rather than failing silently.
+
+---
+
+## Alternatives Rejected
+
+### Alternative A: New `Detector` classes for slash commands
+
+The initial research considered adding a `SlashCommandDetector` to the
+`DetectorRegistry`. This was rejected for two reasons:
+
+1. Detectors return a `DetectionResult` with a `type` field — but a slash
+   command does not create a new detection type, it mutates the session type in
+   `OmnibarFormState`. The Detector architecture has no mechanism to mutate form
+   state as a side effect of detection.
+2. A `SlashCommandDetector` at any priority would require coordination with
+   `LocalPathDetector` (priority 100), which also fires on leading `/`. The
+   priority ordering would need to encode slash-command awareness, coupling the
+   two detectors.
+
+Pre-processing before `detect()` is simpler and has no coupling to the registry.
+
+### Alternative B: Ctrl+Tab for session type cycling
+
+Browser-level key interception prevents `Ctrl+Tab` from being reliably
+`preventDefault`-ed in Chrome and Firefox. The shortcut fires a tab-switch
+action at the browser chrome level before any JavaScript keydown handler runs.
+Testing in Chrome confirmed this. Tab (without modifier) is used instead,
+gated on `!isDropdownVisible` to avoid conflicts with the path-completion
+dropdown.
+
+### Alternative C: Separate form fields for all omnibar configuration
+
+Adding explicit dropdowns or pickers for session type and first prompt inside
+the omnibar modal was rejected on the grounds of visual complexity. The omnibar
+is designed to be a single-input surface. Form fields work against this design
+and increase the number of interaction steps for experienced users. The
+expandable firstPrompt textarea (accessed via disclosure triangle or `>`
+shorthand) is the minimum viable escape hatch for users who prefer the
+visual approach.
+
+### Alternative D: Parsing the `>` separator in the Detector layer
+
+An alternative was to have `SessionSearchDetector` split on `>` and return
+both `suggestedName` (from the name part) and a new `suggestedPrompt` field in
+`DetectionResult`. This was rejected because `DetectionResult` is a stable
+interface shared across all detectors, and extending it for a feature specific
+to `SessionSearchDetector` would add noise for all callers. The pure function
+approach keeps the parsing isolated to the consumption site (Omnibar.tsx).

--- a/project_plans/omnibar-session-name-ux/requirements.md
+++ b/project_plans/omnibar-session-name-ux/requirements.md
@@ -1,0 +1,84 @@
+# Requirements: Omnibar Session Name UX
+
+Status: Draft | Phase: 1 - Ideation complete
+Created: 2026-05-05
+
+## Problem Statement
+
+When users open the omnibar, type a name or prompt, and select a session type
+(especially one-shot), they are forced to re-type the session name in a separate
+field. There is no way to inject a first prompt when creating a session. There
+is also no keyboard shortcut or inline syntax to switch session types without
+reaching for the mouse.
+
+**Who has this problem:** All users of the Stapler Squad omnibar who create
+sessions, particularly one-off/one-shot sessions.
+
+## Success Criteria
+
+1. User types text in the omnibar → session name is auto-populated as a
+   smart kebab-case slug — no re-typing required in any session creation mode
+2. User can optionally provide a first prompt via an expandable section below
+   the session name, or inline using a separator shorthand (Todoist-style `>`)
+3. User can cycle through session types with a keyboard shortcut (Tab/Ctrl+Tab)
+   while focused in the omnibar input
+4. User can switch session type inline via slash-command prefix
+   (e.g. `/oneoff`, `/worktree`, `/dir`)
+
+## Scope
+
+### Must Have (MoSCoW)
+- Auto-populate session name field from omnibar typed input as a smart
+  kebab-case slug in all session creation modes
+- Expandable "First prompt (optional)" section below session name
+- Inline separator shorthand to split session name from first prompt
+  (e.g. `my session > do something important`)
+- Keyboard shortcut to cycle through session types (Tab / Ctrl+Tab while in
+  the omnibar input)
+- Slash-command prefix to switch session type inline
+  (`/oneoff`, `/worktree`, `/existing`, `/dir`)
+- ADR documenting the Todoist-style inline shorthand syntax pattern and the
+  principle that the omnibar supports rich inline commands (to guide future
+  feature work)
+
+### Out of Scope
+- Adding new session creation types
+- Persistent/reusable prompt templates
+- Adding new omnibar detection patterns (DetectorRegistry entries)
+- Any backend-only changes unrelated to supporting the first prompt
+
+## Constraints
+
+Tech stack: React + TypeScript (vanilla-extract CSS), ConnectRPC/protobuf for
+backend, Go server
+Timeline: Not set
+Dependencies:
+- `proto/session/v1/session.proto` — may need a new `first_prompt` field on
+  `CreateSessionRequest` to support passing the first Claude prompt through
+- Session creation registry (7 touchpoints) — any new fields threaded to the
+  RPC require all 7 touchpoints to be updated
+- `web-app/src/lib/omnibar/actions/` — OmnibarAction union + dispatch must be
+  updated if behavior changes
+
+## Context
+
+### Existing Work
+- One-off session feature (2026-04-24) is the canonical example of the
+  flag-on-create_session pattern; first-prompt should follow the same pattern
+- The omnibar already uses a DetectorRegistry for input pattern detection
+- Session types: directory, new_worktree, existing_worktree, one_off
+- The inline slash-command concept does not exist yet; this is net-new
+
+### Stakeholders
+- Tyler Stapler (sole practitioner / end user)
+
+## Research Dimensions Needed
+
+[ ] Stack - how the slug generation should work (library vs. custom), how
+    first_prompt would be threaded from UI → RPC → session startup
+[ ] Features - survey comparable tools (Todoist, Linear, Raycast) for
+    inline shorthand UX patterns; session-type cycling in launcher UIs
+[ ] Architecture - where to parse the inline separator, state shape for
+    first-prompt in OmnibarFormState, ADR structure
+[ ] Pitfalls - edge cases in slug generation (emoji, special chars, long
+    input), shorthand parsing ambiguities, keyboard shortcut conflicts

--- a/project_plans/omnibar-session-name-ux/research/findings-architecture.md
+++ b/project_plans/omnibar-session-name-ux/research/findings-architecture.md
@@ -1,0 +1,350 @@
+# Findings: Architecture
+
+## Summary
+
+Four architectural decisions shape this feature. Each has been analyzed against the actual codebase
+topology: Omnibar.tsx, OmnibarCreationPanel.tsx, detector.ts, useModeReducer.ts, and the
+OmnibarContext/useSessionService pipeline.
+
+The central theme: all four features sit at the boundary between the detection pipeline (150ms
+debounce, returns DetectionResult) and the React form state (synchronous, drives UI). Decisions
+made here govern UX responsiveness, testability, and future extensibility of the omnibar as a
+command surface.
+
+Key grounding observations from code:
+- Detection fires at 150ms debounce in a `useEffect` on `input` (Omnibar.tsx lines 329-384).
+- Auto-fill of session name is gated on `result.suggestedName` (lines 361-366); if SessionSearch
+  returns `suggestedName: ""` (detector.ts line 300), the fill never happens — this is the exact
+  gap to close for Q3.
+- Slash-command prefix detection (`new/` shorthand) lives in `NewSessionDetector` at priority 35
+  and feeds a `new_prefix_typed` mode action — this is the established pattern for prefix commands.
+- `OmnibarFormState` has no `firstPrompt`; `OmnibarSessionData.prompt` is defined; OmnibarContext
+  already passes `prompt: data.prompt` to the RPC. The field exists at every layer except the form
+  state interface and the panel UI.
+- `handleSubmit` (Omnibar.tsx lines 639-641) builds `finalPrompt` from attached images only.
+  Adding `firstPrompt` to OmnibarFormState without updating this produces silent data loss.
+
+---
+
+## Options Surveyed
+
+### Q1: Where should inline `>` separator parsing happen?
+
+**Option A: onChange handler (live split)**
+Parse on every keystroke. As soon as the user types `>`, split the input string in place:
+left side → `sessionName`, right side → `firstPrompt`. The main input field then holds only
+the path/search portion; `firstPrompt` is populated immediately.
+
+Implications: The `>` character is consumed from the primary input field. Reversal (backspacing
+past `>`) requires detecting that `firstPrompt` is empty and recombining — adds state machine
+complexity. Path detection (`/foo/bar > start coding`) must receive only the path-portion, which
+requires the split to already have happened before detection runs.
+
+**Option B: Derived value for display, split on submit (compute-on-read)**
+Store the raw unsplit string in `input`. Compute `parsedName` and `parsedPrompt` as derived
+values at the point of use: in `canSubmit`, `handleSubmit`, and the session name preview label.
+Detection pipeline receives the full `my-name > first prompt` string — no path/URL pattern contains
+`>`, so it falls through to SessionSearch, which then triggers the bare-text auto-fill path
+described in Q3. The parse is a pure function `parseInputWithSeparator(input)`.
+
+Implications: `input` is the single source of truth. No state recombination needed on backspace.
+The pure function is trivially testable. Visual feedback can be provided by showing a parsed
+preview in the session name field label. Clean separation between parse-time and effect-time.
+
+**Option C: Submit handler only**
+No live feedback. Parse in `handleSubmit` just before calling `onCreateSession`.
+
+Implications: User cannot verify the split before committing. Fails progressive disclosure UX
+principle for power syntax. Acceptable only for an MVP, not a finished feature.
+
+---
+
+### Q2: Where should slash-command prefix parsing happen?
+
+**Option A: New Detector in DetectorRegistry (priority < 10)**
+Register a `SlashCommandDetector` at priority 5. Matches `/oneoff ...`, `/worktree ...`.
+Returns a DetectionResult with a new `InputType.SlashCommand` variant carrying `commandName`
+and `remainder` in `metadata`.
+
+Implications: Consistent with how `NewSessionDetector` handles `new/` prefix at priority 35.
+Fully testable in isolation. BUT: creates a coupling problem. The modeReducer currently
+cannot set `sessionType` in formState — it only controls display mode. A SlashCommand
+InputType would need to somehow communicate `sessionType = "one_off"` to `OmnibarFormState`,
+which lives outside the detection pipeline. This requires either (a) a new action type in
+modeReducer that also carries a formState patch, or (b) a side-effect in the detection
+useEffect that reads `result.metadata.command` and calls `setFormField`. Option (b) is the
+path of least resistance but muddles the responsibilities of the detection useEffect.
+
+Critically: the `LocalPathDetector` at priority 100 accepts any string starting with `/`
+that contains multiple slashes. `/oneoff hello world` has only one slash so would not match
+LocalPathDetector — but a priority-5 `SlashCommandDetector` with an open-ended pattern like
+`/\w+` would also match `/tmp/myproject`, stealing it from LocalPathDetector. This requires
+tight allowlisting in the detector.
+
+**Option B: Pre-processing step before DetectorRegistry (input preprocessing)**
+In the 150ms debounce `useEffect`, before calling `detect(input)`, check if input starts
+with `/` followed by a known command keyword. If matched, call `setFormField("sessionType", ...)`
+immediately, strip the command prefix, and pass the remainder to `detect()`.
+
+Implications: Synchronous — no debounce lag on the type switch. No new InputType enum needed.
+Cannot be tested via DetectorRegistry unit tests, but testable as a pure `parseSlashCommand()`
+function. Has one explicit branching point rather than requiring modeReducer/formState
+coordination with a new InputType. More direct for this use case: slash commands mutate
+form state, not detection type.
+
+**Option C: OmnibarCreationPanel interceptor**
+Parse in the creation panel. Rejected: the panel only receives `formState`, not `input`.
+Threading raw input down as a prop violates the existing boundary.
+
+---
+
+### Q3: Where should bare-text → kebab slug auto-fill happen?
+
+**Option A: SessionSearchDetector returns suggestedName**
+Change `SessionSearchDetector.detect()` to compute a slug:
+`suggestedName: toKebabSlug(trimmed)` instead of `suggestedName: ""`.
+The auto-fill logic in Omnibar.tsx lines 361-366 fires because `result.suggestedName` is now
+non-empty. The existing `lastSuggestedNameRef` guard (line 362-365) prevents overwriting a
+manually edited name. Zero new state, one-line change in detector.ts.
+
+Implications: Consistent with how every other detector supplies `suggestedName`. The guard
+(`sessionName === ""` OR `sessionName === lastSuggestedNameRef.current`) correctly skips
+auto-fill if the user already typed a name. This is the minimal change with maximum leverage.
+
+**Option B: Separate useEffect on input**
+Add a new `useEffect` watching `input` and detection type; if type is SessionSearch, compute
+slug and call `setSessionName`.
+
+Implications: Duplicates the manual-edit guard that already exists. More surface area, more
+tests. No benefit over Option A.
+
+**Option C: Preview-only state, commit on Tab/Enter**
+Show computed slug as a greyed placeholder in the session name field. Commit only on Tab or
+on typing something different.
+
+Implications: Requires "suggested but uncommitted" vs "user typed" distinction in state.
+The existing `lastSuggestedNameRef` already provides this distinction implicitly via Option A.
+Option C adds complexity for the same UX outcome.
+
+---
+
+### Q4: ADR structure for inline-shorthand concept
+
+**Option A: Single ADR covering the full inline shorthand concept**
+Title: "ADR-NNN: Omnibar Inline Shorthand Language"
+Covers both the `>` separator and `/command` prefix as a unified "command language" design
+decision. Sections: Context, Decision, Consequences, Alternatives Rejected, Extension Contract
+(how to add new slash commands). This documents the design intent and prevents ad-hoc extension.
+
+**Option B: Separate ADRs per feature**
+One ADR for `>` separator parse location, one for slash command routing. Granular but risks
+over-formalization for what are essentially two implementation choices within one UX feature.
+
+**Option C: No ADR — extend existing registry rules**
+Update `.claude/rules/session-creation-registry.md` and `.claude/rules/feature-testing-registry.md`
+with inline shorthand conventions. Skips the ADR format entirely.
+
+---
+
+## Trade-off Matrix
+
+| Decision | Option | Responsiveness | Testability | Code Surface | State Complexity | Safe Extension |
+|---|---|---|---|---|---|---|
+| Q1 `>` separator | A: onChange split | Instant | Medium | Medium | High (recombine) | Low |
+| Q1 `>` separator | **B: derive on read** | Instant (computed) | High (pure fn) | Low | None | High |
+| Q1 `>` separator | C: submit only | None | High | Low | None | N/A |
+| Q2 slash command | A: Detector + InputType | 150ms lag | High | Medium | High (coupling) | Low |
+| Q2 slash command | **B: Pre-processing** | Instant | High (pure fn) | Low | None | Medium |
+| Q2 slash command | C: Panel interceptor | Instant | Low | Medium | High | Low |
+| Q3 bare-text slug | **A: SessionSearchDetector** | 150ms lag | High | Minimal | None | High |
+| Q3 bare-text slug | B: Separate useEffect | 150ms lag | Medium | Medium | Low | Medium |
+| Q3 bare-text slug | C: Preview-only state | Instant | High | High | High | Medium |
+| Q4 ADR | **A: Single ADR** | N/A | N/A | N/A | N/A | High |
+| Q4 ADR | B: Separate ADRs | N/A | N/A | N/A | N/A | Medium |
+| Q4 ADR | C: No ADR | N/A | N/A | N/A | N/A | Low |
+
+---
+
+## Risk and Failure Modes
+
+**Q1 — `>` in non-bare-text inputs**
+Paths never contain `>` (shell would expand it). GitHub URLs don't contain `>`. However,
+pasted content (git commit messages, bash heredocs) might. Mitigation (Option B): only apply
+the separator parse when `detection?.type === InputType.SessionSearch`. Path and URL inputs
+are never in SessionSearch type — the parse is gated by detection type, not by character presence.
+
+**Q2 — slash command collides with local paths**
+`/tmp/foo` is a valid local path. A greedy SlashCommandDetector at priority 5 would intercept
+it. Mitigation for both options: require known command keywords in an explicit allowlist
+(`KNOWN_SLASH_COMMANDS = ["oneoff", "worktree", "directory"]`). Never match `/tmp`, `/usr`,
+`/home`, etc. Check `input.startsWith("/" + knownCommand + " ")` or
+`input.startsWith("/" + knownCommand + "\n")` — require a space or end-of-input after the keyword.
+
+**Q3 — slug update races with manual editing**
+The existing `lastSuggestedNameRef` guard (Omnibar.tsx:362-365) handles this: if
+`sessionName !== lastSuggestedNameRef.current`, auto-fill is skipped. A slug from
+SessionSearchDetector flows through the same guard. No new race condition introduced.
+
+**firstPrompt threading gap in handleSubmit**
+Current code (Omnibar.tsx:639-641): `finalPrompt = imagePaths.length > 0 ? imagePaths.join(" ") : undefined`. Adding `firstPrompt` to OmnibarFormState without patching this line produces a silent
+data loss bug. The correct logic: `finalPrompt = [formState.firstPrompt?.trim(), ...imagePaths].filter(Boolean).join("\n") || undefined`.
+
+**ADR without extension contract**
+If the shorthand concept is underdocumented, future developers add new slash commands as
+ad-hoc `if (input.startsWith("/"))` checks scattered in Omnibar.tsx's onChange handler.
+The ADR must specify: "new slash commands are added to `KNOWN_SLASH_COMMANDS` in
+`parseSlashCommand.ts`, not as inline conditionals."
+
+---
+
+## Migration and Adoption Cost
+
+**firstPrompt field — 4 precise touchpoints:**
+1. `OmnibarFormState` interface (Omnibar.tsx:36-50) — add `firstPrompt: string`
+2. `INITIAL_FORM_STATE` (Omnibar.tsx:52-66) — add `firstPrompt: ""`
+3. `handleSubmit` (Omnibar.tsx:639-641) — incorporate `formState.firstPrompt` into `finalPrompt`
+4. `OmnibarCreationPanel` — add expandable textarea below session name field
+
+These are additive, non-breaking. No proto change needed (`initial_prompt` field 15 already
+exists in the proto and is threaded through the full stack).
+
+**Slug auto-fill — 1 touchpoint:**
+- `SessionSearchDetector.detect()` — change `suggestedName: ""` to `suggestedName: toKebabSlug(trimmed)`
+
+**`>` separator (Option B) — 3 touchpoints:**
+1. New pure function `parseInputWithSeparator(input: string): { name: string; firstPrompt: string }`
+2. `canSubmit` — call the function to extract name for validation preview
+3. `handleSubmit` — call the function to extract `firstPrompt` (merged with image paths)
+
+**Slash command preprocessing (Option B) — 2 touchpoints:**
+1. New pure function `parseSlashCommand(input: string): { command: string; remainder: string } | null`
+2. Top of the 150ms debounce `useEffect` in Omnibar.tsx — call `parseSlashCommand`, set
+   `formField("sessionType", ...)` if matched, pass remainder to `detect()`
+
+**Registry updates (per `.claude/rules/`):**
+- No new RPC method → no `backend-features.json` entry
+- No new session creation mode lifecycle → 7-touchpoint checklist NOT triggered for slash
+  commands that alias existing modes (one_off, worktree)
+- New UI component (firstPrompt textarea) → add entry to `frontend-features.json`
+
+---
+
+## Operational Concerns
+
+**Detection debounce and slug freshness**: Slug updates from SessionSearchDetector fire after
+150ms. If the user types fast and submits immediately with Cmd+Enter before debounce fires,
+the session name reflects pre-debounce state. This is identical behavior to existing branch/path
+auto-fill — not a new regression.
+
+**Expandable textarea height**: The first prompt textarea will sit below the session name field
+in an already-constrained modal. Start at 1 row; expand on focus or content overflow.
+`field-sizing: content` is the modern CSS approach [TRAINING_ONLY - verify browser support];
+fallback is a `rows` adjustment on `onChange` using `scrollHeight`.
+
+**Slash command visual feedback**: When user types `/oneoff `, the session type switches to
+`one_off`, the path input disappears (already hidden for one_off mode), and the mode badge
+changes. The existing one_off hint ("Directory will be created in your one-off base directory…")
+displays correctly as long as `sessionType === "one_off"` is set. No additional feedback logic
+needed beyond what already exists.
+
+**`>` separator feedback**: In Option B (derive on read), the user has no live signal that the
+split will happen. Add a computed session name preview label: when input contains `>` and
+detection type is SessionSearch, show "Session name: `<computed-slug>`" below the input field.
+This is additive to the existing detection badge.
+
+---
+
+## Prior Art and Lessons Learned
+
+**`NewSessionDetector` at priority 35**: Already the canonical example of prefix-command
+shortcut in this codebase. Matches `new/` prefix, returns `InputType.NewSession` with remainder
+in `parsedValue`. The modeReducer dispatches `new_prefix_typed` which sets `creation_with_repo`
+mode with the remainder as the query. The key difference for slash commands: `NewSessionDetector`
+does not need to set `formState.sessionType` because `creation_with_repo` mode implies a new
+worktree. Slash commands like `/oneoff` DO need to set `sessionType` in formState. This is the
+coupling gap that makes pre-processing (Q2 Option B) preferable to a new Detector (Q2 Option A).
+
+**`lastSuggestedNameRef` guard pattern**: The existing guard (Omnibar.tsx:169, used at lines
+362-365) is a mature solution to the "auto-fill without stomping manual edits" problem. Any
+new slug auto-fill must go through this same guard. SessionSearchDetector returning `suggestedName`
+gets this protection automatically — no new guard logic needed.
+
+**Image path prompt concatenation**: Current `finalPrompt` is `imagePaths.join(" ")`. Adding
+`firstPrompt` must prepend text before image paths. The forward-compatible format:
+`[textPrompt, ...imagePaths].filter(Boolean).join("\n")`. This is backward-compatible because
+when `firstPrompt` is empty, the result equals the existing behavior.
+
+**`one_off` session mode pattern**: One-off mode already demonstrates the "flag on existing
+session type" pattern: `sessionType === "one_off"` in formState maps to `SessionType.DIRECTORY`
+in the proto + `oneOff: true` flag. Slash commands that activate existing modes (e.g., `/oneoff`)
+simply set `formState.sessionType` to the existing string value — no new proto field or session
+type constant needed.
+
+---
+
+## Open Questions
+
+1. **Separator character choice**: Is `>` the right separator? Alternatives: `|`, `//`, `::`.
+   `>` has Todoist precedent but evokes shell redirection. `|` evokes Unix pipes. `//` is least
+   ambiguous but requires two characters. Decision needed before implementation — it affects the
+   pure function signature and the ADR.
+
+2. **Slug character limit**: Should `toKebabSlug` cap output length? Tmux session names and git
+   branch names have practical limits. Suggested cap: 40 characters. The ADR should specify this.
+
+3. **Slash command discovery**: No current mechanism shows available slash commands. A lone `/`
+   typed by the user could show a contextual command dropdown. Out of scope for initial feature
+   but the ADR extension contract should reserve this UX slot.
+
+4. **`>` parse scope**: Should the separator apply only in SessionSearch mode, or also when the
+   user has manually switched to one-off mode (where the input is the session name, not a path)?
+   In one-off mode, the input field is currently the session name field — the separator might be
+   welcome there too. Needs UX decision.
+
+5. **firstPrompt field naming**: `OmnibarFormState` will use `firstPrompt`; `OmnibarSessionData`
+   uses `prompt`. The ADR should codify this naming convention to prevent confusion with "AI
+   assistant prompts" vs "initial session start prompts."
+
+---
+
+## Recommendation
+
+**Q1 — `>` separator parsing: Option B (derive on read)**
+
+Parse `input` with a pure function `parseInputWithSeparator(s: string): { name: string; firstPrompt: string }`
+at the point of use — in `canSubmit`, `handleSubmit`, and in a session name preview label.
+Apply only when `detection?.type === InputType.SessionSearch` to prevent false fires on path
+inputs. Zero new state. Testable as a pure function. Add a visible preview label when the
+separator is detected.
+
+**Q2 — slash command prefix: Option B (pre-processing before DetectorRegistry)**
+
+Add a `parseSlashCommand(input: string)` pure function with an explicit known-command allowlist.
+Call at the top of the 150ms debounce `useEffect` in Omnibar.tsx, before `detect(input)`.
+If matched, call `setFormField("sessionType", ...)` immediately, pass remainder to `detect()`,
+update the mode badge. This avoids the InputType/modeReducer/formState coupling problem and
+keeps slash-command logic in one testable, auditable function.
+
+**Q3 — bare-text slug auto-fill: Option A (SessionSearchDetector returns suggestedName)**
+
+Change the single line in `SessionSearchDetector.detect()` from `suggestedName: ""` to
+`suggestedName: toKebabSlug(trimmed)`. The existing `lastSuggestedNameRef` guard in Omnibar.tsx
+handles manual-edit protection automatically. Minimal change, maximum leverage.
+
+**Q4 — ADR structure: Option A (single ADR)**
+
+Write `ADR-NNN: Omnibar Inline Shorthand Language` covering both the `>` separator and
+`/command` prefix as a unified design decision. Required sections: Context, Decision,
+Consequences, Extension Contract (exactly how to add new slash commands), Alternatives Rejected.
+The extension contract is the most important section — it prevents future ad-hoc proliferation.
+
+---
+
+## Pending Web Searches
+
+1. `field-sizing content CSS property browser support 2026` — verify browser support for
+   the auto-expanding textarea approach before recommending it in implementation
+2. `inline command language UX patterns omnibar launcher Raycast Linear` — confirm prior
+   art for `/command` prefix in production launcher interfaces
+3. `tmux session name maximum length limit` — confirm tmux session name character limit to
+   inform slug truncation default

--- a/project_plans/omnibar-session-name-ux/research/findings-features.md
+++ b/project_plans/omnibar-session-name-ux/research/findings-features.md
@@ -1,0 +1,201 @@
+# Findings: Features
+
+## Summary
+
+Three features are under consideration: (1) an inline separator shorthand (`name > prompt`), (2) slash-command prefixes to switch session type inline (`/oneoff`, `/worktree`, etc.), and (3) a keyboard shortcut to cycle through session types from the omnibar input.
+
+All three have strong prior art in widely-used tools. The separator shorthand closely matches Todoist's natural-language inline syntax. The slash-command prefix matches Slack, Notion, and Linear's command-palette patterns. The keyboard cycling already exists in the codebase at the radio-group level (arrow keys in `SessionTypeRadioGroup`) but needs to be exposed at the omnibar input level.
+
+The core UX tension across all three: power-user ergonomics vs. beginner discoverability. Todoist-style inline syntax is invisible until you know about it; tools that succeed with it always pair it with a visible affordance (ghost text, tooltip, or sidebar hint).
+
+---
+
+## Options Surveyed
+
+### Feature 1: Inline separator shorthand
+
+**Option A — `>` separator** (Todoist-style chevron)
+Todoist uses a right-pointing chevron to mean "then" or "and do." Maps naturally to "session name, then start with this prompt." `>` is not a shell redirect in this context (omnibar is not a shell). Visual metaphor: `>` suggests "pass to" or "pipe into."
+
+**Option B — `|` pipe separator**
+Familiar from shell and functional programming. Readable. But `|` visually competes with path separators and is less natural as "attach a prompt to a name."
+
+**Option C — `:` colon separator**
+Used by VS Code quick-open (`file:line`), browsers (`url:query`), and GitHub search (`is:open`). Risk: colons appear in path-like inputs and the existing `PathWithBranchDetector` uses `@` but future patterns could add `:`.
+
+**Option D — ` -- ` double-dash separator**
+CLI idiom. Requires two characters plus spaces. Too verbose for an omnibar.
+
+**Option E — `\n` newline (Shift+Enter)**
+Alfred and some launchers treat a second line as note/subtext. Cleanest visual separation. Keyboard cost: chord required. Conflicts with "submit on Enter" unless Shift+Enter is explicitly intercepted.
+
+### Feature 2: Slash-command prefix for session type switching
+
+**Option A — `/oneoff`, `/worktree`, `/dir`, `/existing`**
+Matches Slack's `/slash-command` convention. Slash at position 0 is unambiguous — no existing detector matches it (`NewSessionDetector` uses `new/` with slash after the word, not before). Slash is muscle memory for Slack/Notion users.
+
+**Option B — `!`-prefixed mode shortcuts (`!oneoff`, `!worktree`)**
+Bang-prefix convention from DuckDuckGo bangs and npm. Unambiguous but less learnable.
+
+**Option C — Tab-activated mode picker overlay**
+Pressing Tab opens a floating mode selector. Adds UI complexity; is essentially Option D below.
+
+**Option D — Cycle on Tab (no inline syntax)**
+Tab cycles through session types without any slash syntax. Simple. Zero parsing. Risks conflicting with Tab autocomplete for paths if that is ever added.
+
+### Feature 3: Keyboard shortcut to cycle through session types
+
+**Option A — Tab (while in omnibar input, creation panel visible)**
+Simplest. Mirrors VS Code quick-open. Risk: Tab is the standard "move focus to next field" HTML key; `preventDefault` required.
+
+**Option B — Ctrl+Tab**
+High conflict risk; browsers intercept Ctrl+Tab for browser-tab switching before the page sees it.
+
+**Option C — Alt+Arrow (Up/Down)**
+Consistent with existing `SessionTypeRadioGroup` arrow-key behavior. Low conflict risk. Less discoverable.
+
+**Option D — Dedicated shortcut with visible UI hint (e.g., `⌘K` or `⌘/`)**
+Best discoverability. Higher implementation cost.
+
+---
+
+## Trade-off Matrix
+
+| Option | Discoverability | Parsing complexity | Conflict risk | Power-user ceiling | Prior art strength |
+|---|---|---|---|---|---|
+| `>` separator | Low (invisible) | Low | None in this context | High | Strong (Todoist) |
+| `\|` separator | Low | Low | Low | High | Medium |
+| `:` separator | Low | Low | Medium (future path patterns) | High | Strong (VS Code, GitHub) |
+| `\n` separator | Medium | None | Low | Low | Medium |
+| `/oneoff` prefix | Medium | Low | None | High | Strong (Slack, Notion, Linear) |
+| `!oneoff` prefix | Low | Low | None | Medium | Weak |
+| Tab cycling | High | None | Medium (form focus) | Medium | Strong (VS Code) |
+| Ctrl+Tab cycling | Medium | None | High (browser intercepts) | Medium | Weak |
+| Alt+Arrow cycling | Low | None | Low | Medium | Weak |
+
+---
+
+## Risk and Failure Modes
+
+### Separator shorthand
+
+**Ambiguous inputs.** The character `>` does not appear in any current detector pattern (verified by reading `detector.ts`). Splitting on the first `>` will not conflict with GitHub URL detectors, PathWithBranchDetector, or LocalPathDetector. If a user types a session name containing `>` (e.g., a markdown-heading-like label `> Note`), the right half will be treated as the first prompt. This is acceptable: `>` is rare in session names and the split is visually obvious.
+
+**Multi-`>` inputs.** `name > part1 > part2` — must split on only the first `>`. Text after the first separator belongs entirely to the prompt. Implement as `indexOf(">")` split, not a global `split(">")`.
+
+**Empty segments.** `> prompt` (no name) or `name >` (no prompt) must be handled gracefully: treat empty name as "untitled" or skip separator parsing altogether when either side is empty.
+
+### Slash-command prefix
+
+**Conflicts with existing `NewSessionDetector`.** `NewSessionDetector` (priority 35) matches `new/` — a word then slash. A `/oneoff` prefix starts with `/`, not a word. These are orthogonal. No conflict.
+
+**Conflicts with path inputs.** `LocalPathDetector` matches `/absolute/path`. A slash followed by a non-command word (e.g., `/home`) must fall through to `LocalPathDetector`, not be treated as a mode command. The slash-command parser must only match exact registered keywords (`/oneoff`, `/worktree`, `/dir`, `/existing`). Unrecognized `/foo` falls through as-is.
+
+**Discoverability.** Users who never read documentation will never discover slash commands. Mitigation: ghost text or a hint shown when the omnibar is first focused.
+
+### Tab cycling
+
+**Browser focus management.** Capturing `Tab` in the omnibar input prevents advancing focus through creation panel fields below. `preventDefault` is required, and must be conditional: only activate Tab cycling when the creation panel is shown and no results dropdown is open.
+
+**Dropdown interaction.** When the session-search results dropdown is open, Tab may be expected to select the focused result. Tab cycling for session types must be suppressed when the dropdown is visible.
+
+---
+
+## Migration and Adoption Cost
+
+**Separator shorthand.** Zero breaking changes. The feature is purely additive: existing inputs without `>` parse identically. The `initial_prompt` field (#15) already exists in `CreateSessionRequest` proto and the threading pipeline exists up to `OmnibarContext`. The only missing piece is a `firstPrompt` field in `OmnibarFormState` and a textarea in `OmnibarCreationPanel`. Cost: low.
+
+**Slash-command prefix.** Requires adding a new detector (or pre-detector guard) before the `DetectorRegistry`. Existing detectors are unaffected. Maps cleanly onto the existing `SESSION_TYPES` array and the radio group's `onChange` handler. The `NewSessionDetector` (priority 35) is the model to follow. Cost: low-medium.
+
+**Tab cycling.** Requires a `keydown` handler on the omnibar input, gated on creation-panel visibility. Connects to `OmnibarFormState.sessionType` via the same state path that `SessionTypeRadioGroup` already uses. Cost: low.
+
+---
+
+## Operational Concerns
+
+**Ghost text / hints.** Without discoverable affordances, the separator and slash commands will have near-zero adoption from new users. A ghost text suffix in the input (e.g., `my session > first prompt`) disappears on first keypress and never annoys repeat users. This is the standard Todoist approach.
+
+**Session name derivation order.** When a user types `my feature > implement auth`, the slug generator must receive only the pre-separator text (`my feature`), not the full string.
+
+**Slash-command + separator interaction.** What happens with `/oneoff my feature > prompt`? The slash command is consumed first (sets session type to one-off), the remainder `my feature > prompt` is parsed for name + separator. Order: slash-command stripping runs before separator parsing.
+
+**Keyboard shortcut conflict audit.** Tab cycling must be conditional: active only when the creation panel is shown and no autocomplete dropdown is open.
+
+---
+
+## Prior Art and Lessons Learned
+
+### Todoist inline syntax [TRAINING_ONLY - verify details]
+
+Todoist allows a single task input field to embed metadata inline: `@label`, `#project`, `!!1`–`!!4` for priority, and natural language dates.
+
+UX principles that make it work:
+1. **Inline parsing is real-time**: as the user types, matched tokens are highlighted or converted to chips. Immediate feedback that the parser understood the input.
+2. **Escape hatch**: pressing Escape cancels the inline match.
+3. **Ghost text onboarding**: the input placeholder walks users through the syntax.
+4. **No mode switching required**: the parser handles all variants simultaneously.
+
+Lesson for Stapler Squad: the `>` separator should produce real-time visual feedback. As soon as `>` is typed, split the input into two visually distinct zones (name | prompt). This mirrors Todoist's chip-based inline feedback.
+
+### Linear command palette [TRAINING_ONLY - verify details]
+
+Linear's `⌘K` palette supports `/` prefix for filtering by resource type (`/issue`, `/project`) and first-token-as-filter. Slash tokens are consumed; the remainder is treated as a query. This is exactly the pattern for `/oneoff` in Stapler Squad.
+
+### Raycast [TRAINING_ONLY - verify details]
+
+Raycast uses Tab to confirm a selected command and advance to its next argument input. The Stapler Squad proposal maps this to Tab confirming a mode selection and cycling to the next type, which is consistent with the mental model.
+
+### Alfred [TRAINING_ONLY - verify details]
+
+Alfred uses `>` as a shell command trigger prefix (at position 0). This is the only case where `>` has a prior meaning in a launcher UI. However, Alfred's `>` is a prefix at position 0; the Stapler Squad `>` is a separator anywhere in the string. No user confusion is expected because Stapler Squad's omnibar is not a generic launcher.
+
+### VS Code Quick Open (`⌘P`) [TRAINING_ONLY - verify details]
+
+VS Code supports inline modifiers in quick open: `:line` suffix to jump to line, `@symbol` to filter by symbol, `#` for workspace-wide symbol search. The `:` separator pattern maps to "name:attribute" rather than "name > content," but the UX model is the same.
+
+### Slack slash commands [TRAINING_ONLY - verify details]
+
+Slack's `/remind`, `/status`, `/away` establish the definitive prior art for `/keyword` as a mode switch in a single-line input. Properties: recognized only at position 0; autocomplete appears immediately when `/` is typed; pressing Space after `/command` confirms and enters argument mode.
+
+---
+
+## Open Questions
+
+1. **Tab conflict with dropdown results.** Does `Omnibar.tsx` use Tab to navigate search results in the dropdown? If yes, Tab cycling must be suppressed when the dropdown is visible.
+
+2. **Ghost text implementation.** Does the current omnibar input use a plain `placeholder` attribute or a layered ghost-text overlay?
+
+3. **Slash-command discovery.** Should typing `/` show an inline autocomplete popup with available commands?
+
+4. **Separator highlight style.** When `>` is detected, how should name vs. prompt zones be visually distinguished?
+
+5. **Empty name + separator.** If the user types `> implement auth` (no name before separator), should the system auto-generate a session name from the first words of the prompt?
+
+---
+
+## Recommendation
+
+**Use `>` as the separator, `/keyword` for session type switching, and Tab (gated) for cycling.**
+
+Rationale:
+- `>` has the strongest "pass output to next stage" metaphor for developers. It is unambiguous in the omnibar context. Its visual scan-ability is high: a user sees at a glance where the name ends and the prompt begins.
+- `/keyword` is the industry standard for mode switching in single-line inputs (Slack, Notion, Linear, GitHub search). The `NewSessionDetector` already establishes the slash-prefix pattern in this codebase; `/oneoff` is the natural extension.
+- Tab cycling is the simplest cycling implementation, consistent with VS Code Quick Open. The conflict risk is manageable: gate Tab cycling on creation-panel visibility and suppress it when any dropdown is open.
+
+**Implementation priority order:**
+1. Auto-populate session name from bare omnibar text (unblocks the separator feature)
+2. `>` separator shorthand (highest UX value, lowest complexity)
+3. Tab cycling for session types (no parser needed, pure event handler)
+4. `/keyword` prefix commands (most complex; implement last)
+
+**Discoverability must be addressed.** Recommend a ghost-text placeholder in the omnibar input showing the separator syntax.
+
+---
+
+## Pending Web Searches
+
+1. `todoist inline syntax natural language UX principles 2024` — verify chip-based real-time feedback behavior
+2. `raycast launcher keyboard shortcut tab cycling session type 2024` — confirm whether Raycast uses Tab for argument cycling
+3. `linear command palette slash command filter UX 2024` — verify `/` prefix behavior in Linear
+4. `alfredapp greater-than prefix shell trigger 2024` — confirm Alfred's `>` shell-trigger convention
+5. `command palette inline syntax separator prior art UX 2025` — broader survey for newer launchers

--- a/project_plans/omnibar-session-name-ux/research/findings-pitfalls.md
+++ b/project_plans/omnibar-session-name-ux/research/findings-pitfalls.md
@@ -1,0 +1,163 @@
+# Findings: Pitfalls
+
+## Summary
+
+Four feature areas — slug generation, inline `>` separator, Tab/Ctrl+Tab keyboard shortcuts, and slash-command prefix detection — each carry distinct failure modes. The keyboard shortcut design has the highest severity: `Ctrl+Tab` is a hard browser-level conflict with no workaround; Tab inside the omnibar is already claimed by path-completion autocomplete dropdown cycling. Slug generation has the widest surface area of edge cases but all are solvable with a standard normalization pipeline. The `>` separator is low-risk on supported platforms. Slash-command priority injection into the DetectorRegistry is a one-line fix but must happen at the right layer.
+
+**Prioritized pitfall list (highest to lowest):**
+
+1. **[CRITICAL] Ctrl+Tab is a browser/OS conflict — abandon it**
+2. **[HIGH] Tab key dual-purpose collision** (already used for path completion cycling in `Omnibar.tsx`)
+3. **[HIGH] `/oneoff` detected as LocalPath** before slash-command detector runs
+4. **[MEDIUM] Slug degenerates to empty string** on all-emoji, all-special-chars, or whitespace-only input
+5. **[MEDIUM] `>` separator fires on path-detected inputs** — should only run in bare-text `SessionSearch` mode
+6. **[LOW] Leading-number slug** — valid in git but unusual
+7. **[LOW] Long-input slug truncation** — produces trailing hyphen; needs trimming
+8. **[LOW] Multiple `>` characters** — need a clear rule (first split wins)
+
+---
+
+## Options Surveyed
+
+### Slug Generation Edge Cases
+
+| Input | Expected Slug | Risk |
+|---|---|---|
+| `MY FEATURE` | `my-feature` | None — `.toLowerCase()` handles it |
+| `123-test` | `123-test` | Git branch warning (valid but unusual) |
+| `  ` (spaces only) | `""` (empty) | Must handle: block submit with inline error |
+| `!!!` (specials only) | `""` (empty) | Must handle: block submit with inline error |
+| `🚀 launch` | `launch` | Emoji stripped; remaining text slugified |
+| `🚀` (emoji only) | `""` (empty) | Degenerate: block submit, not silent fallback |
+| `你好世界` (CJK only) | `""` (empty after latin-strip) | Degenerate: no pinyin romanization; block submit |
+| `a > b > c` | slug:`a`, prompt:`b > c` | Take first `>` only; rest is prompt verbatim |
+| 120-character input | truncated to ~50 chars at word boundary | Trailing-hyphen risk after truncation |
+| `$(rm -rf /)` | `rm-rf` | No injection risk; shell chars stripped, residual slugified |
+
+### Inline `>` Separator Platform Considerations
+
+`>` is a valid character in macOS/Linux filenames but a shell redirection operator. Since the omnibar input is a UI text field (not a shell), there is no shell interpretation risk. On Windows `>` is forbidden in filenames, but session names are not used as filenames — they become slugified branch names and UI labels. `>` is safe as a separator on all supported platforms. The only risk is a user genuinely wanting `>` in their session name, which is a documented trade-off.
+
+### Keyboard Shortcut Options
+
+| Shortcut | Conflict | Verdict |
+|---|---|---|
+| Tab | Path-completion cycling already in `Omnibar.tsx`; browser focus trap | Context-dependent: usable only when `isDropdownVisible === false` |
+| Ctrl+Tab | Browser tab-switching — **not deliverable to JS event listeners** in Chrome/Firefox/Safari | Abandon entirely |
+| Alt+Tab | macOS application switcher; Windows window switcher | Abandon entirely |
+| Ctrl+, | VS Code "open settings" — only fires if omnibar is the active focus | Viable |
+| Ctrl+[ / Ctrl+] | Not universally claimed; matches VS Code panel navigation | Strongest alternative candidate |
+| Shift+Tab | Browser reverse-focus cycle; works with `preventDefault` but harms a11y | Avoid |
+
+**VS Code precedent:** Ctrl+Shift+P command palette uses Tab for autocomplete, Ctrl+Tab for editor tab cycling — in separate keyboard contexts. Linear uses prefix keys not Tab. Raycast uses Tab for a "secondary action" (open-in vs. copy), not for mode cycling.
+
+### Slash-Command vs. Path Detection Conflict
+
+Current `LocalPathDetector` (priority 100) fires on any input where `trimmed.startsWith("/")`. A slash-command like `/oneoff` starts with `/` → `isAbsolute = true` → returns `InputType.LocalPath` with `suggestedName: "oneoff"`. The command is silently misinterpreted.
+
+A new `SlashCommandDetector` must run at priority < 10 (before all existing detectors). It must match only the exact known command strings (`/oneoff`, `/worktree`, `/dir`, `/existing`) and return null for everything else (so `/opt/homebrew` is not intercepted).
+
+---
+
+## Trade-off Matrix
+
+| Feature | Option A | Option B | Winner |
+|---|---|---|---|
+| Slug degenerate fallback | Return `""` — block submit with error | Return `"session"` literal | Block submit + show inline error. Silent `"session"` creates naming collisions |
+| `>` separator scope | Fire on all input modes | Fire only in `SessionSearch` / bare-text mode | Bare-text only — paths and URLs must not be split on `>` |
+| Tab for session type cycling | Use Tab always | Gate Tab on `!isDropdownVisible` | Gate on `!isDropdownVisible` — path completion behavior is load-bearing |
+| Ctrl+Tab | Intercept with `e.preventDefault()` | Abandon | Abandon — browser does not deliver this event to JS |
+| Multiple `>` in input | First split: name=`a`, prompt=`b > c` | Last split: name=`a > b`, prompt=`c` | First split — leftmost `>` is the separator; rest is prompt verbatim |
+| SlashCommandDetector priority | Priority 5 (before all) | Priority 8 | Priority 5; exact value matters less than being first |
+
+---
+
+## Risk and Failure Modes
+
+**RF-1 [MEDIUM]: Slug degenerates to empty string.** Trigger: emoji-only, CJK-only, or special-char-only input. Effect: submit gated on `!!sessionName.trim()` silently blocks; no feedback. Mitigation: show inline validation error ("Session name is empty after cleaning special characters").
+
+**RF-2 [CRITICAL]: Ctrl+Tab delivers no event to JS.** Trigger: user presses Ctrl+Tab. Effect: browser switches tabs; omnibar context and in-progress session data are discarded. Mitigation: do not implement Ctrl+Tab. Use Ctrl+[ / Ctrl+] or Tab (gated).
+
+**RF-3 [HIGH]: Tab cycles session type while path completion dropdown is open.** Trigger: user types a path, dropdown appears, presses Tab expecting to autocomplete the path — but Tab was re-bound to "cycle session type." Effect: path completion bypassed; session type changes unexpectedly. Mitigation: gate the session-type-cycling Tab shortcut on `!isDropdownVisible`. The `isDropdownVisible` boolean already exists in `Omnibar.tsx`.
+
+**RF-4 [HIGH]: `/oneoff` detected as LocalPath.** Trigger: user types `/oneoff`. Effect: `LocalPathDetector` fires (priority 100 but `startsWith("/")` guard triggers); mode not switched; local-path badge appears. Mitigation: register `SlashCommandDetector` at priority 5 in `createDefaultRegistry()`.
+
+**RF-5 [MEDIUM]: `>` fires on path inputs.** Trigger: user types `/Users/foo/project > ` accidentally. Effect: input is split; path before `>` becomes session name slug; text after `>` becomes first prompt; path is silently lost. Mitigation: only apply `>` splitting when `detection.type === InputType.SessionSearch`.
+
+**RF-6 [LOW]: Trailing hyphen after slug truncation.** Trigger: long input truncated at word boundary ends in `-`. Effect: ugly slug. Mitigation: `slug.replace(/-+$/, "")` after truncation.
+
+**RF-7 [LOW]: Leading-digit slug.** Trigger: `123 fix auth`. Result: `123-fix-auth`. Git allows it; some older CI tools may warn. Mitigation: document in ADR; no code change required.
+
+**RF-8 [LOW]: Slug auto-fill race with manual session name edit.** Trigger: user manually clears and re-types session name; continuing to edit the main input triggers a new `suggestedName` that overwrites the manual value. Mitigation: the existing `lastSuggestedNameRef` guard in `Omnibar.tsx` lines 360–364 already handles this — confirm the new bare-text slug path uses the same guard.
+
+---
+
+## Migration and Adoption Cost
+
+All mitigations are additive. No existing session data or user preferences require migration. The `lastSuggestedNameRef` guard already exists. The `SlashCommandDetector` is a new class in `detector.ts` — no existing tests break unless the priority ordering is wrong. `Ctrl+Tab` removal is a non-change (it was never shipped).
+
+Estimated file touchpoints:
+- `/web-app/src/lib/omnibar/detector.ts` — add `SlashCommandDetector`, register at priority 5
+- `/web-app/src/lib/omnibar/detector.test.ts` — new describe block for `SlashCommandDetector`
+- `/web-app/src/components/sessions/Omnibar.tsx` — gate Tab shortcut on `!isDropdownVisible`; add `>` parsing gated on `SessionSearch` type; slug normalization call
+- New pure function module: slug normalization + tests (no component coupling)
+
+---
+
+## Operational Concerns
+
+**Slug empty-state UX:** If the slug pipeline returns empty and `canSubmit` is blocked, the creation panel shows a silently disabled submit button with no explanation. Inline validation message is required.
+
+**IME (Input Method Editor) on CJK keyboards:** macOS/Windows CJK IMEs fire `compositionstart`/`compositionend` events. During composition, `onChange` fires with partial phonetic input. The 150ms debounce in the existing detection effect is likely sufficient to avoid mid-composition slugification, but the slug pipeline should be aware that composed characters may yield empty output.
+
+**`>` in pasted clipboard content:** A user pasting from a terminal error like `Build failed: step > overflow` will see the `>` separator fire and split their intended session name. This is acceptable behavior in bare-text mode as long as the session name field shows the split result immediately (live preview feedback).
+
+---
+
+## Prior Art and Lessons Learned
+
+**Todoist inline syntax**: key lesson is **visible real-time feedback** — users must see the split result as they type, not only on submit.
+
+**Linear command palette**: uses `/` prefix for command mode — identical to what slash-commands propose here. Vocabulary must be a closed set.
+
+**VS Code Tab in command palette**: Tab completes autocomplete selection. It does NOT cycle result modes. VS Code uses separate shortcuts for mode switching. **Do not multiplex Tab across two conflicting functions in the same input element.**
+
+**Browser Ctrl+Tab behavior** [TRAINING_ONLY - verify]: Ctrl+Tab is intercepted at the OS message pump level before the JS event listener receives it in Chrome, Firefox, and Safari. No JS workaround exists.
+
+---
+
+## Open Questions
+
+1. **What shortcut replaces Ctrl+Tab?** Ctrl+[ and Ctrl+] are the strongest candidates. Needs a decision before implementation.
+
+2. **Should `/oneoff` switch the session type globally (mutating the creation panel radio state), or produce a transient badge that only applies on submit?**
+
+3. **How does `>` separator interact with the `lastSuggestedNameRef` guard?** If the user typed `my feature > do something` and previously manually edited the session name field, the guard would prevent auto-fill. The `>` separator parse must decide whether to bypass or respect the guard.
+
+4. **What is the slug truncation limit?** Recommend 50-char soft limit with 100-char hard cap.
+
+5. **Should `SlashCommandDetector` return a new `InputType.SlashCommand` enum value, or mutate mode state directly via `dispatchMode`?**
+
+---
+
+## Recommendation
+
+Do not implement Ctrl+Tab. Use Tab (gated on `!isDropdownVisible`) as the session-type cycling shortcut, with a labeled hint in the creation panel footer.
+
+Gate Tab-for-session-type-cycling on `!isDropdownVisible`. The existing `isDropdownVisible` boolean in `Omnibar.tsx` is the correct insertion point.
+
+Register `SlashCommandDetector` at priority 5 in `createDefaultRegistry()`. Match only the exact known command strings. Return null for all other `/`-prefixed input.
+
+Gate `>` separator parsing on `detection.type === InputType.SessionSearch` (bare text only).
+
+Implement slug normalization as a pure function. Return `""` for degenerate inputs and surface an inline validation error rather than substituting `"session"`.
+
+---
+
+## Pending Web Searches
+
+1. `site:chromium.org ctrlTab keydown preventDefault browser` — verify whether any modern Chromium version delivers Ctrl+Tab to JS keydown listeners
+2. `"ctrl+tab" site:bugzilla.mozilla.org javascript keydown` — same for Firefox
+3. `Linear command palette slash commands keyboard UX 2026` — verify Linear's exact slash-command behavior
+4. `Raycast keyboard mode cycling shortcut design` — verify Raycast's session-type cycling UX pattern
+5. `React controlled input IME compositionend onChange CJK` — confirm React's IME handling for CJK slug generation

--- a/project_plans/omnibar-session-name-ux/research/findings-stack.md
+++ b/project_plans/omnibar-session-name-ux/research/findings-stack.md
@@ -1,0 +1,153 @@
+# Findings: Stack
+
+## Summary
+
+Two independent gaps to fill:
+
+1. **Session name auto-fill for bare text input**: `SessionSearchDetector` always returns `suggestedName: ""`, so when the user types free text (no path or URL), the session name field stays blank. The fix is to slugify the omnibar input text and set it as `suggestedName` inside `SessionSearchDetector`.
+
+2. **First prompt UI wiring**: `initial_prompt` (field 15) exists in the proto, is generated in TypeScript bindings (`initialPrompt: string` in `CreateSessionRequest`), and is used in `SessionWizard`. However, the omnibar path (`OmnibarFormState → OmnibarSessionData → OmnibarContext → useSessionService → RPC`) does not thread it at all: `OmnibarFormState` has no `firstPrompt` field, `OmnibarCreationPanel` has no textarea for it, `useSessionService.createSession` does not pass `initialPrompt` to the RPC, and `OmnibarContext.handleCreateSession` does not forward it.
+
+No slug library is installed. The codebase uses inline simple `replace(/\//g, "-")` patterns throughout `detector.ts`.
+
+---
+
+## Options Surveyed
+
+### Q1: Slugify approach for bare-text → session name
+
+**Option A: Inline custom function**
+
+A small pure function colocated in `detector.ts` or a new `web-app/src/lib/omnibar/slugify.ts`:
+
+```ts
+export function toSessionSlug(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")   // strip non-alphanumeric except spaces/hyphens
+    .replace(/\s+/g, "-")            // spaces → hyphens
+    .replace(/-{2,}/g, "-")          // collapse multiple hyphens
+    .replace(/^-|-$/g, "")           // trim leading/trailing hyphens
+    .slice(0, 50);                   // reasonable length cap
+}
+```
+
+Consistent with the existing pattern of inline `replace` chains throughout `detector.ts`. Covers the stated use case (2–8 words, ASCII-dominant).
+
+**Option B: `npm slugify`**
+
+~4 KB gzipped. Supports locale-aware transliteration (é→e, ü→u). Overkill for session name input; adds a dependency the size-limit tooling must track.
+
+**Option C: `@sindresorhus/slugify`**
+
+Pure ESM, ~2 KB gzipped. Strong Unicode support. Same verdict: unnecessary for this use case.
+
+---
+
+### Q2: Wiring `initial_prompt` through the omnibar path
+
+The gap is a multi-step addition across 4 files:
+
+1. Add `firstPrompt: string` to `OmnibarFormState` and `INITIAL_FORM_STATE` in `Omnibar.tsx`
+2. Add `firstPrompt?: string` to `OmnibarSessionData` in `Omnibar.tsx`
+3. Add a `<textarea>` for first prompt in `OmnibarCreationPanel.tsx`
+4. Pass `initialPrompt: data.firstPrompt` in `OmnibarContext.tsx handleCreateSession`
+5. Add `initialPrompt: request.initialPrompt` to the RPC call body in `useSessionService.ts`
+
+`SessionWizard` already implements the full pattern (`initialPrompt`, zod schema, character counter at 10,000, react-hook-form registration) — that is the reference design.
+
+---
+
+## Trade-off Matrix
+
+| Criterion | Inline slug fn | npm slugify | @sindresorhus/slugify |
+|---|---|---|---|
+| Bundle size impact | 0 KB | ~4 KB gzip | ~2 KB gzip |
+| Unicode/emoji support | No (ASCII-only) | Yes | Yes |
+| Correctness for use case | Sufficient | Over-engineered | Over-engineered |
+| Consistency with codebase | High (matches existing) | Low | Low |
+| Maintenance burden | Minimal | Dep updates | Dep updates |
+
+---
+
+## Risk and Failure Modes
+
+**Slug collision**: Two different inputs can produce the same slug. Not a problem — session names are labels, not unique keys.
+
+**Empty slug**: Input like "!!! ???" collapses to `""` after stripping. Guard: if result is empty, return `""` (leave field blank, same as current behavior). Do not default to `"session"`.
+
+**`prompt` vs `initialPrompt` confusion**: These are distinct proto fields with different semantics:
+- `prompt` (field 7): pre-session uploaded image paths (space-joined). Populated from `attachedImagePathsRef`.
+- `initial_prompt` (field 15): injects via CLAUDE.md; no size limit; shell-safe. This is the correct field for the new textarea.
+
+Do not mix them. The new textarea must populate `initialPrompt`, not `prompt`.
+
+**handleSubmit data loss**: `handleSubmit` (Omnibar.tsx lines 639-641) builds `finalPrompt` from attached images only. Adding `firstPrompt` to OmnibarFormState without updating this line produces silent data loss. Fix: `[formState.firstPrompt?.trim(), ...imagePaths].filter(Boolean).join("\n") || undefined`.
+
+**Prompt length**: `SessionWizard` caps at 10,000. A shorter limit (2,000) is more appropriate for quick-create context.
+
+---
+
+## Migration and Adoption Cost
+
+No proto changes, no schema migrations. All fields already exist in generated TypeScript (`initialPrompt: string` confirmed at line 233 of `/web-app/src/gen/session/v1/session_pb.ts`).
+
+Touch points:
+- `/web-app/src/components/sessions/Omnibar.tsx`: add `firstPrompt` to `OmnibarFormState` and `OmnibarSessionData`
+- `/web-app/src/components/sessions/OmnibarCreationPanel.tsx`: add textarea
+- `/web-app/src/lib/contexts/OmnibarContext.tsx`: pass `initialPrompt: data.firstPrompt`
+- `/web-app/src/lib/hooks/useSessionService.ts`: add `initialPrompt: request.initialPrompt` to RPC call
+- `/web-app/src/lib/omnibar/detector.ts` (`SessionSearchDetector`): set `suggestedName: toSessionSlug(trimmed)`
+- New: `web-app/src/lib/omnibar/slugify.ts` (~15 lines) with unit test
+
+Total: 5–6 file edits, 0 new npm dependencies.
+
+---
+
+## Operational Concerns
+
+**Size-limit**: No new packages, so the JS bundle limit is unaffected.
+
+**Tests**: The slug function should have a unit test. `SessionSearchDetector` change should add a case to `detector.test.ts`. The omnibar firstPrompt round-trip should have a Jest/RTL test. The `session:create` entry in `docs/registry/backend-features.json` should have its `lastModified` bumped.
+
+---
+
+## Prior Art and Lessons Learned
+
+**Existing slug patterns in `detector.ts`** (lines 70, 139, 185): These are minimal inline replacements (slash → hyphen) on already-clean identifiers from URLs/paths. Free-text input needs additionally: `toLowerCase()`, non-alphanumeric stripping, and space-to-hyphen conversion.
+
+**`SessionWizard` `initialPrompt` pattern** is the reference implementation. Key detail: it passes `initialPrompt` directly as a named field; the omnibar version can simplify by skipping zod validation if desired.
+
+**`suggestedName` as the auto-fill hook**: The auto-fill logic in `Omnibar.tsx` lines 361–364 reads `result.suggestedName` and writes to `sessionName`. Putting the slug in `suggestedName` inside `SessionSearchDetector` is the correct hook — no `Omnibar.tsx` auto-fill logic changes needed.
+
+---
+
+## Open Questions
+
+1. Should the first-prompt textarea appear in the main form body or inside "Advanced Options"? Quick-create context suggests main form (bottom, above Advanced), not buried.
+2. What is the character limit for the omnibar first-prompt textarea? `SessionWizard` uses 10,000; 2,000 is more appropriate here.
+3. Should the slug cap at 50 chars or follow a session name validation limit? 50 chars is a reasonable default.
+
+---
+
+## Recommendation
+
+**For slug generation**: Implement an inline `toSessionSlug` pure function in a new `web-app/src/lib/omnibar/slugify.ts`. Do not add an npm package. Update `SessionSearchDetector.detect()` to return `suggestedName: toSessionSlug(trimmed)` instead of `""`. This matches codebase style and has zero bundle impact.
+
+**For first prompt wiring**: Follow the `SessionWizard` `initialPrompt` pattern exactly. Add `firstPrompt: string` to `OmnibarFormState` and `OmnibarSessionData`, add a textarea to `OmnibarCreationPanel`, pass it through `OmnibarContext` as `initialPrompt`, and add `initialPrompt: request.initialPrompt` to `useSessionService.createSession`. Do not confuse `prompt` (image paths) with `initialPrompt` (text injection). Patch `handleSubmit` to incorporate `firstPrompt` into `finalPrompt`.
+
+---
+
+## Web Search Results
+
+Web search not performed — codebase evidence was sufficient for all decisions.
+
+Key file paths referenced:
+- `web-app/src/lib/omnibar/detector.ts` — `SessionSearchDetector`, existing slug patterns
+- `web-app/src/components/sessions/Omnibar.tsx` — `OmnibarFormState`, `OmnibarSessionData`, auto-fill logic (lines 361–364)
+- `web-app/src/components/sessions/OmnibarCreationPanel.tsx` — form fields, no first-prompt textarea
+- `web-app/src/lib/contexts/OmnibarContext.tsx` — `handleCreateSession`, `prompt: data.prompt` present, `initialPrompt` absent
+- `web-app/src/lib/hooks/useSessionService.ts` — `createSession`, `initialPrompt` field absent from RPC call
+- `web-app/src/gen/session/v1/session_pb.ts` line 233 — `initialPrompt: string` confirmed in generated `CreateSessionRequest`
+- `web-app/src/components/sessions/SessionWizard.tsx` — reference implementation of `initialPrompt` textarea pattern

--- a/project_plans/omnibar-session-name-ux/research/research_plan.md
+++ b/project_plans/omnibar-session-name-ux/research/research_plan.md
@@ -1,0 +1,53 @@
+# Research Plan: Omnibar Session Name UX
+
+## Context (grounded in codebase as of 2026-05-05)
+
+Key discoveries from codebase survey:
+- `initial_prompt` field (#15) already exists in `CreateSessionRequest` proto
+- `useSessionService.ts` passes `prompt: request.prompt` to the RPC — pipeline exists
+- `OmnibarContext.tsx` passes `prompt: data.prompt` — pipeline exists
+- BUT `OmnibarFormState` has no `firstPrompt` field; `OmnibarCreationPanel` has no prompt textarea
+- Session name auto-fill only works for detected paths/URLs via `suggestedName`; bare text typed
+  as a session name (SessionSearch type) does NOT auto-populate the name field
+- `SessionTypeRadioGroup` already supports arrow-key cycling, but only inside the creation panel
+- No inline slash-command or separator parsing exists anywhere
+
+## Subtopics
+
+### 1. Stack — slug generation + first_prompt threading
+Scope: How to convert arbitrary user input to a smart kebab-case slug. Whether to use a
+library (slugify, deburr+parameterize, custom) or implement inline. Confirm the full
+`first_prompt` threading path from UI → OmnibarFormState → OmnibarSessionData →
+OmnibarContext → useSessionService → RPC.
+Search cap: 3 searches
+Trade-off axes: bundle size, Unicode handling, edge case correctness, maintenance burden
+
+### 2. Features — Todoist-style inline shorthand + launcher UX patterns
+Scope: Survey Todoist's inline syntax model (dates, labels, priorities as inline text).
+Survey Linear, Raycast, Spotlight for session-type cycling UX. Understand the principles
+behind "inline command syntax" in launcher interfaces.
+Search cap: 4 searches
+Trade-off axes: discoverability, parsing complexity, reversibility, power-user ceiling
+
+### 3. Architecture — inline parsing location + formState shape + ADR design
+Scope: Where exactly to parse the "name > prompt" separator: input onChange handler vs.
+a derived computed value vs. submit time. How to add `firstPrompt` to OmnibarFormState
+and thread it to OmnibarSessionData. ADR structure for the inline-shorthand concept.
+Where to handle slash-command prefix detection: before or after DetectorRegistry.
+Search cap: 3 searches
+Trade-off axes: UX responsiveness, state complexity, testability
+
+### 4. Pitfalls — edge cases + keyboard conflicts + parsing ambiguity
+Scope: Slug generation edge cases (emoji, all-caps, special chars, >40 chars).
+Separator parsing ambiguity (path inputs contain `>` ? No, but worktree labels might).
+Tab key conflict (Tab already used for path completion dropdown cycling in Omnibar).
+Ctrl+Tab browser/OS level conflicts.
+Search cap: 3 searches
+Trade-off axes: safety, UX correctness, conflict surface
+
+## Output files
+- research/findings-stack.md
+- research/findings-features.md
+- research/findings-architecture.md
+- research/findings-pitfalls.md
+- research/synthesis.md (parent agent, after all findings complete)

--- a/project_plans/omnibar-session-name-ux/research/synthesis.md
+++ b/project_plans/omnibar-session-name-ux/research/synthesis.md
@@ -1,0 +1,178 @@
+# Research Synthesis: Omnibar Session Name UX
+
+## Decision Required
+
+How to implement smart session name auto-population, a first-prompt textarea, an inline separator shorthand (`>`), slash-command session type switching, and Tab-based type cycling in the Stapler Squad omnibar — with each feature integrated into the existing detection pipeline, form state, and RPC layer.
+
+## Context
+
+The omnibar currently auto-fills session names only for detected paths/URLs (via `suggestedName` in `DetectionResult`). When a user types plain text (e.g., `implement oauth`), the `SessionSearchDetector` returns `suggestedName: ""` and the session name field stays blank. When switching to one-shot mode, the user must re-type the name they already wrote.
+
+The `initial_prompt` field (#15) already exists in `CreateSessionRequest` proto and is threaded through the full server stack, but the omnibar UI path is missing: no `firstPrompt` in `OmnibarFormState`, no textarea in `OmnibarCreationPanel`, no forwarding in `OmnibarContext` or `useSessionService`.
+
+Three features are entirely new: the `>` inline separator, `/command` prefix switching, and Tab cycling for session types.
+
+Web search confirmed: **Ctrl+Tab cannot be delivered to JavaScript in Chrome** (browser reserves it for tab switching). This is the single hardest constraint.
+
+## Options Considered
+
+| Feature | Option A | Option B | Option C |
+|---|---|---|---|
+| Slug source | npm slugify | @sindresorhus/slugify | **Inline pure function** |
+| Slug hook | New `useEffect` | **SessionSearchDetector returns suggestedName** | Preview-only state |
+| `>` separator parse | onChange live split | **Derive on read (pure function, gated)** | Submit only |
+| Slash command routing | New Detector + InputType | **Pre-process before detect()** | Panel interceptor |
+| Keyboard cycling | Ctrl+Tab (abandoned) | **Tab (gated on !isDropdownVisible)** | Ctrl+[ / Ctrl+] |
+| ADR format | **Single ADR** | Two ADRs | Rules file update only |
+
+## Dominant Trade-off
+
+**Parsing complexity vs. state simplicity.** Option A approaches (live split, new Detector, new InputType enum) provide immediate responsiveness but introduce bidirectional state management and deep coupling into the detection architecture. Option B approaches (pure functions, pre-processing, derive on read) are slightly less "live" but produce zero new state, remain trivially testable, and respect the existing separation between detection and form state.
+
+All recommendations land on Option B — defer computation to the narrowest point of use.
+
+## Recommendation
+
+### 1. Slug generation — Inline `toSessionSlug` pure function
+
+**Choose: Custom inline function in `web-app/src/lib/omnibar/slugify.ts`**
+
+```ts
+export function toSessionSlug(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 50);
+}
+```
+
+Zero bundle impact. Consistent with existing codebase style. Return `""` for degenerate inputs (emoji-only, all-specials) — never substitute a literal like `"session"`. Show an inline error when the slug is empty and submit is blocked.
+
+**Hook into: `SessionSearchDetector.detect()`** — single line change: `suggestedName: toSessionSlug(trimmed)`. The existing `lastSuggestedNameRef` guard in `Omnibar.tsx` handles manual-edit protection automatically.
+
+Accept these costs: no Unicode transliteration (emoji, CJK produce empty slug). This is acceptable — session names are ASCII-dominant in practice; degenerate inputs show an error.
+
+### 2. First prompt — Wire `initialPrompt` through the omnibar path
+
+**Choose: Follow the SessionWizard pattern exactly**
+
+4 precise touchpoints:
+1. Add `firstPrompt: string` to `OmnibarFormState` and `INITIAL_FORM_STATE`
+2. Add `firstPrompt?: string` to `OmnibarSessionData`
+3. Add optional expandable textarea in `OmnibarCreationPanel` below session name (main form body, above Advanced Options)
+4. Patch `handleSubmit` — **critical**: current line produces silent data loss if not updated: `finalPrompt = [formState.firstPrompt?.trim(), ...imagePaths].filter(Boolean).join("\n") || undefined`
+
+Then thread through `OmnibarContext` (`initialPrompt: data.firstPrompt`) and `useSessionService` (`initialPrompt: request.initialPrompt`).
+
+**Do not confuse `prompt` (image paths, field 7) with `initialPrompt` (text injection, field 15).** They are distinct proto fields.
+
+Accept these costs: character limit TBD (recommend 2,000 for quick-create context vs. SessionWizard's 10,000).
+
+### 3. `>` inline separator — Derive on read, gated on SessionSearch
+
+**Choose: Pure function `parseInputWithSeparator`, called at canSubmit + handleSubmit + preview label**
+
+```ts
+function parseInputWithSeparator(s: string): { name: string; firstPrompt: string } {
+  const idx = s.indexOf(">");
+  if (idx === -1) return { name: s, firstPrompt: "" };
+  return { name: s.slice(0, idx).trim(), firstPrompt: s.slice(idx + 1).trim() };
+}
+```
+
+**Gate on `detection?.type === InputType.SessionSearch` only.** Path inputs and URL inputs never enter SessionSearch type — the separator cannot fire on `/foo/bar` or `https://...`.
+
+Split on first `>` only. `a > b > c` → name: `a`, firstPrompt: `b > c`.
+
+**Visual feedback**: When input contains `>` and type is SessionSearch, show a preview label: `"Session name: my-feature"` below the input. This is the critical discoverability hook — without it, the separator is invisible.
+
+Accept these costs: users who want `>` in a session name cannot use it. This is documented in the ADR.
+
+### 4. Slash command prefix — Pre-process before DetectorRegistry
+
+**Choose: `parseSlashCommand()` pure function, called at the top of the 150ms debounce `useEffect` before `detect()`**
+
+```ts
+const KNOWN_SLASH_COMMANDS: Record<string, SessionTypeValue> = {
+  oneoff: "one_off",
+  worktree: "new_worktree",
+  dir: "directory",
+  existing: "existing_worktree",
+};
+
+function parseSlashCommand(input: string): { sessionType: SessionTypeValue; remainder: string } | null {
+  const match = /^\/([a-z]+)(?:\s+(.*))?$/i.exec(input.trim());
+  if (!match) return null;
+  const cmd = match[1].toLowerCase();
+  if (!KNOWN_SLASH_COMMANDS[cmd]) return null;
+  return { sessionType: KNOWN_SLASH_COMMANDS[cmd], remainder: match[2]?.trim() ?? "" };
+}
+```
+
+In the debounce `useEffect`: call `parseSlashCommand(input)` first. If matched, call `setFormField("sessionType", result.sessionType)`, then call `detect(result.remainder)` on the remainder. Do NOT call `detect()` on the full input including the slash command.
+
+**Why not a new Detector**: A `SlashCommandDetector` in `DetectorRegistry` would need to communicate `sessionType` back to `OmnibarFormState` — a separate state tree from `DetectionResult`. Pre-processing keeps the coupling minimal: one pure function, one state mutation, one pass to `detect()`.
+
+Accept these costs: slash commands are not discoverable without in-UI hints. A ghost-text placeholder in the creation panel (e.g., "Type /oneoff to switch to one-off mode") is the recommended minimum.
+
+### 5. Tab cycling — Gated on `!isDropdownVisible`
+
+**Choose: Tab key in the omnibar input, conditional on `!isDropdownVisible`**
+
+```ts
+// In Omnibar.tsx handleKeyDown, inside creation mode branch:
+if (e.key === "Tab" && !isDropdownVisible && modeState.type !== "discovery") {
+  e.preventDefault();
+  const types = SESSION_TYPES.map(t => t.value);
+  const idx = types.indexOf(sessionType);
+  const next = types[(idx + 1) % types.length];
+  setFormField("sessionType", next);
+}
+```
+
+**Do not implement Ctrl+Tab.** Confirmed by web search: Chrome does not deliver Ctrl+Tab to JavaScript keydown listeners — the browser intercepts it for tab switching before the event reaches the page. No workaround exists.
+
+Show a hint in the creation panel footer: `Tab: cycle type`. This is the minimum discoverability for a power-user shortcut.
+
+Accept these costs: Tab cannot be used for form field navigation while creation mode is open (it cycles session types instead). This is acceptable — Tab is already non-standard in this modal context.
+
+### 6. ADR
+
+Write `ADR-NNN: Omnibar Inline Shorthand Language` as a single ADR. Required sections:
+- Context (why the omnibar is becoming a command surface, not just a search field)
+- Decision (adopt `>` separator and `/command` prefix as the omnibar's inline command language)
+- Consequences (discoverability requirements, known limitations)
+- Extension Contract (how to add new slash commands: add to `KNOWN_SLASH_COMMANDS`, add hint text, add test)
+- Alternatives Rejected (multiple input fields, separate mode selector, Ctrl+Tab)
+
+The Extension Contract section is the critical piece — it prevents future ad-hoc `if (input.startsWith("/"))` proliferation.
+
+## Implementation Order (critical path)
+
+1. **`toSessionSlug` + SessionSearchDetector** — unblocks everything (name auto-fill fixes the core UX bug; slug function is reused by `>` separator)
+2. **`firstPrompt` threading** — independent; wire proto field through to textarea
+3. **`>` separator (derive on read)** — depends on step 1 (slug function) and step 2 (firstPrompt in formState)
+4. **Tab cycling** — independent; pure event handler addition
+5. **`/command` prefix pre-processing** — most complex; implement last; depends on slug function
+
+## Open Questions Before Committing
+
+- [ ] What character limit for the first-prompt textarea? (2,000 recommended; needs decision)
+- [ ] Should `>` separator apply in one-off mode (where input == session name, not a path)? Likely yes — needs UX decision
+- [ ] What replaces Ctrl+Tab in the shortcut legend? Tab (gated) is the answer, but the footer hint text needs finalization
+
+These are product decisions, not blockers — all have clear defaults that can be confirmed during implementation.
+
+## Sources
+
+- [findings-stack.md](./findings-stack.md) — slug generation options, `initialPrompt` threading gap analysis
+- [findings-features.md](./findings-features.md) — Todoist/Raycast/Linear/Slack prior art, separator and slash-command UX
+- [findings-architecture.md](./findings-architecture.md) — 4 architecture decisions with trade-off matrices and code-grounded analysis
+- [findings-pitfalls.md](./findings-pitfalls.md) — Ctrl+Tab browser constraint (confirmed), edge cases, priority conflicts
+- Web search: [Todoist natural language UX](https://thesweetsetup.com/using-natural-language-with-todoist/) — confirms inline parsing + real-time feedback as the key UX principle
+- Web search: [Chrome Ctrl+Tab behavior](https://www.robin-drexler.com/2015/07/07/overriding-default-browser-shortcuts) — confirms browser-level interception; confirmed by [Chromium bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1052569)
+- Web search: [Command palette prior art](https://destiner.io/blog/post/designing-a-command-palette/) — confirms `/` prefix as established convention

--- a/session/tmux/server_registry.go
+++ b/session/tmux/server_registry.go
@@ -143,6 +143,16 @@ func (r *TmuxServerRegistry) IsHealthy() bool {
 	return r.healthy
 }
 
+// NotifySessionCreated proactively marks a session as existing in the registry.
+// Called by TmuxSession.start() after a new session is confirmed via list-sessions,
+// so that DoesSessionExist() returns true before the async %session-created
+// control-mode event is processed.
+func (r *TmuxServerRegistry) NotifySessionCreated(name string) {
+	r.mu.Lock()
+	r.sessions[name] = true
+	r.mu.Unlock()
+}
+
 // SubscribePaneExit implements PaneExitSubscriber. The returned channel is
 // closed when the named session/pane exits or when ctx is cancelled.
 func (r *TmuxServerRegistry) SubscribePaneExit(ctx context.Context, sessionName string) <-chan struct{} {

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -663,6 +663,11 @@ func (t *TmuxSession) start(workDir string, setupCleanup bool, cleanup *CleanupF
 	// causes poll-loop timeouts when the event is delayed. A single no-cache check
 	// right after successful new-session avoids the 10s wait in the common case.
 	if t.DoesSessionExistNoCache() {
+		// Proactively update the registry so DoesSessionExist() returns true
+		// immediately — the async %session-created event may not have arrived yet.
+		if notifier, ok := t.registry.(interface{ NotifySessionCreated(string) }); ok {
+			notifier.NotifySessionCreated(t.sanitizedName)
+		}
 		t.invalidateExistsCache()
 	} else {
 		// Fall back to the poll loop for the rare case where the session isn't

--- a/web-app/src/components/sessions/Omnibar.tsx
+++ b/web-app/src/components/sessions/Omnibar.tsx
@@ -16,7 +16,9 @@ import { Session, SessionStatus } from "@/gen/session/v1/types_pb";
 import { PathCompletionDropdown, type CompletionEntry } from "./PathCompletionDropdown";
 import { OmnibarResultList, getResultListItemCount, getHighlightedItemId } from "./OmnibarResultList";
 import { OmnibarModeBadge } from "./OmnibarModeBadge";
-import { OmnibarCreationPanel } from "./OmnibarCreationPanel";
+import { OmnibarCreationPanel, SESSION_TYPES } from "./OmnibarCreationPanel";
+import { parseSlashCommand } from "@/lib/omnibar/parseSlashCommand";
+import { parseInputWithSeparator } from "@/lib/omnibar/parseInput";
 import {
   overlay, modal, inputContainer, typeIndicator, input as inputClass,
   detectionInfo, detectionBadge, unknown,
@@ -47,6 +49,7 @@ export interface OmnibarFormState {
   parentDir: string;
   projectName: string;
   newProjectSessionType: "directory" | "new_worktree";
+  firstPrompt: string;
 }
 
 const INITIAL_FORM_STATE: OmnibarFormState = {
@@ -63,6 +66,7 @@ const INITIAL_FORM_STATE: OmnibarFormState = {
   parentDir: "",
   projectName: "",
   newProjectSessionType: "new_worktree",
+  firstPrompt: "",
 };
 
 // Consolidated UI state
@@ -90,6 +94,7 @@ export interface OmnibarSessionData {
   existingWorktree?: string;
   workingDir?: string;
   oneOff?: boolean;
+  initialPrompt?: string;
   // New project mode: tells the context layer to use SESSION_TYPE_NEW_PROJECT
   isNewProject?: boolean;
   // Directory mode confirmation: retry with directory creation enabled
@@ -332,7 +337,14 @@ export function Omnibar({ isOpen, onClose, onCreateSession, onNavigateToSession,
 
     debounceRef.current = setTimeout(() => {
       if (input.trim()) {
-        const result = detect(input);
+        // Pre-process slash commands before detection so /oneoff etc. aren't
+        // misidentified as local paths by LocalPathDetector (priority 100).
+        const slashCmd = parseSlashCommand(input);
+        if (slashCmd) {
+          setFormField("sessionType", slashCmd.sessionType);
+        }
+        const detectInput = slashCmd ? slashCmd.remainder : input;
+        const result = detect(detectInput || input);
         setDetection(result);
 
         // Reset dropdown dismissed state when input type changes modes.
@@ -354,11 +366,22 @@ export function Omnibar({ isOpen, onClose, onCreateSession, onNavigateToSession,
           }
         }
 
-        // Auto-fill session name if:
+        // Auto-fill session name (and firstPrompt for `>` separator) if:
         // 1. Session name is empty, OR
         // 2. Session name matches the last auto-suggested name (not manually edited)
         // This allows suggestions to update as the user types the path (e.g., "~" → "sqlway")
-        if (result.suggestedName) {
+        if (result.type === InputType.SessionSearch && !slashCmd) {
+          // Derive-on-read: split on first `>` to populate name + firstPrompt
+          const parsed = parseInputWithSeparator(input);
+          const derivedName = parsed.name;
+          if (derivedName && (!sessionNameRef.current || sessionNameRef.current === lastSuggestedNameRef.current)) {
+            setSessionName(derivedName);
+            lastSuggestedNameRef.current = derivedName;
+          }
+          if (parsed.firstPrompt) {
+            setFormField("firstPrompt", parsed.firstPrompt);
+          }
+        } else if (result.suggestedName) {
           if (!sessionNameRef.current || sessionNameRef.current === lastSuggestedNameRef.current) {
             setSessionName(result.suggestedName);
             lastSuggestedNameRef.current = result.suggestedName;
@@ -537,6 +560,16 @@ export function Omnibar({ isOpen, onClose, onCreateSession, onNavigateToSession,
         }
       }
 
+      // Tab cycles session type when in creation mode and no dropdown is open
+      if (e.key === "Tab" && !isDiscoveryMode && !isDropdownVisible) {
+        e.preventDefault();
+        const types = SESSION_TYPES.map((t) => t.value);
+        const idx = types.indexOf(sessionType as typeof types[number]);
+        const next = types[(idx + 1) % types.length];
+        setFormField("sessionType", next as OmnibarFormState["sessionType"]);
+        return;
+      }
+
       if (e.key === "Escape") {
         // Stop propagation so the global document listener doesn't call onClose() a second time.
         e.nativeEvent.stopImmediatePropagation();
@@ -567,6 +600,8 @@ export function Omnibar({ isOpen, onClose, onCreateSession, onNavigateToSession,
       handleCompletionSelect,
       onClose,
       dispatchMode,
+      sessionType,
+      setFormField,
     ]
   );
 
@@ -639,6 +674,7 @@ export function Omnibar({ isOpen, onClose, onCreateSession, onNavigateToSession,
       // Build prompt from attached image paths (pre-session uploads go to temp dir).
       const imagePaths = attachedImagePathsRef.current;
       const finalPrompt = imagePaths.length > 0 ? imagePaths.join(" ") : undefined;
+      const firstPromptText = formState.firstPrompt?.trim() || undefined;
 
       let sessionData: OmnibarSessionData;
 
@@ -655,6 +691,7 @@ export function Omnibar({ isOpen, onClose, onCreateSession, onNavigateToSession,
           autoYes,
           sessionType: newProjectSessionType,
           isNewProject: true,
+          initialPrompt: firstPromptText,
         };
       } else {
         sessionData = {
@@ -669,6 +706,7 @@ export function Omnibar({ isOpen, onClose, onCreateSession, onNavigateToSession,
           existingWorktree: sessionType === "one_off" ? undefined : (existingWorktree.trim() || undefined),
           workingDir: sessionType === "one_off" ? undefined : (workingDir.trim() || undefined),
           oneOff: sessionType === "one_off" ? true : undefined,
+          initialPrompt: firstPromptText,
         };
 
         // Handle GitHub URLs - path will be resolved server-side
@@ -1031,6 +1069,11 @@ export function Omnibar({ isOpen, onClose, onCreateSession, onNavigateToSession,
                 <span className={shortcutKey}>Tab</span> Complete
               </span>
             </>
+          )}
+          {!isDiscoveryMode && !isDropdownVisible && (
+            <span className={shortcut}>
+              <span className={shortcutKey}>Tab</span> Cycle type
+            </span>
           )}
         </div>
       </div>

--- a/web-app/src/components/sessions/OmnibarCreationPanel.tsx
+++ b/web-app/src/components/sessions/OmnibarCreationPanel.tsx
@@ -20,7 +20,7 @@ import * as styles from "./OmnibarCreationPanel.css";
 
 // ─── Session Type Radio Group ────────────────────────────────────────────────
 
-const SESSION_TYPES = [
+export const SESSION_TYPES = [
   { value: "new_worktree", label: "New Worktree" },
   { value: "directory", label: "Directory" },
   { value: "existing_worktree", label: "Use Worktree" },
@@ -144,7 +144,7 @@ export function OmnibarCreationPanel({
   const {
     sessionName, branch, program, category, autoYes,
     useTitleAsBranch, sessionType, existingWorktree, workingDir,
-    parentDir, projectName, newProjectSessionType,
+    parentDir, projectName, newProjectSessionType, firstPrompt,
   } = formState;
 
   // ─── Load default parentDir from config when new_project mode is first selected ──
@@ -258,6 +258,16 @@ export function OmnibarCreationPanel({
             value={sessionName}
             onChange={(e) => setFormField("sessionName", e.target.value)}
           />
+          {!sessionName && (
+            <span className={hint} style={{ color: "var(--error)" }}>
+              Session name is empty — type a name above or use &ldquo;name &gt; prompt&rdquo; syntax
+            </span>
+          )}
+          {firstPrompt && sessionName && (
+            <span className={hint}>
+              Session name: <strong>{sessionName}</strong> · First prompt will be injected automatically
+            </span>
+          )}
         </div>
 
         {/* Session Type — ARIA radio group (ADR-003: arrow keys cycle) */}
@@ -541,6 +551,28 @@ export function OmnibarCreationPanel({
             ))}
           </div>
         )}
+
+        {/* First Prompt (optional) */}
+        <div className={field}>
+          <label className={labelClass} htmlFor="omnibar-first-prompt">
+            First Prompt <span style={{ fontWeight: "normal", opacity: 0.6 }}>(optional)</span>
+          </label>
+          <textarea
+            id="omnibar-first-prompt"
+            className={fieldInput}
+            placeholder="What should Claude do first? (injected as CLAUDE.md on session start)"
+            rows={3}
+            maxLength={2000}
+            value={formState.firstPrompt}
+            onChange={(e) => setFormField("firstPrompt", e.target.value)}
+            style={{ resize: "vertical", fontFamily: "inherit", fontSize: "inherit" }}
+          />
+          {formState.firstPrompt.length > 1800 && (
+            <span className={hint} style={{ color: "var(--warning)" }}>
+              {2000 - formState.firstPrompt.length} characters remaining
+            </span>
+          )}
+        </div>
 
         {/* Advanced Options */}
         <div className={collapsible}>

--- a/web-app/src/components/sessions/__tests__/OmnibarCreationPanel.attach.test.tsx
+++ b/web-app/src/components/sessions/__tests__/OmnibarCreationPanel.attach.test.tsx
@@ -25,6 +25,7 @@ const DEFAULT_FORM_STATE: OmnibarFormState = {
   parentDir: "",
   projectName: "",
   newProjectSessionType: "new_worktree",
+  firstPrompt: "",
 };
 
 function buildProps(overrides: Partial<OmnibarCreationPanelProps> = {}): OmnibarCreationPanelProps {

--- a/web-app/src/lib/contexts/OmnibarContext.tsx
+++ b/web-app/src/lib/contexts/OmnibarContext.tsx
@@ -122,6 +122,7 @@ export function OmnibarProvider({ children }: OmnibarProviderProps) {
         sessionType: effectiveSessionType,
         oneOff: data.oneOff ?? false,
         createIfMissing: data.createIfMissing ?? false,
+        initialPrompt: data.initialPrompt,
       });
 
       if (session) {

--- a/web-app/src/lib/hooks/useSessionService.ts
+++ b/web-app/src/lib/hooks/useSessionService.ts
@@ -172,6 +172,7 @@ export function useSessionService(
           sessionType: request.sessionType,
           oneOff: request.oneOff ?? false,
           createIfMissing: request.createIfMissing ?? false,
+          initialPrompt: request.initialPrompt,
         });
 
         // Add to store (with duplicate check handled by entity adapter upsertOne)

--- a/web-app/src/lib/omnibar/detector.ts
+++ b/web-app/src/lib/omnibar/detector.ts
@@ -4,6 +4,7 @@
  */
 
 import { InputType, DetectionResult, GitHubRef } from "./types";
+import { toSessionSlug } from "./slugify";
 
 export interface Detector {
   name: string;
@@ -297,7 +298,7 @@ class SessionSearchDetector implements Detector {
       type: InputType.SessionSearch,
       confidence: 0.5,
       parsedValue: trimmed,
-      suggestedName: "",
+      suggestedName: toSessionSlug(trimmed),
     };
   }
 }

--- a/web-app/src/lib/omnibar/parseInput.test.ts
+++ b/web-app/src/lib/omnibar/parseInput.test.ts
@@ -1,0 +1,44 @@
+import { parseInputWithSeparator } from "./parseInput";
+
+describe("parseInputWithSeparator", () => {
+  it("slugifies name and returns empty prompt when no separator", () => {
+    const result = parseInputWithSeparator("my feature");
+    expect(result.name).toBe("my-feature");
+    expect(result.firstPrompt).toBe("");
+  });
+
+  it("splits on first > and slugifies the name part", () => {
+    const result = parseInputWithSeparator("my feature > implement auth");
+    expect(result.name).toBe("my-feature");
+    expect(result.firstPrompt).toBe("implement auth");
+  });
+
+  it("keeps everything after first > (including nested >) as firstPrompt", () => {
+    const result = parseInputWithSeparator("a > b > c");
+    expect(result.name).toBe("a");
+    expect(result.firstPrompt).toBe("b > c");
+  });
+
+  it("returns empty name when separator is at start", () => {
+    const result = parseInputWithSeparator("> implement auth");
+    expect(result.name).toBe("");
+    expect(result.firstPrompt).toBe("implement auth");
+  });
+
+  it("returns empty prompt when separator is at end", () => {
+    const result = parseInputWithSeparator("my feature >");
+    expect(result.name).toBe("my-feature");
+    expect(result.firstPrompt).toBe("");
+  });
+
+  it("trims whitespace from firstPrompt", () => {
+    const result = parseInputWithSeparator("feature >   do something   ");
+    expect(result.firstPrompt).toBe("do something");
+  });
+
+  it("handles empty input", () => {
+    const result = parseInputWithSeparator("");
+    expect(result.name).toBe("");
+    expect(result.firstPrompt).toBe("");
+  });
+});

--- a/web-app/src/lib/omnibar/parseInput.ts
+++ b/web-app/src/lib/omnibar/parseInput.ts
@@ -1,0 +1,24 @@
+import { toSessionSlug } from "./slugify";
+
+export interface ParsedInput {
+  name: string;
+  firstPrompt: string;
+}
+
+/**
+ * Splits bare-text omnibar input on the first `>` character.
+ * Only call this when detection type is SessionSearch — never on path or URL inputs.
+ *
+ * "my feature > implement auth" → { name: "my-feature", firstPrompt: "implement auth" }
+ * "my feature"                  → { name: "my-feature", firstPrompt: "" }
+ * "> implement auth"            → { name: "", firstPrompt: "implement auth" }
+ */
+export function parseInputWithSeparator(input: string): ParsedInput {
+  const idx = input.indexOf(">");
+  if (idx === -1) {
+    return { name: toSessionSlug(input), firstPrompt: "" };
+  }
+  const rawName = input.slice(0, idx);
+  const firstPrompt = input.slice(idx + 1).trim();
+  return { name: toSessionSlug(rawName), firstPrompt };
+}

--- a/web-app/src/lib/omnibar/parseSlashCommand.test.ts
+++ b/web-app/src/lib/omnibar/parseSlashCommand.test.ts
@@ -1,0 +1,62 @@
+import { parseSlashCommand, KNOWN_SLASH_COMMANDS } from "./parseSlashCommand";
+
+describe("parseSlashCommand", () => {
+  it("returns null for plain text", () => {
+    expect(parseSlashCommand("my feature")).toBeNull();
+  });
+
+  it("returns null for unknown slash commands", () => {
+    expect(parseSlashCommand("/unknown")).toBeNull();
+  });
+
+  it("returns null for absolute paths (should fall through to LocalPathDetector)", () => {
+    expect(parseSlashCommand("/opt/homebrew")).toBeNull();
+    expect(parseSlashCommand("/Users/foo/project")).toBeNull();
+  });
+
+  it("parses /oneoff → one_off with empty remainder", () => {
+    const result = parseSlashCommand("/oneoff");
+    expect(result?.sessionType).toBe("one_off");
+    expect(result?.remainder).toBe("");
+  });
+
+  it("parses /worktree → new_worktree with remainder", () => {
+    const result = parseSlashCommand("/worktree my feature");
+    expect(result?.sessionType).toBe("new_worktree");
+    expect(result?.remainder).toBe("my feature");
+  });
+
+  it("parses /dir → directory", () => {
+    const result = parseSlashCommand("/dir");
+    expect(result?.sessionType).toBe("directory");
+  });
+
+  it("parses /existing → existing_worktree", () => {
+    const result = parseSlashCommand("/existing");
+    expect(result?.sessionType).toBe("existing_worktree");
+  });
+
+  it("parses /project → new_project", () => {
+    const result = parseSlashCommand("/project");
+    expect(result?.sessionType).toBe("new_project");
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseSlashCommand("/ONEOFF")?.sessionType).toBe("one_off");
+    expect(parseSlashCommand("/Worktree")?.sessionType).toBe("new_worktree");
+  });
+
+  it("trims whitespace from remainder", () => {
+    const result = parseSlashCommand("/oneoff   my session   ");
+    expect(result?.remainder).toBe("my session");
+  });
+
+  it("KNOWN_SLASH_COMMANDS covers all session types", () => {
+    const values = Object.values(KNOWN_SLASH_COMMANDS);
+    expect(values).toContain("one_off");
+    expect(values).toContain("new_worktree");
+    expect(values).toContain("directory");
+    expect(values).toContain("existing_worktree");
+    expect(values).toContain("new_project");
+  });
+});

--- a/web-app/src/lib/omnibar/parseSlashCommand.ts
+++ b/web-app/src/lib/omnibar/parseSlashCommand.ts
@@ -1,0 +1,33 @@
+import type { OmnibarFormState } from "@/components/sessions/Omnibar";
+
+type SessionTypeValue = OmnibarFormState["sessionType"];
+
+export const KNOWN_SLASH_COMMANDS: Record<string, SessionTypeValue> = {
+  oneoff: "one_off",
+  worktree: "new_worktree",
+  dir: "directory",
+  existing: "existing_worktree",
+  project: "new_project",
+};
+
+export interface SlashCommandResult {
+  sessionType: SessionTypeValue;
+  remainder: string;
+}
+
+/**
+ * Parses a `/command [remainder]` prefix from the omnibar input.
+ * Returns null for any input that isn't a known slash command.
+ * Unknown `/foo` inputs fall through to normal detection (e.g. LocalPathDetector).
+ *
+ * Must be called BEFORE detect() in the debounce effect so the slash prefix
+ * is consumed before path detectors can misidentify it.
+ */
+export function parseSlashCommand(input: string): SlashCommandResult | null {
+  const match = /^\/([a-z]+)(?:\s+(.*))?$/i.exec(input.trim());
+  if (!match) return null;
+  const cmd = match[1].toLowerCase();
+  const sessionType = KNOWN_SLASH_COMMANDS[cmd];
+  if (!sessionType) return null;
+  return { sessionType, remainder: match[2]?.trim() ?? "" };
+}

--- a/web-app/src/lib/omnibar/slugify.test.ts
+++ b/web-app/src/lib/omnibar/slugify.test.ts
@@ -1,0 +1,61 @@
+import { toSessionSlug } from "./slugify";
+
+describe("toSessionSlug", () => {
+  it("converts spaces to hyphens", () => {
+    expect(toSessionSlug("my feature branch")).toBe("my-feature-branch");
+  });
+
+  it("lowercases input", () => {
+    expect(toSessionSlug("MY FEATURE")).toBe("my-feature");
+  });
+
+  it("strips non-alphanumeric characters", () => {
+    expect(toSessionSlug("fix: auth bug!")).toBe("fix-auth-bug");
+  });
+
+  it("collapses multiple hyphens", () => {
+    expect(toSessionSlug("foo---bar")).toBe("foo-bar");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(toSessionSlug("-hello-")).toBe("hello");
+  });
+
+  it("returns empty string for all-special input", () => {
+    expect(toSessionSlug("!!!")).toBe("");
+  });
+
+  it("returns empty string for emoji-only input", () => {
+    expect(toSessionSlug("🚀")).toBe("");
+  });
+
+  it("strips emoji and slugifies remaining text", () => {
+    expect(toSessionSlug("🚀 launch")).toBe("launch");
+  });
+
+  it("returns empty string for CJK-only input", () => {
+    expect(toSessionSlug("中文")).toBe("");
+  });
+
+  it("returns empty string for whitespace-only input", () => {
+    expect(toSessionSlug("   ")).toBe("");
+  });
+
+  it("strips shell special characters without injection risk", () => {
+    expect(toSessionSlug("$(rm -rf /)")).toBe("rm-rf");
+  });
+
+  it("truncates at 60 characters", () => {
+    const long = "a".repeat(70);
+    expect(toSessionSlug(long).length).toBeLessThanOrEqual(60);
+  });
+
+  it("does not leave trailing hyphen after truncation", () => {
+    const slug = toSessionSlug("word-".repeat(15));
+    expect(slug.endsWith("-")).toBe(false);
+  });
+
+  it("handles leading digits (valid but unusual)", () => {
+    expect(toSessionSlug("123 fix auth")).toBe("123-fix-auth");
+  });
+});

--- a/web-app/src/lib/omnibar/slugify.ts
+++ b/web-app/src/lib/omnibar/slugify.ts
@@ -1,0 +1,12 @@
+export function toSessionSlug(input: string): string {
+  const slug = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60)
+    .replace(/-+$/, "");
+  return slug;
+}


### PR DESCRIPTION
## Summary

- **Session name auto-population**: `SessionSearchDetector` now returns `toSessionSlug(input)` as `suggestedName` for bare-text queries — typing "implement oauth" in the omnibar auto-fills "implement-oauth" in the session name field. The existing `lastSuggestedNameRef` guard prevents overwriting manual edits.
- **First prompt injection**: New `firstPrompt` textarea in the creation panel (2000 char limit) threads `initialPrompt` through `OmnibarFormState → OmnibarContext → useSessionService → CreateSessionRequest` (proto field 15). Fixes a silent data loss bug in `handleSubmit` where `firstPrompt` would have been dropped.
- **Inline separator shorthand**: Type `"my feature > implement auth"` — parsed on read via `parseInputWithSeparator()`, gated on `SessionSearch` detection type only (never fires on paths/URLs). Preview hint shown when active.
- **Slash command type switching**: `/oneoff`, `/worktree`, `/dir`, `/existing`, `/project` pre-processed before `detect()` so they're not swallowed by `LocalPathDetector`. Sets session type and passes remainder to the detector.
- **Tab cycling**: In creation mode with no dropdown open, Tab cycles through session types. "Tab: cycle type" hint shown in the footer shortcuts bar.
- **ADR-001**: Documents `>` separator and `/command` prefix as the omnibar's unified inline shorthand language, including an Extension Contract for adding new commands.

## New files

- `web-app/src/lib/omnibar/slugify.ts` + `.test.ts` — `toSessionSlug()` pure function (14 tests)
- `web-app/src/lib/omnibar/parseInput.ts` + `.test.ts` — `parseInputWithSeparator()` (8 tests)  
- `web-app/src/lib/omnibar/parseSlashCommand.ts` + `.test.ts` — `parseSlashCommand()` + `KNOWN_SLASH_COMMANDS` (10 tests)
- `project_plans/omnibar-session-name-ux/decisions/ADR-001-omnibar-inline-shorthand-language.md`

## Test plan

- [ ] Open omnibar, type plain text like "implement oauth" → session name field auto-fills "implement-oauth"
- [ ] Switch to one-off mode → session name still auto-fills from input
- [ ] Type "my feature > implement auth" → session name fills "my-feature", First Prompt textarea fills "implement auth", preview hint appears
- [ ] Type `/oneoff` → session type switches to One-off; type `/worktree my session` → type switches + name fills "my-session"
- [ ] In creation mode with no path dropdown open, press Tab → cycles through session types; footer shows "Tab: cycle type" hint
- [ ] Fill First Prompt textarea manually, create session → verify `initialPrompt` is injected (check `~/.stapler-squad/logs/stapler-squad.log` for `initial_prompt` field in create request)
- [ ] All 32 new unit tests: `cd web-app && npx jest --no-coverage --testPathPatterns="slugify|parseInput|parseSlashCommand"`