### PR TITLE
fix(notifications): fix type mapping, approval guard, and dedup loop

### DIFF
--- a/web-app/src/lib/contexts/NotificationContext.tsx
+++ b/web-app/src/lib/contexts/NotificationContext.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from "react";
 import { NotificationToast } from "@/components/ui/NotificationToast";
 import { NotificationData, NotificationHistoryItem } from "@/lib/types/notification";
-import { ReviewItem } from "@/gen/session/v1/types_pb";
+import { ReviewItem, AttentionReason } from "@/gen/session/v1/types_pb";
 import { useAuditLog } from "@/lib/hooks/useAuditLog";
 import { useNotificationHistory } from "@/lib/hooks/useNotificationHistory";
 import { groupNotifications } from "@/lib/utils/notificationGrouping";
@@ -47,6 +47,25 @@ interface NotificationContextValue {
 }
 
 const NotificationContext = createContext<NotificationContextValue | null>(null);
+
+function reviewItemToNotificationType(reason: AttentionReason): NotificationData["notificationType"] {
+  switch (reason) {
+    case AttentionReason.APPROVAL_PENDING:
+    case AttentionReason.WAITING_FOR_USER:
+      return "approval_needed";
+    case AttentionReason.INPUT_REQUIRED:
+      return "question";
+    case AttentionReason.ERROR_STATE:
+    case AttentionReason.TESTS_FAILING:
+      return "error";
+    case AttentionReason.STALE:
+      return "warning";
+    case AttentionReason.TASK_COMPLETE:
+      return "task_complete";
+    default:
+      return "info";
+  }
+}
 
 export function NotificationProvider({ children }: { children: React.ReactNode }) {
   const [notifications, setNotifications] = useState<NotificationData[]>([]);
@@ -100,13 +119,18 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       }
 
       // Pass 2: add backend items not covered by any local item.
+      // Mutate existingDedupKeys as we go so duplicate-type records (e.g. multiple
+      // auto_approved entries for the same session) don't all slip through.
       const existingIds = new Set(updated.map((n) => n.id));
       const existingDedupKeys = new Set(updated.map((n) => `${n.sessionId ?? ""}:${n.notificationType ?? ""}`));
-      const newFromBackend = backendItems.filter((n) => {
-        if (existingIds.has(n.id)) return false;
+      const newFromBackend: NotificationHistoryItem[] = [];
+      for (const n of backendItems) {
+        if (existingIds.has(n.id)) continue;
         const dk = `${n.sessionId ?? ""}:${n.notificationType ?? ""}`;
-        return !existingDedupKeys.has(dk);
-      });
+        if (existingDedupKeys.has(dk)) continue;
+        newFromBackend.push(n);
+        existingDedupKeys.add(dk);
+      }
 
       return [...newFromBackend, ...updated];
     });
@@ -119,7 +143,18 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
       // Only show the latest toast per session — replace any existing toast for the
       // same sessionId so they don't stack. Older notifications remain in history.
+      // Exception: never displace an approval toast (one with onApprove/onDeny) with
+      // a notification that lacks those callbacks — approvals require explicit resolution.
       setNotifications((prev) => {
+        const existing = prev.find((n) => n.sessionId === notification.sessionId);
+        if (
+          existing &&
+          (existing.onApprove || existing.onDeny) &&
+          !notification.onApprove &&
+          !notification.onDeny
+        ) {
+          return prev;
+        }
         const without = prev.filter((n) => n.sessionId !== notification.sessionId);
         return [...without, newNotification];
       });
@@ -159,6 +194,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         sessionName: item.sessionName || "Unnamed Session",
         message: item.context || "This session is waiting for your input",
         priority: mapPriority(item.priority),
+        notificationType: reviewItemToNotificationType(item.reason),
         onView,
         onAcknowledge,
       });

--- a/web-app/src/lib/contexts/__tests__/NotificationContext.test.tsx
+++ b/web-app/src/lib/contexts/__tests__/NotificationContext.test.tsx
@@ -3,6 +3,22 @@ import { renderHook, act } from "@testing-library/react";
 import { NotificationProvider, useNotifications } from "@/lib/contexts/NotificationContext";
 import { TOAST_STALE_MS, ACTIONABLE_TOAST_STALE_MS } from "@/lib/notification-policy";
 import type { NotificationData } from "@/lib/types/notification";
+import type { ReviewItem } from "@/gen/session/v1/types_pb";
+
+// AttentionReason numeric values — matches proto/session/v1/types.proto
+const AttentionReason = {
+  UNSPECIFIED: 0,
+  APPROVAL_PENDING: 1,
+  INPUT_REQUIRED: 2,
+  ERROR_STATE: 3,
+  IDLE_TIMEOUT: 4,
+  TASK_COMPLETE: 5,
+  UNCOMMITTED_CHANGES: 6,
+  IDLE: 7,
+  STALE: 8,
+  WAITING_FOR_USER: 9,
+  TESTS_FAILING: 10,
+} as const;
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -68,6 +84,16 @@ function makeNotification(
     message: "Something needs your attention",
     ...overrides,
   };
+}
+
+function makeReviewItem(reason: number, sessionId = "session-1"): ReviewItem {
+  return {
+    sessionId,
+    sessionName: "Test Session",
+    reason,
+    context: "Some context",
+    priority: 2,
+  } as unknown as ReviewItem;
 }
 
 // ---------------------------------------------------------------------------
@@ -420,6 +446,150 @@ describe("NotificationContext", () => {
 
       expect(result.current.notifications).toHaveLength(1);
       expect(result.current.notifications[0].notificationType).toBe("approval_needed");
+    });
+  });
+
+  describe("showSessionNotification — reviewItemToNotificationType mapping", () => {
+    it.each([
+      [AttentionReason.APPROVAL_PENDING, "approval_needed"],
+      [AttentionReason.WAITING_FOR_USER, "approval_needed"],
+      [AttentionReason.INPUT_REQUIRED, "question"],
+      [AttentionReason.ERROR_STATE, "error"],
+      [AttentionReason.TESTS_FAILING, "error"],
+      [AttentionReason.STALE, "warning"],
+      [AttentionReason.TASK_COMPLETE, "task_complete"],
+      [AttentionReason.IDLE, "info"],
+      [AttentionReason.UNSPECIFIED, "info"],
+    ])("reason %i → notificationType %s", (reason, expectedType) => {
+      const { result } = renderHook(() => useNotifications(), { wrapper });
+
+      act(() => {
+        result.current.showSessionNotification(makeReviewItem(reason));
+      });
+
+      expect(result.current.notifications[0].notificationType).toBe(expectedType);
+    });
+
+    it("populates sessionId, sessionName, and message from the ReviewItem", () => {
+      const { result } = renderHook(() => useNotifications(), { wrapper });
+
+      act(() => {
+        result.current.showSessionNotification(makeReviewItem(AttentionReason.APPROVAL_PENDING));
+      });
+
+      const n = result.current.notifications[0];
+      expect(n.sessionId).toBe("session-1");
+      expect(n.sessionName).toBe("Test Session");
+      expect(n.message).toBeTruthy();
+    });
+
+    it("passes onView and onAcknowledge callbacks through to the notification", () => {
+      const onView = jest.fn();
+      const onAcknowledge = jest.fn();
+      const { result } = renderHook(() => useNotifications(), { wrapper });
+
+      act(() => {
+        result.current.showSessionNotification(
+          makeReviewItem(AttentionReason.APPROVAL_PENDING),
+          onView,
+          onAcknowledge
+        );
+      });
+
+      const n = result.current.notifications[0];
+      n.onView?.();
+      n.onAcknowledge?.();
+      expect(onView).toHaveBeenCalledTimes(1);
+      expect(onAcknowledge).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("approval toast guard (addNotification displacement prevention)", () => {
+    it("does not displace an approval toast with a non-approval notification from the same session", () => {
+      const { result } = renderHook(() => useNotifications(), { wrapper });
+      const onApprove = jest.fn();
+      const onDeny = jest.fn();
+
+      act(() => {
+        result.current.addNotification(
+          makeNotification({ notificationType: "approval_needed", onApprove, onDeny })
+        );
+      });
+      const approvalId = result.current.notifications[0].id;
+
+      act(() => {
+        result.current.addNotification(makeNotification({ notificationType: "info" }));
+      });
+
+      expect(result.current.notifications).toHaveLength(1);
+      expect(result.current.notifications[0].id).toBe(approvalId);
+      expect(result.current.notifications[0].notificationType).toBe("approval_needed");
+    });
+
+    it("allows a new approval-capable notification to replace an existing approval toast", () => {
+      const { result } = renderHook(() => useNotifications(), { wrapper });
+
+      act(() => {
+        result.current.addNotification(
+          makeNotification({ message: "first approval", notificationType: "approval_needed", onApprove: jest.fn(), onDeny: jest.fn() })
+        );
+      });
+
+      act(() => {
+        result.current.addNotification(
+          makeNotification({ message: "second approval", notificationType: "approval_needed", onApprove: jest.fn(), onDeny: jest.fn() })
+        );
+      });
+
+      expect(result.current.notifications).toHaveLength(1);
+      expect(result.current.notifications[0].message).toBe("second approval");
+    });
+
+    it("allows notifications from a different session to appear alongside an approval toast", () => {
+      const { result } = renderHook(() => useNotifications(), { wrapper });
+
+      act(() => {
+        result.current.addNotification(
+          makeNotification({ sessionId: "s1", notificationType: "approval_needed", onApprove: jest.fn(), onDeny: jest.fn() })
+        );
+        result.current.addNotification(
+          makeNotification({ sessionId: "s2", notificationType: "info" })
+        );
+      });
+
+      expect(result.current.notifications).toHaveLength(2);
+    });
+
+    it("allows normal replacement when no approval toast is active", () => {
+      const { result } = renderHook(() => useNotifications(), { wrapper });
+
+      act(() => {
+        result.current.addNotification(makeNotification({ message: "first" }));
+      });
+      act(() => {
+        result.current.addNotification(makeNotification({ message: "second" }));
+      });
+
+      expect(result.current.notifications).toHaveLength(1);
+      expect(result.current.notifications[0].message).toBe("second");
+    });
+
+    it("suppressed notification is still recorded in history", () => {
+      const { result } = renderHook(() => useNotifications(), { wrapper });
+
+      act(() => {
+        result.current.addNotification(
+          makeNotification({ notificationType: "approval_needed", onApprove: jest.fn(), onDeny: jest.fn() })
+        );
+      });
+      act(() => {
+        result.current.addNotification(makeNotification({ notificationType: "info" }));
+      });
+
+      // Toast suppressed — only 1 active
+      expect(result.current.notifications).toHaveLength(1);
+      // Both in history
+      expect(result.current.notificationHistory).toHaveLength(2);
     });
   });
 });

--- a/web-app/src/lib/hooks/__tests__/useReviewQueueNotifications.test.ts
+++ b/web-app/src/lib/hooks/__tests__/useReviewQueueNotifications.test.ts
@@ -15,17 +15,17 @@ import { renderHook, act } from "@testing-library/react";
 
 jest.mock("@/gen/session/v1/types_pb", () => ({
   AttentionReason: {
+    UNSPECIFIED: 0,
     APPROVAL_PENDING: 1,
     INPUT_REQUIRED: 2,
-    WAITING_FOR_USER: 3,
-    ERROR_STATE: 4,
-    TESTS_FAILING: 5,
-    STALE: 6,
-    TASK_COMPLETE: 7,
-    IDLE: 8,
-    UNCOMMITTED_CHANGES: 9,
-    IDLE_TIMEOUT: 10,
-    UNSPECIFIED: 0,
+    ERROR_STATE: 3,
+    IDLE_TIMEOUT: 4,
+    TASK_COMPLETE: 5,
+    UNCOMMITTED_CHANGES: 6,
+    IDLE: 7,
+    STALE: 8,
+    WAITING_FOR_USER: 9,
+    TESTS_FAILING: 10,
   },
 }));
 
@@ -262,8 +262,8 @@ describe("useReviewQueueNotifications — dwell-time filter", () => {
 
   describe("tier routing", () => {
     it("adds Tier 3 items to history only (no toast, no sound)", () => {
-      // TASK_COMPLETE = 7 → Tier 3
-      const item = makeItem("session-t3", 7);
+      // TASK_COMPLETE = 5 → Tier 3
+      const item = makeItem("session-t3", 5);
 
       const { rerender } = renderHook(
         ({ items }) => useReviewQueueNotifications(items, { enabled: true }),
@@ -286,8 +286,8 @@ describe("useReviewQueueNotifications — dwell-time filter", () => {
       );
     });
 
-    it("shows toast + sound for Tier 2 items (ERROR_STATE = 4)", () => {
-      const item = makeItem("session-t2", 4 /* ERROR_STATE */);
+    it("shows toast + sound for Tier 2 items (ERROR_STATE = 3)", () => {
+      const item = makeItem("session-t2", 3 /* ERROR_STATE */);
 
       const { rerender } = renderHook(
         ({ items }) => useReviewQueueNotifications(items, { enabled: true }),


### PR DESCRIPTION
## Summary

- **`reviewItemToNotificationType` mapping**: New pure function mapping `AttentionReason` proto enum → UI `notificationType`. Adds explicit `TASK_COMPLETE → "task_complete"` branch (was silently falling through to `"info"`).
- **Approval toast displacement guard**: `addNotification` now holds an active approval toast (one with `onApprove`/`onDeny`) in place when a weaker notification arrives for the same session, preventing accidental dismissal of approval UX mid-flow.
- **Pass 2 dedup loop in history hydration**: Changed from `.filter()` to an imperative loop that mutates `existingDedupKeys` inside the body, preventing multiple backend records sharing the same `sessionId:notificationType` key from all passing the filter and flooding history.

## Test plan

- [x] All existing `NotificationContext.test.tsx` tests pass (23 → 39 tests)
- [x] Added `showSessionNotification` tests covering all 9 `AttentionReason` branches via parameterized `it.each`
- [x] Added 5 approval guard tests: no-displace when approval active, replacement by new approval, cross-session independence, normal replacement without guard, suppressed notification still in history
- [x] Fixed `useReviewQueueNotifications.test.ts` mock enum values — hand-rolled values had `WAITING_FOR_USER=3` (actual: 9), `ERROR_STATE=4` (actual: 3), `TASK_COMPLETE=7` (actual: 5), etc. Tier routing tests were exercising fictional behavior. All 16 tests still pass with corrected values.
- [x] Full notification suite: 171 tests, 0 failures