### PR TITLE
fix(macos): stable TCC permission grants via self-signed codesigning

### DIFF
--- a/.claude/docs/codesigning.md
+++ b/.claude/docs/codesigning.md
@@ -1,0 +1,102 @@
+# macOS Code Signing for TCC Permission Persistence
+
+## What this does
+
+stapler-squad signs its binary with a self-signed certificate (`StaplerSquadDev`) on every `make install-service`. The certificate anchors the Designated Requirement (DR), so macOS TCC grants (Full Disk Access, Apple Events) survive rebuilds without re-prompting.
+
+Without a stable cert-anchored DR, every rebuild changes the binary's cdhash and macOS treats it as a new app — requiring a fresh round of permission dialogs.
+
+## One-time setup
+
+Run once per developer machine:
+
+```bash
+# Install OpenSSL if needed (macOS ships LibreSSL, which won't work)
+brew install openssl
+
+# Create and trust the self-signed cert
+OPENSSL_BIN=$(brew --prefix openssl)/bin/openssl make setup-codesign
+```
+
+If `openssl version` shows `OpenSSL` (not `LibreSSL`), you can omit `OPENSSL_BIN`:
+
+```bash
+make setup-codesign
+```
+
+The script is idempotent — running it a second time prints "StaplerSquadDev cert already present." and exits without creating a duplicate.
+
+## Verifying the setup
+
+After `make install-service`, run:
+
+```bash
+make verify-codesign
+```
+
+Pass criteria:
+- `Authority=StaplerSquadDev` in the Code Signature section
+- `Identifier=com.stapler-squad` in the Code Signature section
+- DR section contains `anchor H"<cert-sha1>"` or `anchor trusted` (cert-anchored, not `cdhash`)
+- `CFBundleIdentifier => "com.stapler-squad"` in the Embedded Info.plist section
+- `com.apple.security.automation.apple-events` in the Entitlements section
+
+## Exporting the cert for backup
+
+If you need to move the cert to another machine or back it up:
+
+1. Open **Keychain Access** (`/Applications/Utilities/Keychain Access.app`)
+2. Select the **login** keychain
+3. Find **StaplerSquadDev** in the My Certificates category
+4. Right-click → **Export "StaplerSquadDev"**
+5. Save as `.p12`, set a password when prompted
+
+## Re-importing on a new machine
+
+```bash
+security import StaplerSquadDev.p12 \
+    -k ~/Library/Keychains/login.keychain-db \
+    -T /usr/bin/codesign
+```
+
+Then run `make setup-codesign` (it will detect the cert exists and skip creation, but the set-key-partition-list step ensures codesign can access the key without prompting).
+
+Actually for a clean import, just run the full setup again — the script checks for the cert and exits early if found. You may need to delete the old cert entry first in Keychain Access if re-importing on the same machine.
+
+## Diagnosing TCC issues
+
+### Check current grants
+
+```bash
+# List Apple Events grants for stapler-squad
+sqlite3 ~/Library/Application\ Support/com.apple.TCC/TCC.db \
+    "SELECT client, auth_value, auth_reason FROM access WHERE client = 'com.stapler-squad';"
+```
+
+Note: reading TCC.db directly may require Full Disk Access for your terminal.
+
+### Reset grants (development only)
+
+```bash
+make tcc-reset
+```
+
+This resets all TCC grants for `com.stapler-squad`. Use during development to reproduce the first-launch permission prompt experience. Requires `sudo`.
+
+### Re-grant after reset
+
+1. Run `make install-service`
+2. Open System Settings → Privacy & Security → Full Disk Access
+3. Enable the toggle for `stapler-squad`
+4. Trigger FocusWindow in the UI to re-approve Apple Events for each target app
+
+## How it works
+
+The `make install-service` flow on macOS:
+
+1. `go build` with `CGO_LDFLAGS="-sectcreate __TEXT __info_plist Info.plist"` embeds the plist into the binary's `__TEXT/__info_plist` Mach-O section
+2. `otool` assertion verifies the plist was actually embedded (catches silent `CGO_ENABLED=0` failures)
+3. `codesign --sign "StaplerSquadDev" --entitlements entitlements.plist` signs the binary
+4. `install-service.sh` stops, installs, and restarts the LaunchAgent
+
+The `CFBundleIdentifier = com.stapler-squad` in the embedded plist causes TCC to track the app by bundle ID (`client_type=0`) rather than path+hash. The cert-anchored DR means the TCC row's `csreq` field matches every rebuild as long as the same cert is used.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ go build .                  # Build the application
 
 make install-service        # Build web UI + Go binary + install/restart system service (ALWAYS use this)
 make uninstall-service      # Remove the service
+make setup-codesign         # (macOS, one-time) Create self-signed cert for TCC grant persistence
+make verify-codesign        # Check binary signing status
+make tcc-reset              # Reset TCC grants (development/debugging only)
+
+See `.claude/docs/codesigning.md` for first-time setup and cert backup instructions.
 
 STAPLER_SQUAD_USE_CONTROL_MODE=false ./stapler-squad   # Disable tmux control mode (legacy polling)
 ./stapler-squad --tmux-keep-server                     # Keep tmux server alive after sessions close
@@ -217,6 +222,7 @@ make e2e-lighthouse
 |---|---|
 | Profiling / lock-up debugging | `.claude/docs/profiling.md` |
 | OpenTelemetry / Datadog setup | `.claude/docs/opentelemetry.md` |
+| macOS code signing / TCC | `.claude/docs/codesigning.md` |
 | PTY multiplexing (ssq-mux) | `.claude/docs/pty-multiplexing.md` |
 | State file isolation / multi-instance | `.claude/docs/state-isolation.md` |
 | Tag-based session organization | `.claude/docs/tag-organization.md` |

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.stapler-squad</string>
+    <key>CFBundleName</key>
+    <string>stapler-squad</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>stapler-squad uses Apple Events to bring your editor or browser to the foreground when you click Focus Window.</string>
+</dict>
+</plist>

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # Comprehensive development and analysis toolchain
 
 # Variables
+UNAME_S := $(shell uname -s)
 PROFILE_FLAGS ?=
 PROFILE_PORT ?= 6060
 SERVER_FLAGS ?= --remote-access --tmux-keep-server
@@ -45,7 +46,7 @@ endif
 		touch $(ASDF_STAMP); \
 	fi
 
-.PHONY: help build test benchmark install-tools lint lint-custom analyze nil-safety security format fmt-check check-deps clean all proto-gen proto-lint proto-build web-build web-dev restart-web restart-web-profile qr demo-video demo-post-process demo-gif benchmark-baseline benchmark-compare benchmark-tier1 profile-goroutines profile-block profile-mutex profile-trace build-mux install-mux install-service uninstall-service preview coverage-func coverage-gaps coverage-pkg coverage-refactor registry-generate-backend registry-generate-frontend registry-generate registry-diff e2e-report e2e-lighthouse build-tmux build-tmux-embed build-embedded clean-tmux init-submodules test-with-pinned-tmux vet-architecture vet-rpc-markers coverage-integration
+.PHONY: help build test benchmark install-tools lint lint-custom analyze nil-safety security format fmt-check check-deps clean all proto-gen proto-lint proto-build web-build web-dev restart-web restart-web-profile qr demo-video demo-post-process demo-gif benchmark-baseline benchmark-compare benchmark-tier1 profile-goroutines profile-block profile-mutex profile-trace build-mux install-mux install-service uninstall-service setup-codesign _codesign-binary verify-codesign tcc-reset preview coverage-func coverage-gaps coverage-pkg coverage-refactor registry-generate-backend registry-generate-frontend registry-generate registry-diff e2e-report e2e-lighthouse build-tmux build-tmux-embed build-embedded clean-tmux init-submodules test-with-pinned-tmux vet-architecture vet-rpc-markers coverage-integration
 
 # Default target
 help: ## Show this help message
@@ -106,7 +107,15 @@ build: stapler-squad ## Build the Go application
 
 stapler-squad: ensure-tools proto-gen server/web/dist lint $(GO_FILES) ## Build the Go binary
 	@echo "Building Go application..."
+ifeq ($(UNAME_S),Darwin)
+	CGO_LDFLAGS="-sectcreate __TEXT __info_plist $(CURDIR)/Info.plist" \
+		go build -o stapler-squad .
+	@# Verify Info.plist was actually embedded (catches silent CGO_ENABLED=0 failures)
+	@otool -s __TEXT __info_plist "$(CURDIR)/stapler-squad" | grep -q "Contents of" || \
+		(echo "ERROR: Info.plist was not embedded. Ensure CGO_ENABLED=1 and try again." && exit 1)
+else
 	go build -o stapler-squad .
+endif
 	@echo "✅ stapler-squad built successfully"
 
 # Install web-app npm dependencies when package-lock.json changes
@@ -228,7 +237,14 @@ build-tmux-embed: build-tmux ## Copy built tmux into the embed dir for go build 
 	@echo "✅ session/tmux/embed/tmux ready ($(shell $(BIN_TMUX) -V 2>/dev/null || echo unknown))"
 
 build-embedded: build-tmux-embed ## Build stapler-squad with tmux bundled inside the binary
+ifeq ($(UNAME_S),Darwin)
+	CGO_LDFLAGS="-sectcreate __TEXT __info_plist $(CURDIR)/Info.plist" \
+		go build -tags embed_tmux -o stapler-squad .
+	@otool -s __TEXT __info_plist "$(CURDIR)/stapler-squad" | grep -q "Contents of" || \
+		(echo "ERROR: Info.plist was not embedded in embedded build." && exit 1)
+else
 	go build -tags embed_tmux -o stapler-squad .
+endif
 	@echo "✅ stapler-squad built with embedded tmux"
 
 clean-tmux: ## Remove the built tmux binary and submodule build artifacts
@@ -238,10 +254,59 @@ clean-tmux: ## Remove the built tmux binary and submodule build artifacts
 	@echo "✅ tmux artifacts cleaned"
 
 install-service: build ## Install stapler-squad as a system service (systemd on Linux, LaunchAgent on macOS)
+ifeq ($(UNAME_S),Darwin)
+	@$(MAKE) _codesign-binary
+endif
 	@STAPLER_SQUAD_BIN="$(CURDIR)/stapler-squad" ./scripts/install-service.sh $(if $(NO_PROFILE),--no-profile) $(if $(PROFILE_PORT),--profile-port $(PROFILE_PORT))
+
+_codesign-binary: ## Sign the binary with StaplerSquadDev cert (called by install-service on macOS)
+	@if ! ./scripts/check-codesign.sh; then \
+		echo "  StaplerSquadDev signing cert not found."; \
+		echo "   Run 'make setup-codesign' once to create it, then retry."; \
+		exit 1; \
+	fi
+	@echo "Signing binary..."
+	codesign --force \
+		--sign "StaplerSquadDev" \
+		--entitlements "$(CURDIR)/entitlements.plist" \
+		"$(CURDIR)/stapler-squad"
+	@echo "Binary signed"
 
 uninstall-service: ## Remove the system service and disable auto-start on login
 	@./scripts/install-service.sh --uninstall
+
+setup-codesign: ## (macOS only) Create self-signed codesign certificate for stable TCC identity
+	@# Requires OpenSSL (not LibreSSL). Set OPENSSL_BIN to override, e.g.:
+	@#   OPENSSL_BIN=$(brew --prefix openssl)/bin/openssl make setup-codesign
+	@./scripts/setup-codesign.sh
+
+verify-codesign: ## Verify binary code signing status and TCC identity
+	@echo "=== Code Signature ==="
+	@codesign -dv --verbose=4 "$(CURDIR)/stapler-squad" 2>&1
+	@echo ""
+	@echo "=== Designated Requirement (must be cert-anchored, not cdhash-anchored) ==="
+	@codesign -d --requirements - "$(CURDIR)/stapler-squad" 2>&1
+	@# PASS: DR contains "anchor trusted" or "anchor H\"<cert-sha1>\""
+	@# FAIL: DR contains only "cdhash H\"<binary-hash>\"" — means ad-hoc or no cert
+	@echo ""
+	@echo "=== Entitlements ==="
+	@codesign -d --entitlements - "$(CURDIR)/stapler-squad" 2>&1
+	@echo ""
+	@echo "=== Embedded Info.plist ==="
+	@# NOTE: otool -s output is offset+hex+ASCII interleaved; strip offsets and ASCII
+	@# before feeding to xxd. The awk extracts the 2nd-5th columns (hex groups only).
+	@otool -s __TEXT __info_plist "$(CURDIR)/stapler-squad" | \
+		tail -n +2 | \
+		awk '{for(i=2;i<=NF&&length($$i)==8;i++) printf $$i; print ""}' | \
+		tr -d '\n' | xxd -r -p | plutil -p - 2>&1 || \
+		echo "(no embedded plist — Info.plist not embedded; check CGO_ENABLED=1)"
+
+tcc-reset: ## Reset TCC grants for stapler-squad (causes one-time re-prompt; use during development only)
+	@echo "Resetting TCC grants for com.stapler-squad..."
+	@# Must use sudo; without it the system TCC DB (FDA) reset is silently skipped.
+	@# Do NOT add || true: sudo failure should surface as an error, not silently succeed.
+	sudo tccutil reset All com.stapler-squad
+	@echo "Done. Grants will be re-prompted on next launch."
 
 # Isolated preview instance — does NOT touch the running global service.
 # Auto-picks a free port and uses a branch-scoped STAPLER_SQUAD_INSTANCE so

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/infoplist_darwin.go
+++ b/infoplist_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package main
+
+// cgo is imported here only to force the Go toolchain to invoke the external
+// (C) linker on Darwin, which is required for CGO_LDFLAGS=-sectcreate to take
+// effect. The Go internal linker ignores CGO_LDFLAGS entirely.
+import "C"

--- a/scripts/check-codesign.sh
+++ b/scripts/check-codesign.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# check-codesign.sh — Check whether the StaplerSquadDev signing cert exists
+# and is trusted. Used by the Makefile _codesign-binary guard.
+#
+# Exit 0 if cert is found, exit 1 if not.
+
+# macOS-only guard
+[ "$(uname)" = "Darwin" ] || exit 0
+
+if security find-identity -v -p codesigning | grep -q "StaplerSquadDev"; then
+    exit 0
+else
+    exit 1
+fi

--- a/scripts/setup-codesign.sh
+++ b/scripts/setup-codesign.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# setup-codesign.sh — Create a self-signed code-signing certificate for
+# stable TCC identity. Run once per developer machine.
+#
+# Requires OpenSSL (not LibreSSL). If macOS's default openssl is LibreSSL,
+# install real OpenSSL first:
+#   brew install openssl
+# Then either add it to PATH or run:
+#   OPENSSL_BIN=$(brew --prefix openssl)/bin/openssl make setup-codesign
+
+set -e
+
+# 1. Check macOS
+[ "$(uname)" = "Darwin" ] || { echo "macOS only"; exit 0; }
+
+# 2. Skip if cert already exists (idempotent)
+if security find-identity -v -p codesigning | grep -q "StaplerSquadDev"; then
+    echo "StaplerSquadDev cert already present."
+    exit 0
+fi
+
+# PREREQUISITE: Requires OpenSSL (not LibreSSL). macOS ships LibreSSL which
+# lacks -addext support. Check and error early if LibreSSL is detected.
+# Resolve OPENSSL first so OPENSSL_BIN override is respected in the check.
+OPENSSL="${OPENSSL_BIN:-openssl}"
+if "$OPENSSL" version | grep -q LibreSSL; then
+    echo "ERROR: Requires OpenSSL (not LibreSSL). Run: brew install openssl"
+    echo "Then either add Homebrew openssl to PATH or set OPENSSL_BIN:"
+    echo "  OPENSSL_BIN=\$(brew --prefix openssl)/bin/openssl make setup-codesign"
+    exit 1
+fi
+
+# 3. Generate cert and key with openssl
+# No -extensions v3_req (avoids duplicate keyUsage from v3_req defaults).
+# No keyEncipherment (RSA key transport, not needed for code signing).
+"$OPENSSL" req -x509 -newkey rsa:2048 -keyout /tmp/staplerdev.key -out /tmp/staplerdev.crt \
+    -days 7300 -nodes \
+    -subj "/CN=StaplerSquadDev/O=StaplerSquadDev" \
+    -addext "keyUsage=critical,digitalSignature" \
+    -addext "extendedKeyUsage=codeSigning"
+
+# Include -name so the private key label in keychain matches "StaplerSquadDev"
+# (required for set-key-partition-list -l filter to work correctly)
+"$OPENSSL" pkcs12 -export -out /tmp/StaplerSquadDev.p12 \
+    -inkey /tmp/staplerdev.key -in /tmp/staplerdev.crt \
+    -passout pass:"" -name "StaplerSquadDev"
+
+# 4. Import into login keychain (-T grants codesign access at import time)
+security import /tmp/StaplerSquadDev.p12 \
+    -k ~/Library/Keychains/login.keychain-db \
+    -P "" -T /usr/bin/codesign
+
+# 5. Set trust: user domain only (no -d flag; -d = admin domain, requires sudo)
+# User-domain trust is sufficient for codesign on behalf of the current user.
+security add-trusted-cert -r trustRoot \
+    -k ~/Library/Keychains/login.keychain-db \
+    /tmp/staplerdev.crt
+
+# 6. Set key partition list so codesign never prompts (no -k flag; omitting -k
+# causes security to use the currently-unlocked keychain without a password arg,
+# which is correct for the login keychain on a logged-in developer machine)
+security set-key-partition-list \
+    -S "apple-tool:,apple:,codesign:" \
+    -s -l "StaplerSquadDev" \
+    ~/Library/Keychains/login.keychain-db
+
+# 7. Clean up temp files
+rm -f /tmp/staplerdev.key /tmp/staplerdev.crt /tmp/StaplerSquadDev.p12
+
+echo "StaplerSquadDev certificate created and trusted successfully."
+echo "Run 'make verify-codesign' after 'make install-service' to confirm signing."


### PR DESCRIPTION
## Problem

On macOS, stapler-squad showed two permission dialogs on every restart:
1. **"stapler-squad would like to access data from other apps"** — re-appeared after every approval
2. **Full Disk Access resets** — FDA grant disappeared on every `make install-service` + restart cycle

**Root cause:** `make install-service` rebuilds the binary on every deploy. The binary was unsigned. macOS TCC (Transparency, Consent, and Control) tracks permission grants by code signing identity (Designated Requirement). An unsigned binary uses path + content hash as its pseudo-identity; rebuilding changes the hash, TCC sees a new executable, all prior grants become void.

## Solution

Sign the binary with a persistent self-signed certificate. The DR becomes cert-SHA1-anchored instead of cdhash-anchored — stable across any number of rebuilds using the same cert.

**Why not ad-hoc signing (`codesign -s -`)?** Ad-hoc signing is also cdhash-anchored. Every rebuild still produces a new DR. Grants still reset. Seven alternative approaches were evaluated and eliminated; self-signed cert + embedded Info.plist is the only approach that works without an Apple Developer Program account.

## What changed

### New Makefile targets

```
make setup-codesign   # (one-time per machine) Create StaplerSquadDev signing cert
make verify-codesign  # Diagnostic: DR type, entitlements, embedded plist
make tcc-reset        # Dev tool: scoped tccutil reset for com.stapler-squad
```

`install-service` now signs the binary after build on macOS. Fails with a clear message if cert not found (run `make setup-codesign` first).

### New files

| File | Purpose |
|------|---------|
| `Info.plist` | Embedded in binary: `CFBundleIdentifier=com.stapler-squad`, `NSAppleEventsUsageDescription` |
| `entitlements.plist` | Declares `com.apple.security.automation.apple-events` only |
| `infoplist_darwin.go` | `//go:build darwin` cgo stub to force external linker for `-sectcreate` |
| `scripts/setup-codesign.sh` | One-time cert setup via OpenSSL + `security import`; idempotent |
| `scripts/check-codesign.sh` | Cert existence check used by Makefile guard |
| `.claude/docs/codesigning.md` | Developer guide: setup, cert backup, diagnostics |

### macOS build pipeline (Darwin only)

```
go build (CGO_LDFLAGS=-sectcreate embeds Info.plist) →
otool assertion (fails immediately if plist not embedded) →
codesign --sign StaplerSquadDev --entitlements entitlements.plist
```

Linux build path unchanged.

## First-time setup

```bash
brew install openssl   # if not already installed
make setup-codesign    # one-time cert creation
make install-service   # now signs the binary
make verify-codesign   # confirm DR is cert-anchored
```

After first grant of FDA and Apple Events in System Settings, subsequent `make install-service` rebuilds will not re-prompt.

## Test plan

- [ ] `make setup-codesign` completes, cert visible in Keychain Access as "StaplerSquadDev"
- [ ] `make install-service` completes without error; service starts on :8543
- [ ] `make verify-codesign` shows `Authority=StaplerSquadDev`, `Identifier=com.stapler-squad`, DR contains `anchor H"..."` (not `cdhash`)
- [ ] First launch: FDA and Apple Events prompts appear once each
- [ ] Grant both; run `make install-service` again → **no new permission dialogs**
- [ ] Reboot; confirm FDA still granted in System Settings → Privacy & Security

## Notes

- **No Apple Developer Program account required** — uses a machine-local self-signed cert
- **No hardened runtime** — `--options runtime` kills Go goroutines on Apple Silicon (SIGKILL). Not needed; hardened runtime is only required for notarization.
- **`openssl` must be real OpenSSL, not LibreSSL** — `setup-codesign.sh` detects LibreSSL and prints the `brew install openssl` / `OPENSSL_BIN=` fix
- The "access data from other apps" dialog (Apple Events) is triggered by the `FocusWindow` RPC in `utility_service.go`. After signing is stable, it prompts once per target app, then persists.
