### PR TITLE
fix(detection): detect ✻ asterism prefix as Claude active state

### DIFF
--- a/gen/proto/go/session/v1/backlog.pb.go
+++ b/gen/proto/go/session/v1/backlog.pb.go
@@ -586,6 +586,83 @@ func (x *ItemSession) GetTriageResult() *TriageResult {
 	return nil
 }
 
+// BacklogStatusEvent records a single status transition for a backlog item.
+type BacklogStatusEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	FromStatus    string                 `protobuf:"bytes,2,opt,name=from_status,json=fromStatus,proto3" json:"from_status,omitempty"`
+	ToStatus      string                 `protobuf:"bytes,3,opt,name=to_status,json=toStatus,proto3" json:"to_status,omitempty"`
+	TriggeredBy   string                 `protobuf:"bytes,4,opt,name=triggered_by,json=triggeredBy,proto3" json:"triggered_by,omitempty"` // "user" or "system"
+	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BacklogStatusEvent) Reset() {
+	*x = BacklogStatusEvent{}
+	mi := &file_session_v1_backlog_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BacklogStatusEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BacklogStatusEvent) ProtoMessage() {}
+
+func (x *BacklogStatusEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_session_v1_backlog_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BacklogStatusEvent.ProtoReflect.Descriptor instead.
+func (*BacklogStatusEvent) Descriptor() ([]byte, []int) {
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *BacklogStatusEvent) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *BacklogStatusEvent) GetFromStatus() string {
+	if x != nil {
+		return x.FromStatus
+	}
+	return ""
+}
+
+func (x *BacklogStatusEvent) GetToStatus() string {
+	if x != nil {
+		return x.ToStatus
+	}
+	return ""
+}
+
+func (x *BacklogStatusEvent) GetTriggeredBy() string {
+	if x != nil {
+		return x.TriggeredBy
+	}
+	return ""
+}
+
+func (x *BacklogStatusEvent) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
 // BacklogItem represents a unit of work in the backlog.
 type BacklogItem struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
@@ -608,13 +685,14 @@ type BacklogItem struct {
 	UpdatedAt          *timestamppb.Timestamp `protobuf:"bytes,17,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
 	ItemSessions       []*ItemSession         `protobuf:"bytes,18,rep,name=item_sessions,json=itemSessions,proto3" json:"item_sessions,omitempty"`
 	SourceId           string                 `protobuf:"bytes,19,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	StatusEvents       []*BacklogStatusEvent  `protobuf:"bytes,20,rep,name=status_events,json=statusEvents,proto3" json:"status_events,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
 
 func (x *BacklogItem) Reset() {
 	*x = BacklogItem{}
-	mi := &file_session_v1_backlog_proto_msgTypes[7]
+	mi := &file_session_v1_backlog_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -626,7 +704,7 @@ func (x *BacklogItem) String() string {
 func (*BacklogItem) ProtoMessage() {}
 
 func (x *BacklogItem) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[7]
+	mi := &file_session_v1_backlog_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -639,7 +717,7 @@ func (x *BacklogItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BacklogItem.ProtoReflect.Descriptor instead.
 func (*BacklogItem) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{7}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *BacklogItem) GetId() string {
@@ -775,6 +853,13 @@ func (x *BacklogItem) GetSourceId() string {
 	return ""
 }
 
+func (x *BacklogItem) GetStatusEvents() []*BacklogStatusEvent {
+	if x != nil {
+		return x.StatusEvents
+	}
+	return nil
+}
+
 // ItemSource represents an external plugin source that syncs items into the
 // backlog.
 type ItemSource struct {
@@ -793,7 +878,7 @@ type ItemSource struct {
 
 func (x *ItemSource) Reset() {
 	*x = ItemSource{}
-	mi := &file_session_v1_backlog_proto_msgTypes[8]
+	mi := &file_session_v1_backlog_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -805,7 +890,7 @@ func (x *ItemSource) String() string {
 func (*ItemSource) ProtoMessage() {}
 
 func (x *ItemSource) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[8]
+	mi := &file_session_v1_backlog_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -818,7 +903,7 @@ func (x *ItemSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ItemSource.ProtoReflect.Descriptor instead.
 func (*ItemSource) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{8}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ItemSource) GetId() string {
@@ -894,7 +979,7 @@ type SourceSyncEvent struct {
 
 func (x *SourceSyncEvent) Reset() {
 	*x = SourceSyncEvent{}
-	mi := &file_session_v1_backlog_proto_msgTypes[9]
+	mi := &file_session_v1_backlog_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -906,7 +991,7 @@ func (x *SourceSyncEvent) String() string {
 func (*SourceSyncEvent) ProtoMessage() {}
 
 func (x *SourceSyncEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[9]
+	mi := &file_session_v1_backlog_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -919,7 +1004,7 @@ func (x *SourceSyncEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SourceSyncEvent.ProtoReflect.Descriptor instead.
 func (*SourceSyncEvent) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{9}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SourceSyncEvent) GetId() string {
@@ -995,7 +1080,7 @@ type CreateBacklogItemRequest struct {
 
 func (x *CreateBacklogItemRequest) Reset() {
 	*x = CreateBacklogItemRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[10]
+	mi := &file_session_v1_backlog_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1007,7 +1092,7 @@ func (x *CreateBacklogItemRequest) String() string {
 func (*CreateBacklogItemRequest) ProtoMessage() {}
 
 func (x *CreateBacklogItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[10]
+	mi := &file_session_v1_backlog_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1020,7 +1105,7 @@ func (x *CreateBacklogItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBacklogItemRequest.ProtoReflect.Descriptor instead.
 func (*CreateBacklogItemRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{10}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *CreateBacklogItemRequest) GetTitle() string {
@@ -1096,7 +1181,7 @@ type CreateBacklogItemResponse struct {
 
 func (x *CreateBacklogItemResponse) Reset() {
 	*x = CreateBacklogItemResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[11]
+	mi := &file_session_v1_backlog_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1108,7 +1193,7 @@ func (x *CreateBacklogItemResponse) String() string {
 func (*CreateBacklogItemResponse) ProtoMessage() {}
 
 func (x *CreateBacklogItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[11]
+	mi := &file_session_v1_backlog_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1121,7 +1206,7 @@ func (x *CreateBacklogItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBacklogItemResponse.ProtoReflect.Descriptor instead.
 func (*CreateBacklogItemResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{11}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *CreateBacklogItemResponse) GetItem() *BacklogItem {
@@ -1147,7 +1232,7 @@ type GetBacklogItemRequest struct {
 
 func (x *GetBacklogItemRequest) Reset() {
 	*x = GetBacklogItemRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[12]
+	mi := &file_session_v1_backlog_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1159,7 +1244,7 @@ func (x *GetBacklogItemRequest) String() string {
 func (*GetBacklogItemRequest) ProtoMessage() {}
 
 func (x *GetBacklogItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[12]
+	mi := &file_session_v1_backlog_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1172,7 +1257,7 @@ func (x *GetBacklogItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBacklogItemRequest.ProtoReflect.Descriptor instead.
 func (*GetBacklogItemRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{12}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GetBacklogItemRequest) GetItemId() string {
@@ -1191,7 +1276,7 @@ type GetBacklogItemResponse struct {
 
 func (x *GetBacklogItemResponse) Reset() {
 	*x = GetBacklogItemResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[13]
+	mi := &file_session_v1_backlog_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1203,7 +1288,7 @@ func (x *GetBacklogItemResponse) String() string {
 func (*GetBacklogItemResponse) ProtoMessage() {}
 
 func (x *GetBacklogItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[13]
+	mi := &file_session_v1_backlog_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1216,7 +1301,7 @@ func (x *GetBacklogItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBacklogItemResponse.ProtoReflect.Descriptor instead.
 func (*GetBacklogItemResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{13}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GetBacklogItemResponse) GetItem() *BacklogItem {
@@ -1238,7 +1323,7 @@ type ListBacklogItemsRequest struct {
 
 func (x *ListBacklogItemsRequest) Reset() {
 	*x = ListBacklogItemsRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[14]
+	mi := &file_session_v1_backlog_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1250,7 +1335,7 @@ func (x *ListBacklogItemsRequest) String() string {
 func (*ListBacklogItemsRequest) ProtoMessage() {}
 
 func (x *ListBacklogItemsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[14]
+	mi := &file_session_v1_backlog_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1263,7 +1348,7 @@ func (x *ListBacklogItemsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBacklogItemsRequest.ProtoReflect.Descriptor instead.
 func (*ListBacklogItemsRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{14}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ListBacklogItemsRequest) GetStatus() []string {
@@ -1303,7 +1388,7 @@ type ListBacklogItemsResponse struct {
 
 func (x *ListBacklogItemsResponse) Reset() {
 	*x = ListBacklogItemsResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[15]
+	mi := &file_session_v1_backlog_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1315,7 +1400,7 @@ func (x *ListBacklogItemsResponse) String() string {
 func (*ListBacklogItemsResponse) ProtoMessage() {}
 
 func (x *ListBacklogItemsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[15]
+	mi := &file_session_v1_backlog_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1328,7 +1413,7 @@ func (x *ListBacklogItemsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBacklogItemsResponse.ProtoReflect.Descriptor instead.
 func (*ListBacklogItemsResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{15}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ListBacklogItemsResponse) GetItems() []*BacklogItem {
@@ -1357,7 +1442,7 @@ type UpdateBacklogItemRequest struct {
 
 func (x *UpdateBacklogItemRequest) Reset() {
 	*x = UpdateBacklogItemRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[16]
+	mi := &file_session_v1_backlog_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1369,7 +1454,7 @@ func (x *UpdateBacklogItemRequest) String() string {
 func (*UpdateBacklogItemRequest) ProtoMessage() {}
 
 func (x *UpdateBacklogItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[16]
+	mi := &file_session_v1_backlog_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1382,7 +1467,7 @@ func (x *UpdateBacklogItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateBacklogItemRequest.ProtoReflect.Descriptor instead.
 func (*UpdateBacklogItemRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{16}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *UpdateBacklogItemRequest) GetItemId() string {
@@ -1471,7 +1556,7 @@ type UpdateBacklogItemResponse struct {
 
 func (x *UpdateBacklogItemResponse) Reset() {
 	*x = UpdateBacklogItemResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[17]
+	mi := &file_session_v1_backlog_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1483,7 +1568,7 @@ func (x *UpdateBacklogItemResponse) String() string {
 func (*UpdateBacklogItemResponse) ProtoMessage() {}
 
 func (x *UpdateBacklogItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[17]
+	mi := &file_session_v1_backlog_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1496,7 +1581,7 @@ func (x *UpdateBacklogItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateBacklogItemResponse.ProtoReflect.Descriptor instead.
 func (*UpdateBacklogItemResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{17}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UpdateBacklogItemResponse) GetItem() *BacklogItem {
@@ -1515,7 +1600,7 @@ type ArchiveBacklogItemRequest struct {
 
 func (x *ArchiveBacklogItemRequest) Reset() {
 	*x = ArchiveBacklogItemRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[18]
+	mi := &file_session_v1_backlog_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1527,7 +1612,7 @@ func (x *ArchiveBacklogItemRequest) String() string {
 func (*ArchiveBacklogItemRequest) ProtoMessage() {}
 
 func (x *ArchiveBacklogItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[18]
+	mi := &file_session_v1_backlog_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1540,7 +1625,7 @@ func (x *ArchiveBacklogItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveBacklogItemRequest.ProtoReflect.Descriptor instead.
 func (*ArchiveBacklogItemRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{18}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ArchiveBacklogItemRequest) GetItemId() string {
@@ -1559,7 +1644,7 @@ type ArchiveBacklogItemResponse struct {
 
 func (x *ArchiveBacklogItemResponse) Reset() {
 	*x = ArchiveBacklogItemResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[19]
+	mi := &file_session_v1_backlog_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1571,7 +1656,7 @@ func (x *ArchiveBacklogItemResponse) String() string {
 func (*ArchiveBacklogItemResponse) ProtoMessage() {}
 
 func (x *ArchiveBacklogItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[19]
+	mi := &file_session_v1_backlog_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1584,7 +1669,7 @@ func (x *ArchiveBacklogItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveBacklogItemResponse.ProtoReflect.Descriptor instead.
 func (*ArchiveBacklogItemResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{19}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ArchiveBacklogItemResponse) GetItem() *BacklogItem {
@@ -1607,7 +1692,7 @@ type TransitionBacklogItemStatusRequest struct {
 
 func (x *TransitionBacklogItemStatusRequest) Reset() {
 	*x = TransitionBacklogItemStatusRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[20]
+	mi := &file_session_v1_backlog_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1619,7 +1704,7 @@ func (x *TransitionBacklogItemStatusRequest) String() string {
 func (*TransitionBacklogItemStatusRequest) ProtoMessage() {}
 
 func (x *TransitionBacklogItemStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[20]
+	mi := &file_session_v1_backlog_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1632,7 +1717,7 @@ func (x *TransitionBacklogItemStatusRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use TransitionBacklogItemStatusRequest.ProtoReflect.Descriptor instead.
 func (*TransitionBacklogItemStatusRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{20}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TransitionBacklogItemStatusRequest) GetItemId() string {
@@ -1679,7 +1764,7 @@ type TransitionBacklogItemStatusResponse struct {
 
 func (x *TransitionBacklogItemStatusResponse) Reset() {
 	*x = TransitionBacklogItemStatusResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[21]
+	mi := &file_session_v1_backlog_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1691,7 +1776,7 @@ func (x *TransitionBacklogItemStatusResponse) String() string {
 func (*TransitionBacklogItemStatusResponse) ProtoMessage() {}
 
 func (x *TransitionBacklogItemStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[21]
+	mi := &file_session_v1_backlog_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1704,7 +1789,7 @@ func (x *TransitionBacklogItemStatusResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use TransitionBacklogItemStatusResponse.ProtoReflect.Descriptor instead.
 func (*TransitionBacklogItemStatusResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{21}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *TransitionBacklogItemStatusResponse) GetItem() *BacklogItem {
@@ -1723,7 +1808,7 @@ type SpawnSessionFromItemRequest struct {
 
 func (x *SpawnSessionFromItemRequest) Reset() {
 	*x = SpawnSessionFromItemRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[22]
+	mi := &file_session_v1_backlog_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1735,7 +1820,7 @@ func (x *SpawnSessionFromItemRequest) String() string {
 func (*SpawnSessionFromItemRequest) ProtoMessage() {}
 
 func (x *SpawnSessionFromItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[22]
+	mi := &file_session_v1_backlog_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1748,7 +1833,7 @@ func (x *SpawnSessionFromItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpawnSessionFromItemRequest.ProtoReflect.Descriptor instead.
 func (*SpawnSessionFromItemRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{22}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *SpawnSessionFromItemRequest) GetItemId() string {
@@ -1768,7 +1853,7 @@ type SpawnSessionFromItemResponse struct {
 
 func (x *SpawnSessionFromItemResponse) Reset() {
 	*x = SpawnSessionFromItemResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[23]
+	mi := &file_session_v1_backlog_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1780,7 +1865,7 @@ func (x *SpawnSessionFromItemResponse) String() string {
 func (*SpawnSessionFromItemResponse) ProtoMessage() {}
 
 func (x *SpawnSessionFromItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[23]
+	mi := &file_session_v1_backlog_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1793,7 +1878,7 @@ func (x *SpawnSessionFromItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SpawnSessionFromItemResponse.ProtoReflect.Descriptor instead.
 func (*SpawnSessionFromItemResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{23}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SpawnSessionFromItemResponse) GetSessionUuid() string {
@@ -1820,7 +1905,7 @@ type AttachSessionToItemRequest struct {
 
 func (x *AttachSessionToItemRequest) Reset() {
 	*x = AttachSessionToItemRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[24]
+	mi := &file_session_v1_backlog_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1832,7 +1917,7 @@ func (x *AttachSessionToItemRequest) String() string {
 func (*AttachSessionToItemRequest) ProtoMessage() {}
 
 func (x *AttachSessionToItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[24]
+	mi := &file_session_v1_backlog_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1845,7 +1930,7 @@ func (x *AttachSessionToItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachSessionToItemRequest.ProtoReflect.Descriptor instead.
 func (*AttachSessionToItemRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{24}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *AttachSessionToItemRequest) GetItemId() string {
@@ -1871,7 +1956,7 @@ type AttachSessionToItemResponse struct {
 
 func (x *AttachSessionToItemResponse) Reset() {
 	*x = AttachSessionToItemResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[25]
+	mi := &file_session_v1_backlog_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1883,7 +1968,7 @@ func (x *AttachSessionToItemResponse) String() string {
 func (*AttachSessionToItemResponse) ProtoMessage() {}
 
 func (x *AttachSessionToItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[25]
+	mi := &file_session_v1_backlog_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1896,7 +1981,7 @@ func (x *AttachSessionToItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttachSessionToItemResponse.ProtoReflect.Descriptor instead.
 func (*AttachSessionToItemResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{25}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *AttachSessionToItemResponse) GetItemSession() *ItemSession {
@@ -1915,7 +2000,7 @@ type TriggerTriageRequest struct {
 
 func (x *TriggerTriageRequest) Reset() {
 	*x = TriggerTriageRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[26]
+	mi := &file_session_v1_backlog_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1927,7 +2012,7 @@ func (x *TriggerTriageRequest) String() string {
 func (*TriggerTriageRequest) ProtoMessage() {}
 
 func (x *TriggerTriageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[26]
+	mi := &file_session_v1_backlog_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1940,7 +2025,7 @@ func (x *TriggerTriageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerTriageRequest.ProtoReflect.Descriptor instead.
 func (*TriggerTriageRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{26}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *TriggerTriageRequest) GetItemId() string {
@@ -1959,7 +2044,7 @@ type TriggerTriageResponse struct {
 
 func (x *TriggerTriageResponse) Reset() {
 	*x = TriggerTriageResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[27]
+	mi := &file_session_v1_backlog_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1971,7 +2056,7 @@ func (x *TriggerTriageResponse) String() string {
 func (*TriggerTriageResponse) ProtoMessage() {}
 
 func (x *TriggerTriageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[27]
+	mi := &file_session_v1_backlog_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1984,7 +2069,7 @@ func (x *TriggerTriageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerTriageResponse.ProtoReflect.Descriptor instead.
 func (*TriggerTriageResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{27}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *TriggerTriageResponse) GetItemSession() *ItemSession {
@@ -2003,7 +2088,7 @@ type ApprovePlanRequest struct {
 
 func (x *ApprovePlanRequest) Reset() {
 	*x = ApprovePlanRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[28]
+	mi := &file_session_v1_backlog_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2015,7 +2100,7 @@ func (x *ApprovePlanRequest) String() string {
 func (*ApprovePlanRequest) ProtoMessage() {}
 
 func (x *ApprovePlanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[28]
+	mi := &file_session_v1_backlog_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2028,7 +2113,7 @@ func (x *ApprovePlanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApprovePlanRequest.ProtoReflect.Descriptor instead.
 func (*ApprovePlanRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{28}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ApprovePlanRequest) GetItemId() string {
@@ -2047,7 +2132,7 @@ type ApprovePlanResponse struct {
 
 func (x *ApprovePlanResponse) Reset() {
 	*x = ApprovePlanResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[29]
+	mi := &file_session_v1_backlog_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2059,7 +2144,7 @@ func (x *ApprovePlanResponse) String() string {
 func (*ApprovePlanResponse) ProtoMessage() {}
 
 func (x *ApprovePlanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[29]
+	mi := &file_session_v1_backlog_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2072,7 +2157,7 @@ func (x *ApprovePlanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApprovePlanResponse.ProtoReflect.Descriptor instead.
 func (*ApprovePlanResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{29}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ApprovePlanResponse) GetItem() *BacklogItem {
@@ -2090,7 +2175,7 @@ type SuggestNextItemRequest struct {
 
 func (x *SuggestNextItemRequest) Reset() {
 	*x = SuggestNextItemRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[30]
+	mi := &file_session_v1_backlog_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2102,7 +2187,7 @@ func (x *SuggestNextItemRequest) String() string {
 func (*SuggestNextItemRequest) ProtoMessage() {}
 
 func (x *SuggestNextItemRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[30]
+	mi := &file_session_v1_backlog_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2115,7 +2200,7 @@ func (x *SuggestNextItemRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuggestNextItemRequest.ProtoReflect.Descriptor instead.
 func (*SuggestNextItemRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{30}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{31}
 }
 
 type SuggestNextItemResponse struct {
@@ -2129,7 +2214,7 @@ type SuggestNextItemResponse struct {
 
 func (x *SuggestNextItemResponse) Reset() {
 	*x = SuggestNextItemResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[31]
+	mi := &file_session_v1_backlog_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2141,7 +2226,7 @@ func (x *SuggestNextItemResponse) String() string {
 func (*SuggestNextItemResponse) ProtoMessage() {}
 
 func (x *SuggestNextItemResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[31]
+	mi := &file_session_v1_backlog_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2154,7 +2239,7 @@ func (x *SuggestNextItemResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuggestNextItemResponse.ProtoReflect.Descriptor instead.
 func (*SuggestNextItemResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{31}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SuggestNextItemResponse) GetItemSession() *ItemSession {
@@ -2182,7 +2267,7 @@ type OverrideVerdictRequest struct {
 
 func (x *OverrideVerdictRequest) Reset() {
 	*x = OverrideVerdictRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[32]
+	mi := &file_session_v1_backlog_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2194,7 +2279,7 @@ func (x *OverrideVerdictRequest) String() string {
 func (*OverrideVerdictRequest) ProtoMessage() {}
 
 func (x *OverrideVerdictRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[32]
+	mi := &file_session_v1_backlog_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2207,7 +2292,7 @@ func (x *OverrideVerdictRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OverrideVerdictRequest.ProtoReflect.Descriptor instead.
 func (*OverrideVerdictRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{32}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *OverrideVerdictRequest) GetItemSessionId() string {
@@ -2240,7 +2325,7 @@ type OverrideVerdictResponse struct {
 
 func (x *OverrideVerdictResponse) Reset() {
 	*x = OverrideVerdictResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[33]
+	mi := &file_session_v1_backlog_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2252,7 +2337,7 @@ func (x *OverrideVerdictResponse) String() string {
 func (*OverrideVerdictResponse) ProtoMessage() {}
 
 func (x *OverrideVerdictResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[33]
+	mi := &file_session_v1_backlog_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2265,7 +2350,7 @@ func (x *OverrideVerdictResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OverrideVerdictResponse.ProtoReflect.Descriptor instead.
 func (*OverrideVerdictResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{33}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *OverrideVerdictResponse) GetItem() *BacklogItem {
@@ -2284,7 +2369,7 @@ type TriggerReReviewRequest struct {
 
 func (x *TriggerReReviewRequest) Reset() {
 	*x = TriggerReReviewRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[34]
+	mi := &file_session_v1_backlog_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2296,7 +2381,7 @@ func (x *TriggerReReviewRequest) String() string {
 func (*TriggerReReviewRequest) ProtoMessage() {}
 
 func (x *TriggerReReviewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[34]
+	mi := &file_session_v1_backlog_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2309,7 +2394,7 @@ func (x *TriggerReReviewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerReReviewRequest.ProtoReflect.Descriptor instead.
 func (*TriggerReReviewRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{34}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *TriggerReReviewRequest) GetItemId() string {
@@ -2328,7 +2413,7 @@ type TriggerReReviewResponse struct {
 
 func (x *TriggerReReviewResponse) Reset() {
 	*x = TriggerReReviewResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[35]
+	mi := &file_session_v1_backlog_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2340,7 +2425,7 @@ func (x *TriggerReReviewResponse) String() string {
 func (*TriggerReReviewResponse) ProtoMessage() {}
 
 func (x *TriggerReReviewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[35]
+	mi := &file_session_v1_backlog_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2353,7 +2438,7 @@ func (x *TriggerReReviewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerReReviewResponse.ProtoReflect.Descriptor instead.
 func (*TriggerReReviewResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{35}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *TriggerReReviewResponse) GetItemSession() *ItemSession {
@@ -2372,7 +2457,7 @@ type TriggerSyncRequest struct {
 
 func (x *TriggerSyncRequest) Reset() {
 	*x = TriggerSyncRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[36]
+	mi := &file_session_v1_backlog_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2384,7 +2469,7 @@ func (x *TriggerSyncRequest) String() string {
 func (*TriggerSyncRequest) ProtoMessage() {}
 
 func (x *TriggerSyncRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[36]
+	mi := &file_session_v1_backlog_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2397,7 +2482,7 @@ func (x *TriggerSyncRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerSyncRequest.ProtoReflect.Descriptor instead.
 func (*TriggerSyncRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{36}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *TriggerSyncRequest) GetSourceId() string {
@@ -2415,7 +2500,7 @@ type TriggerSyncResponse struct {
 
 func (x *TriggerSyncResponse) Reset() {
 	*x = TriggerSyncResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[37]
+	mi := &file_session_v1_backlog_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2427,7 +2512,7 @@ func (x *TriggerSyncResponse) String() string {
 func (*TriggerSyncResponse) ProtoMessage() {}
 
 func (x *TriggerSyncResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[37]
+	mi := &file_session_v1_backlog_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2440,7 +2525,7 @@ func (x *TriggerSyncResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TriggerSyncResponse.ProtoReflect.Descriptor instead.
 func (*TriggerSyncResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{37}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{38}
 }
 
 type CreateItemSourceRequest struct {
@@ -2455,7 +2540,7 @@ type CreateItemSourceRequest struct {
 
 func (x *CreateItemSourceRequest) Reset() {
 	*x = CreateItemSourceRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[38]
+	mi := &file_session_v1_backlog_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2467,7 +2552,7 @@ func (x *CreateItemSourceRequest) String() string {
 func (*CreateItemSourceRequest) ProtoMessage() {}
 
 func (x *CreateItemSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[38]
+	mi := &file_session_v1_backlog_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2480,7 +2565,7 @@ func (x *CreateItemSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateItemSourceRequest.ProtoReflect.Descriptor instead.
 func (*CreateItemSourceRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{38}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *CreateItemSourceRequest) GetPluginId() string {
@@ -2520,7 +2605,7 @@ type CreateItemSourceResponse struct {
 
 func (x *CreateItemSourceResponse) Reset() {
 	*x = CreateItemSourceResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[39]
+	mi := &file_session_v1_backlog_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2532,7 +2617,7 @@ func (x *CreateItemSourceResponse) String() string {
 func (*CreateItemSourceResponse) ProtoMessage() {}
 
 func (x *CreateItemSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[39]
+	mi := &file_session_v1_backlog_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2545,7 +2630,7 @@ func (x *CreateItemSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateItemSourceResponse.ProtoReflect.Descriptor instead.
 func (*CreateItemSourceResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{39}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *CreateItemSourceResponse) GetSource() *ItemSource {
@@ -2563,7 +2648,7 @@ type ListItemSourcesRequest struct {
 
 func (x *ListItemSourcesRequest) Reset() {
 	*x = ListItemSourcesRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[40]
+	mi := &file_session_v1_backlog_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2575,7 +2660,7 @@ func (x *ListItemSourcesRequest) String() string {
 func (*ListItemSourcesRequest) ProtoMessage() {}
 
 func (x *ListItemSourcesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[40]
+	mi := &file_session_v1_backlog_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2588,7 +2673,7 @@ func (x *ListItemSourcesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemSourcesRequest.ProtoReflect.Descriptor instead.
 func (*ListItemSourcesRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{40}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{41}
 }
 
 type ListItemSourcesResponse struct {
@@ -2600,7 +2685,7 @@ type ListItemSourcesResponse struct {
 
 func (x *ListItemSourcesResponse) Reset() {
 	*x = ListItemSourcesResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[41]
+	mi := &file_session_v1_backlog_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2612,7 +2697,7 @@ func (x *ListItemSourcesResponse) String() string {
 func (*ListItemSourcesResponse) ProtoMessage() {}
 
 func (x *ListItemSourcesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[41]
+	mi := &file_session_v1_backlog_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2625,7 +2710,7 @@ func (x *ListItemSourcesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemSourcesResponse.ProtoReflect.Descriptor instead.
 func (*ListItemSourcesResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{41}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ListItemSourcesResponse) GetSources() []*ItemSource {
@@ -2647,7 +2732,7 @@ type UpdateItemSourceRequest struct {
 
 func (x *UpdateItemSourceRequest) Reset() {
 	*x = UpdateItemSourceRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[42]
+	mi := &file_session_v1_backlog_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2659,7 +2744,7 @@ func (x *UpdateItemSourceRequest) String() string {
 func (*UpdateItemSourceRequest) ProtoMessage() {}
 
 func (x *UpdateItemSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[42]
+	mi := &file_session_v1_backlog_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2672,7 +2757,7 @@ func (x *UpdateItemSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateItemSourceRequest.ProtoReflect.Descriptor instead.
 func (*UpdateItemSourceRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{42}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *UpdateItemSourceRequest) GetSourceId() string {
@@ -2712,7 +2797,7 @@ type UpdateItemSourceResponse struct {
 
 func (x *UpdateItemSourceResponse) Reset() {
 	*x = UpdateItemSourceResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[43]
+	mi := &file_session_v1_backlog_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2724,7 +2809,7 @@ func (x *UpdateItemSourceResponse) String() string {
 func (*UpdateItemSourceResponse) ProtoMessage() {}
 
 func (x *UpdateItemSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[43]
+	mi := &file_session_v1_backlog_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2737,7 +2822,7 @@ func (x *UpdateItemSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateItemSourceResponse.ProtoReflect.Descriptor instead.
 func (*UpdateItemSourceResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{43}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *UpdateItemSourceResponse) GetSource() *ItemSource {
@@ -2756,7 +2841,7 @@ type DeleteItemSourceRequest struct {
 
 func (x *DeleteItemSourceRequest) Reset() {
 	*x = DeleteItemSourceRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[44]
+	mi := &file_session_v1_backlog_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2768,7 +2853,7 @@ func (x *DeleteItemSourceRequest) String() string {
 func (*DeleteItemSourceRequest) ProtoMessage() {}
 
 func (x *DeleteItemSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[44]
+	mi := &file_session_v1_backlog_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2781,7 +2866,7 @@ func (x *DeleteItemSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteItemSourceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteItemSourceRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{44}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *DeleteItemSourceRequest) GetSourceId() string {
@@ -2799,7 +2884,7 @@ type DeleteItemSourceResponse struct {
 
 func (x *DeleteItemSourceResponse) Reset() {
 	*x = DeleteItemSourceResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[45]
+	mi := &file_session_v1_backlog_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2811,7 +2896,7 @@ func (x *DeleteItemSourceResponse) String() string {
 func (*DeleteItemSourceResponse) ProtoMessage() {}
 
 func (x *DeleteItemSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[45]
+	mi := &file_session_v1_backlog_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2824,7 +2909,7 @@ func (x *DeleteItemSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteItemSourceResponse.ProtoReflect.Descriptor instead.
 func (*DeleteItemSourceResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{45}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{46}
 }
 
 type GetSyncHistoryRequest struct {
@@ -2836,7 +2921,7 @@ type GetSyncHistoryRequest struct {
 
 func (x *GetSyncHistoryRequest) Reset() {
 	*x = GetSyncHistoryRequest{}
-	mi := &file_session_v1_backlog_proto_msgTypes[46]
+	mi := &file_session_v1_backlog_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2848,7 +2933,7 @@ func (x *GetSyncHistoryRequest) String() string {
 func (*GetSyncHistoryRequest) ProtoMessage() {}
 
 func (x *GetSyncHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[46]
+	mi := &file_session_v1_backlog_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2861,7 +2946,7 @@ func (x *GetSyncHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSyncHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetSyncHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{46}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetSyncHistoryRequest) GetSourceId() string {
@@ -2880,7 +2965,7 @@ type GetSyncHistoryResponse struct {
 
 func (x *GetSyncHistoryResponse) Reset() {
 	*x = GetSyncHistoryResponse{}
-	mi := &file_session_v1_backlog_proto_msgTypes[47]
+	mi := &file_session_v1_backlog_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2892,7 +2977,7 @@ func (x *GetSyncHistoryResponse) String() string {
 func (*GetSyncHistoryResponse) ProtoMessage() {}
 
 func (x *GetSyncHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_session_v1_backlog_proto_msgTypes[47]
+	mi := &file_session_v1_backlog_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2905,7 +2990,7 @@ func (x *GetSyncHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSyncHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetSyncHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_session_v1_backlog_proto_rawDescGZIP(), []int{47}
+	return file_session_v1_backlog_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetSyncHistoryResponse) GetEvents() []*SourceSyncEvent {
@@ -2973,7 +3058,15 @@ const file_session_v1_backlog_proto_rawDesc = "" +
 	"created_at\x18\n" +
 	" \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12@\n" +
 	"\x0ereview_verdict\x18\v \x01(\v2\x19.session.v1.ReviewVerdictR\rreviewVerdict\x12=\n" +
-	"\rtriage_result\x18\f \x01(\v2\x18.session.v1.TriageResultR\ftriageResult\"\x9f\x06\n" +
+	"\rtriage_result\x18\f \x01(\v2\x18.session.v1.TriageResultR\ftriageResult\"\xc0\x01\n" +
+	"\x12BacklogStatusEvent\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
+	"\vfrom_status\x18\x02 \x01(\tR\n" +
+	"fromStatus\x12\x1b\n" +
+	"\tto_status\x18\x03 \x01(\tR\btoStatus\x12!\n" +
+	"\ftriggered_by\x18\x04 \x01(\tR\vtriggeredBy\x129\n" +
+	"\n" +
+	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\xe4\x06\n" +
 	"\vBacklogItem\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12 \n" +
@@ -2998,7 +3091,8 @@ const file_session_v1_backlog_proto_rawDesc = "" +
 	"\n" +
 	"updated_at\x18\x11 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12<\n" +
 	"\ritem_sessions\x18\x12 \x03(\v2\x17.session.v1.ItemSessionR\fitemSessions\x12\x1b\n" +
-	"\tsource_id\x18\x13 \x01(\tR\bsourceId\"\xd9\x02\n" +
+	"\tsource_id\x18\x13 \x01(\tR\bsourceId\x12C\n" +
+	"\rstatus_events\x18\x14 \x03(\v2\x1e.session.v1.BacklogStatusEventR\fstatusEvents\"\xd9\x02\n" +
 	"\n" +
 	"ItemSource\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
@@ -3170,7 +3264,7 @@ func file_session_v1_backlog_proto_rawDescGZIP() []byte {
 	return file_session_v1_backlog_proto_rawDescData
 }
 
-var file_session_v1_backlog_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_session_v1_backlog_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
 var file_session_v1_backlog_proto_goTypes = []any{
 	(*AcCriterion)(nil),                         // 0: session.v1.AcCriterion
 	(*CriterionVerdict)(nil),                    // 1: session.v1.CriterionVerdict
@@ -3179,138 +3273,141 @@ var file_session_v1_backlog_proto_goTypes = []any{
 	(*TriageTask)(nil),                          // 4: session.v1.TriageTask
 	(*TriageResult)(nil),                        // 5: session.v1.TriageResult
 	(*ItemSession)(nil),                         // 6: session.v1.ItemSession
-	(*BacklogItem)(nil),                         // 7: session.v1.BacklogItem
-	(*ItemSource)(nil),                          // 8: session.v1.ItemSource
-	(*SourceSyncEvent)(nil),                     // 9: session.v1.SourceSyncEvent
-	(*CreateBacklogItemRequest)(nil),            // 10: session.v1.CreateBacklogItemRequest
-	(*CreateBacklogItemResponse)(nil),           // 11: session.v1.CreateBacklogItemResponse
-	(*GetBacklogItemRequest)(nil),               // 12: session.v1.GetBacklogItemRequest
-	(*GetBacklogItemResponse)(nil),              // 13: session.v1.GetBacklogItemResponse
-	(*ListBacklogItemsRequest)(nil),             // 14: session.v1.ListBacklogItemsRequest
-	(*ListBacklogItemsResponse)(nil),            // 15: session.v1.ListBacklogItemsResponse
-	(*UpdateBacklogItemRequest)(nil),            // 16: session.v1.UpdateBacklogItemRequest
-	(*UpdateBacklogItemResponse)(nil),           // 17: session.v1.UpdateBacklogItemResponse
-	(*ArchiveBacklogItemRequest)(nil),           // 18: session.v1.ArchiveBacklogItemRequest
-	(*ArchiveBacklogItemResponse)(nil),          // 19: session.v1.ArchiveBacklogItemResponse
-	(*TransitionBacklogItemStatusRequest)(nil),  // 20: session.v1.TransitionBacklogItemStatusRequest
-	(*TransitionBacklogItemStatusResponse)(nil), // 21: session.v1.TransitionBacklogItemStatusResponse
-	(*SpawnSessionFromItemRequest)(nil),         // 22: session.v1.SpawnSessionFromItemRequest
-	(*SpawnSessionFromItemResponse)(nil),        // 23: session.v1.SpawnSessionFromItemResponse
-	(*AttachSessionToItemRequest)(nil),          // 24: session.v1.AttachSessionToItemRequest
-	(*AttachSessionToItemResponse)(nil),         // 25: session.v1.AttachSessionToItemResponse
-	(*TriggerTriageRequest)(nil),                // 26: session.v1.TriggerTriageRequest
-	(*TriggerTriageResponse)(nil),               // 27: session.v1.TriggerTriageResponse
-	(*ApprovePlanRequest)(nil),                  // 28: session.v1.ApprovePlanRequest
-	(*ApprovePlanResponse)(nil),                 // 29: session.v1.ApprovePlanResponse
-	(*SuggestNextItemRequest)(nil),              // 30: session.v1.SuggestNextItemRequest
-	(*SuggestNextItemResponse)(nil),             // 31: session.v1.SuggestNextItemResponse
-	(*OverrideVerdictRequest)(nil),              // 32: session.v1.OverrideVerdictRequest
-	(*OverrideVerdictResponse)(nil),             // 33: session.v1.OverrideVerdictResponse
-	(*TriggerReReviewRequest)(nil),              // 34: session.v1.TriggerReReviewRequest
-	(*TriggerReReviewResponse)(nil),             // 35: session.v1.TriggerReReviewResponse
-	(*TriggerSyncRequest)(nil),                  // 36: session.v1.TriggerSyncRequest
-	(*TriggerSyncResponse)(nil),                 // 37: session.v1.TriggerSyncResponse
-	(*CreateItemSourceRequest)(nil),             // 38: session.v1.CreateItemSourceRequest
-	(*CreateItemSourceResponse)(nil),            // 39: session.v1.CreateItemSourceResponse
-	(*ListItemSourcesRequest)(nil),              // 40: session.v1.ListItemSourcesRequest
-	(*ListItemSourcesResponse)(nil),             // 41: session.v1.ListItemSourcesResponse
-	(*UpdateItemSourceRequest)(nil),             // 42: session.v1.UpdateItemSourceRequest
-	(*UpdateItemSourceResponse)(nil),            // 43: session.v1.UpdateItemSourceResponse
-	(*DeleteItemSourceRequest)(nil),             // 44: session.v1.DeleteItemSourceRequest
-	(*DeleteItemSourceResponse)(nil),            // 45: session.v1.DeleteItemSourceResponse
-	(*GetSyncHistoryRequest)(nil),               // 46: session.v1.GetSyncHistoryRequest
-	(*GetSyncHistoryResponse)(nil),              // 47: session.v1.GetSyncHistoryResponse
-	(*timestamppb.Timestamp)(nil),               // 48: google.protobuf.Timestamp
+	(*BacklogStatusEvent)(nil),                  // 7: session.v1.BacklogStatusEvent
+	(*BacklogItem)(nil),                         // 8: session.v1.BacklogItem
+	(*ItemSource)(nil),                          // 9: session.v1.ItemSource
+	(*SourceSyncEvent)(nil),                     // 10: session.v1.SourceSyncEvent
+	(*CreateBacklogItemRequest)(nil),            // 11: session.v1.CreateBacklogItemRequest
+	(*CreateBacklogItemResponse)(nil),           // 12: session.v1.CreateBacklogItemResponse
+	(*GetBacklogItemRequest)(nil),               // 13: session.v1.GetBacklogItemRequest
+	(*GetBacklogItemResponse)(nil),              // 14: session.v1.GetBacklogItemResponse
+	(*ListBacklogItemsRequest)(nil),             // 15: session.v1.ListBacklogItemsRequest
+	(*ListBacklogItemsResponse)(nil),            // 16: session.v1.ListBacklogItemsResponse
+	(*UpdateBacklogItemRequest)(nil),            // 17: session.v1.UpdateBacklogItemRequest
+	(*UpdateBacklogItemResponse)(nil),           // 18: session.v1.UpdateBacklogItemResponse
+	(*ArchiveBacklogItemRequest)(nil),           // 19: session.v1.ArchiveBacklogItemRequest
+	(*ArchiveBacklogItemResponse)(nil),          // 20: session.v1.ArchiveBacklogItemResponse
+	(*TransitionBacklogItemStatusRequest)(nil),  // 21: session.v1.TransitionBacklogItemStatusRequest
+	(*TransitionBacklogItemStatusResponse)(nil), // 22: session.v1.TransitionBacklogItemStatusResponse
+	(*SpawnSessionFromItemRequest)(nil),         // 23: session.v1.SpawnSessionFromItemRequest
+	(*SpawnSessionFromItemResponse)(nil),        // 24: session.v1.SpawnSessionFromItemResponse
+	(*AttachSessionToItemRequest)(nil),          // 25: session.v1.AttachSessionToItemRequest
+	(*AttachSessionToItemResponse)(nil),         // 26: session.v1.AttachSessionToItemResponse
+	(*TriggerTriageRequest)(nil),                // 27: session.v1.TriggerTriageRequest
+	(*TriggerTriageResponse)(nil),               // 28: session.v1.TriggerTriageResponse
+	(*ApprovePlanRequest)(nil),                  // 29: session.v1.ApprovePlanRequest
+	(*ApprovePlanResponse)(nil),                 // 30: session.v1.ApprovePlanResponse
+	(*SuggestNextItemRequest)(nil),              // 31: session.v1.SuggestNextItemRequest
+	(*SuggestNextItemResponse)(nil),             // 32: session.v1.SuggestNextItemResponse
+	(*OverrideVerdictRequest)(nil),              // 33: session.v1.OverrideVerdictRequest
+	(*OverrideVerdictResponse)(nil),             // 34: session.v1.OverrideVerdictResponse
+	(*TriggerReReviewRequest)(nil),              // 35: session.v1.TriggerReReviewRequest
+	(*TriggerReReviewResponse)(nil),             // 36: session.v1.TriggerReReviewResponse
+	(*TriggerSyncRequest)(nil),                  // 37: session.v1.TriggerSyncRequest
+	(*TriggerSyncResponse)(nil),                 // 38: session.v1.TriggerSyncResponse
+	(*CreateItemSourceRequest)(nil),             // 39: session.v1.CreateItemSourceRequest
+	(*CreateItemSourceResponse)(nil),            // 40: session.v1.CreateItemSourceResponse
+	(*ListItemSourcesRequest)(nil),              // 41: session.v1.ListItemSourcesRequest
+	(*ListItemSourcesResponse)(nil),             // 42: session.v1.ListItemSourcesResponse
+	(*UpdateItemSourceRequest)(nil),             // 43: session.v1.UpdateItemSourceRequest
+	(*UpdateItemSourceResponse)(nil),            // 44: session.v1.UpdateItemSourceResponse
+	(*DeleteItemSourceRequest)(nil),             // 45: session.v1.DeleteItemSourceRequest
+	(*DeleteItemSourceResponse)(nil),            // 46: session.v1.DeleteItemSourceResponse
+	(*GetSyncHistoryRequest)(nil),               // 47: session.v1.GetSyncHistoryRequest
+	(*GetSyncHistoryResponse)(nil),              // 48: session.v1.GetSyncHistoryResponse
+	(*timestamppb.Timestamp)(nil),               // 49: google.protobuf.Timestamp
 }
 var file_session_v1_backlog_proto_depIdxs = []int32{
 	1,  // 0: session.v1.ReviewVerdict.per_criterion:type_name -> session.v1.CriterionVerdict
-	48, // 1: session.v1.ReviewVerdict.override_at:type_name -> google.protobuf.Timestamp
-	48, // 2: session.v1.ReviewVerdict.created_at:type_name -> google.protobuf.Timestamp
+	49, // 1: session.v1.ReviewVerdict.override_at:type_name -> google.protobuf.Timestamp
+	49, // 2: session.v1.ReviewVerdict.created_at:type_name -> google.protobuf.Timestamp
 	3,  // 3: session.v1.TriageResult.suggestions:type_name -> session.v1.TriageSuggestion
 	4,  // 4: session.v1.TriageResult.tasks:type_name -> session.v1.TriageTask
-	48, // 5: session.v1.ItemSession.started_at:type_name -> google.protobuf.Timestamp
-	48, // 6: session.v1.ItemSession.ended_at:type_name -> google.protobuf.Timestamp
-	48, // 7: session.v1.ItemSession.last_commit_at:type_name -> google.protobuf.Timestamp
-	48, // 8: session.v1.ItemSession.last_file_touch_at:type_name -> google.protobuf.Timestamp
-	48, // 9: session.v1.ItemSession.created_at:type_name -> google.protobuf.Timestamp
+	49, // 5: session.v1.ItemSession.started_at:type_name -> google.protobuf.Timestamp
+	49, // 6: session.v1.ItemSession.ended_at:type_name -> google.protobuf.Timestamp
+	49, // 7: session.v1.ItemSession.last_commit_at:type_name -> google.protobuf.Timestamp
+	49, // 8: session.v1.ItemSession.last_file_touch_at:type_name -> google.protobuf.Timestamp
+	49, // 9: session.v1.ItemSession.created_at:type_name -> google.protobuf.Timestamp
 	2,  // 10: session.v1.ItemSession.review_verdict:type_name -> session.v1.ReviewVerdict
 	5,  // 11: session.v1.ItemSession.triage_result:type_name -> session.v1.TriageResult
-	0,  // 12: session.v1.BacklogItem.acceptance_criteria:type_name -> session.v1.AcCriterion
-	48, // 13: session.v1.BacklogItem.plan_approved_at:type_name -> google.protobuf.Timestamp
-	48, // 14: session.v1.BacklogItem.archived_at:type_name -> google.protobuf.Timestamp
-	48, // 15: session.v1.BacklogItem.created_at:type_name -> google.protobuf.Timestamp
-	48, // 16: session.v1.BacklogItem.updated_at:type_name -> google.protobuf.Timestamp
-	6,  // 17: session.v1.BacklogItem.item_sessions:type_name -> session.v1.ItemSession
-	48, // 18: session.v1.ItemSource.last_synced_at:type_name -> google.protobuf.Timestamp
-	48, // 19: session.v1.ItemSource.created_at:type_name -> google.protobuf.Timestamp
-	48, // 20: session.v1.ItemSource.updated_at:type_name -> google.protobuf.Timestamp
-	48, // 21: session.v1.SourceSyncEvent.started_at:type_name -> google.protobuf.Timestamp
-	48, // 22: session.v1.SourceSyncEvent.finished_at:type_name -> google.protobuf.Timestamp
-	0,  // 23: session.v1.CreateBacklogItemRequest.acceptance_criteria:type_name -> session.v1.AcCriterion
-	7,  // 24: session.v1.CreateBacklogItemResponse.item:type_name -> session.v1.BacklogItem
-	7,  // 25: session.v1.GetBacklogItemResponse.item:type_name -> session.v1.BacklogItem
-	7,  // 26: session.v1.ListBacklogItemsResponse.items:type_name -> session.v1.BacklogItem
-	0,  // 27: session.v1.UpdateBacklogItemRequest.acceptance_criteria:type_name -> session.v1.AcCriterion
-	48, // 28: session.v1.UpdateBacklogItemRequest.expected_updated_at:type_name -> google.protobuf.Timestamp
-	7,  // 29: session.v1.UpdateBacklogItemResponse.item:type_name -> session.v1.BacklogItem
-	7,  // 30: session.v1.ArchiveBacklogItemResponse.item:type_name -> session.v1.BacklogItem
-	48, // 31: session.v1.TransitionBacklogItemStatusRequest.expected_updated_at:type_name -> google.protobuf.Timestamp
-	7,  // 32: session.v1.TransitionBacklogItemStatusResponse.item:type_name -> session.v1.BacklogItem
-	6,  // 33: session.v1.SpawnSessionFromItemResponse.item_session:type_name -> session.v1.ItemSession
-	6,  // 34: session.v1.AttachSessionToItemResponse.item_session:type_name -> session.v1.ItemSession
-	6,  // 35: session.v1.TriggerTriageResponse.item_session:type_name -> session.v1.ItemSession
-	7,  // 36: session.v1.ApprovePlanResponse.item:type_name -> session.v1.BacklogItem
-	6,  // 37: session.v1.SuggestNextItemResponse.item_session:type_name -> session.v1.ItemSession
-	7,  // 38: session.v1.SuggestNextItemResponse.item:type_name -> session.v1.BacklogItem
-	7,  // 39: session.v1.OverrideVerdictResponse.item:type_name -> session.v1.BacklogItem
-	6,  // 40: session.v1.TriggerReReviewResponse.item_session:type_name -> session.v1.ItemSession
-	8,  // 41: session.v1.CreateItemSourceResponse.source:type_name -> session.v1.ItemSource
-	8,  // 42: session.v1.ListItemSourcesResponse.sources:type_name -> session.v1.ItemSource
-	8,  // 43: session.v1.UpdateItemSourceResponse.source:type_name -> session.v1.ItemSource
-	9,  // 44: session.v1.GetSyncHistoryResponse.events:type_name -> session.v1.SourceSyncEvent
-	10, // 45: session.v1.BacklogService.CreateBacklogItem:input_type -> session.v1.CreateBacklogItemRequest
-	12, // 46: session.v1.BacklogService.GetBacklogItem:input_type -> session.v1.GetBacklogItemRequest
-	14, // 47: session.v1.BacklogService.ListBacklogItems:input_type -> session.v1.ListBacklogItemsRequest
-	16, // 48: session.v1.BacklogService.UpdateBacklogItem:input_type -> session.v1.UpdateBacklogItemRequest
-	18, // 49: session.v1.BacklogService.ArchiveBacklogItem:input_type -> session.v1.ArchiveBacklogItemRequest
-	20, // 50: session.v1.BacklogService.TransitionBacklogItemStatus:input_type -> session.v1.TransitionBacklogItemStatusRequest
-	22, // 51: session.v1.BacklogService.SpawnSessionFromItem:input_type -> session.v1.SpawnSessionFromItemRequest
-	24, // 52: session.v1.BacklogService.AttachSessionToItem:input_type -> session.v1.AttachSessionToItemRequest
-	26, // 53: session.v1.BacklogService.TriggerTriage:input_type -> session.v1.TriggerTriageRequest
-	28, // 54: session.v1.BacklogService.ApprovePlan:input_type -> session.v1.ApprovePlanRequest
-	30, // 55: session.v1.BacklogService.SuggestNextItem:input_type -> session.v1.SuggestNextItemRequest
-	32, // 56: session.v1.BacklogService.OverrideVerdict:input_type -> session.v1.OverrideVerdictRequest
-	34, // 57: session.v1.BacklogService.TriggerReReview:input_type -> session.v1.TriggerReReviewRequest
-	36, // 58: session.v1.BacklogService.TriggerSync:input_type -> session.v1.TriggerSyncRequest
-	38, // 59: session.v1.BacklogService.CreateItemSource:input_type -> session.v1.CreateItemSourceRequest
-	40, // 60: session.v1.BacklogService.ListItemSources:input_type -> session.v1.ListItemSourcesRequest
-	42, // 61: session.v1.BacklogService.UpdateItemSource:input_type -> session.v1.UpdateItemSourceRequest
-	44, // 62: session.v1.BacklogService.DeleteItemSource:input_type -> session.v1.DeleteItemSourceRequest
-	46, // 63: session.v1.BacklogService.GetSyncHistory:input_type -> session.v1.GetSyncHistoryRequest
-	11, // 64: session.v1.BacklogService.CreateBacklogItem:output_type -> session.v1.CreateBacklogItemResponse
-	13, // 65: session.v1.BacklogService.GetBacklogItem:output_type -> session.v1.GetBacklogItemResponse
-	15, // 66: session.v1.BacklogService.ListBacklogItems:output_type -> session.v1.ListBacklogItemsResponse
-	17, // 67: session.v1.BacklogService.UpdateBacklogItem:output_type -> session.v1.UpdateBacklogItemResponse
-	19, // 68: session.v1.BacklogService.ArchiveBacklogItem:output_type -> session.v1.ArchiveBacklogItemResponse
-	21, // 69: session.v1.BacklogService.TransitionBacklogItemStatus:output_type -> session.v1.TransitionBacklogItemStatusResponse
-	23, // 70: session.v1.BacklogService.SpawnSessionFromItem:output_type -> session.v1.SpawnSessionFromItemResponse
-	25, // 71: session.v1.BacklogService.AttachSessionToItem:output_type -> session.v1.AttachSessionToItemResponse
-	27, // 72: session.v1.BacklogService.TriggerTriage:output_type -> session.v1.TriggerTriageResponse
-	29, // 73: session.v1.BacklogService.ApprovePlan:output_type -> session.v1.ApprovePlanResponse
-	31, // 74: session.v1.BacklogService.SuggestNextItem:output_type -> session.v1.SuggestNextItemResponse
-	33, // 75: session.v1.BacklogService.OverrideVerdict:output_type -> session.v1.OverrideVerdictResponse
-	35, // 76: session.v1.BacklogService.TriggerReReview:output_type -> session.v1.TriggerReReviewResponse
-	37, // 77: session.v1.BacklogService.TriggerSync:output_type -> session.v1.TriggerSyncResponse
-	39, // 78: session.v1.BacklogService.CreateItemSource:output_type -> session.v1.CreateItemSourceResponse
-	41, // 79: session.v1.BacklogService.ListItemSources:output_type -> session.v1.ListItemSourcesResponse
-	43, // 80: session.v1.BacklogService.UpdateItemSource:output_type -> session.v1.UpdateItemSourceResponse
-	45, // 81: session.v1.BacklogService.DeleteItemSource:output_type -> session.v1.DeleteItemSourceResponse
-	47, // 82: session.v1.BacklogService.GetSyncHistory:output_type -> session.v1.GetSyncHistoryResponse
-	64, // [64:83] is the sub-list for method output_type
-	45, // [45:64] is the sub-list for method input_type
-	45, // [45:45] is the sub-list for extension type_name
-	45, // [45:45] is the sub-list for extension extendee
-	0,  // [0:45] is the sub-list for field type_name
+	49, // 12: session.v1.BacklogStatusEvent.created_at:type_name -> google.protobuf.Timestamp
+	0,  // 13: session.v1.BacklogItem.acceptance_criteria:type_name -> session.v1.AcCriterion
+	49, // 14: session.v1.BacklogItem.plan_approved_at:type_name -> google.protobuf.Timestamp
+	49, // 15: session.v1.BacklogItem.archived_at:type_name -> google.protobuf.Timestamp
+	49, // 16: session.v1.BacklogItem.created_at:type_name -> google.protobuf.Timestamp
+	49, // 17: session.v1.BacklogItem.updated_at:type_name -> google.protobuf.Timestamp
+	6,  // 18: session.v1.BacklogItem.item_sessions:type_name -> session.v1.ItemSession
+	7,  // 19: session.v1.BacklogItem.status_events:type_name -> session.v1.BacklogStatusEvent
+	49, // 20: session.v1.ItemSource.last_synced_at:type_name -> google.protobuf.Timestamp
+	49, // 21: session.v1.ItemSource.created_at:type_name -> google.protobuf.Timestamp
+	49, // 22: session.v1.ItemSource.updated_at:type_name -> google.protobuf.Timestamp
+	49, // 23: session.v1.SourceSyncEvent.started_at:type_name -> google.protobuf.Timestamp
+	49, // 24: session.v1.SourceSyncEvent.finished_at:type_name -> google.protobuf.Timestamp
+	0,  // 25: session.v1.CreateBacklogItemRequest.acceptance_criteria:type_name -> session.v1.AcCriterion
+	8,  // 26: session.v1.CreateBacklogItemResponse.item:type_name -> session.v1.BacklogItem
+	8,  // 27: session.v1.GetBacklogItemResponse.item:type_name -> session.v1.BacklogItem
+	8,  // 28: session.v1.ListBacklogItemsResponse.items:type_name -> session.v1.BacklogItem
+	0,  // 29: session.v1.UpdateBacklogItemRequest.acceptance_criteria:type_name -> session.v1.AcCriterion
+	49, // 30: session.v1.UpdateBacklogItemRequest.expected_updated_at:type_name -> google.protobuf.Timestamp
+	8,  // 31: session.v1.UpdateBacklogItemResponse.item:type_name -> session.v1.BacklogItem
+	8,  // 32: session.v1.ArchiveBacklogItemResponse.item:type_name -> session.v1.BacklogItem
+	49, // 33: session.v1.TransitionBacklogItemStatusRequest.expected_updated_at:type_name -> google.protobuf.Timestamp
+	8,  // 34: session.v1.TransitionBacklogItemStatusResponse.item:type_name -> session.v1.BacklogItem
+	6,  // 35: session.v1.SpawnSessionFromItemResponse.item_session:type_name -> session.v1.ItemSession
+	6,  // 36: session.v1.AttachSessionToItemResponse.item_session:type_name -> session.v1.ItemSession
+	6,  // 37: session.v1.TriggerTriageResponse.item_session:type_name -> session.v1.ItemSession
+	8,  // 38: session.v1.ApprovePlanResponse.item:type_name -> session.v1.BacklogItem
+	6,  // 39: session.v1.SuggestNextItemResponse.item_session:type_name -> session.v1.ItemSession
+	8,  // 40: session.v1.SuggestNextItemResponse.item:type_name -> session.v1.BacklogItem
+	8,  // 41: session.v1.OverrideVerdictResponse.item:type_name -> session.v1.BacklogItem
+	6,  // 42: session.v1.TriggerReReviewResponse.item_session:type_name -> session.v1.ItemSession
+	9,  // 43: session.v1.CreateItemSourceResponse.source:type_name -> session.v1.ItemSource
+	9,  // 44: session.v1.ListItemSourcesResponse.sources:type_name -> session.v1.ItemSource
+	9,  // 45: session.v1.UpdateItemSourceResponse.source:type_name -> session.v1.ItemSource
+	10, // 46: session.v1.GetSyncHistoryResponse.events:type_name -> session.v1.SourceSyncEvent
+	11, // 47: session.v1.BacklogService.CreateBacklogItem:input_type -> session.v1.CreateBacklogItemRequest
+	13, // 48: session.v1.BacklogService.GetBacklogItem:input_type -> session.v1.GetBacklogItemRequest
+	15, // 49: session.v1.BacklogService.ListBacklogItems:input_type -> session.v1.ListBacklogItemsRequest
+	17, // 50: session.v1.BacklogService.UpdateBacklogItem:input_type -> session.v1.UpdateBacklogItemRequest
+	19, // 51: session.v1.BacklogService.ArchiveBacklogItem:input_type -> session.v1.ArchiveBacklogItemRequest
+	21, // 52: session.v1.BacklogService.TransitionBacklogItemStatus:input_type -> session.v1.TransitionBacklogItemStatusRequest
+	23, // 53: session.v1.BacklogService.SpawnSessionFromItem:input_type -> session.v1.SpawnSessionFromItemRequest
+	25, // 54: session.v1.BacklogService.AttachSessionToItem:input_type -> session.v1.AttachSessionToItemRequest
+	27, // 55: session.v1.BacklogService.TriggerTriage:input_type -> session.v1.TriggerTriageRequest
+	29, // 56: session.v1.BacklogService.ApprovePlan:input_type -> session.v1.ApprovePlanRequest
+	31, // 57: session.v1.BacklogService.SuggestNextItem:input_type -> session.v1.SuggestNextItemRequest
+	33, // 58: session.v1.BacklogService.OverrideVerdict:input_type -> session.v1.OverrideVerdictRequest
+	35, // 59: session.v1.BacklogService.TriggerReReview:input_type -> session.v1.TriggerReReviewRequest
+	37, // 60: session.v1.BacklogService.TriggerSync:input_type -> session.v1.TriggerSyncRequest
+	39, // 61: session.v1.BacklogService.CreateItemSource:input_type -> session.v1.CreateItemSourceRequest
+	41, // 62: session.v1.BacklogService.ListItemSources:input_type -> session.v1.ListItemSourcesRequest
+	43, // 63: session.v1.BacklogService.UpdateItemSource:input_type -> session.v1.UpdateItemSourceRequest
+	45, // 64: session.v1.BacklogService.DeleteItemSource:input_type -> session.v1.DeleteItemSourceRequest
+	47, // 65: session.v1.BacklogService.GetSyncHistory:input_type -> session.v1.GetSyncHistoryRequest
+	12, // 66: session.v1.BacklogService.CreateBacklogItem:output_type -> session.v1.CreateBacklogItemResponse
+	14, // 67: session.v1.BacklogService.GetBacklogItem:output_type -> session.v1.GetBacklogItemResponse
+	16, // 68: session.v1.BacklogService.ListBacklogItems:output_type -> session.v1.ListBacklogItemsResponse
+	18, // 69: session.v1.BacklogService.UpdateBacklogItem:output_type -> session.v1.UpdateBacklogItemResponse
+	20, // 70: session.v1.BacklogService.ArchiveBacklogItem:output_type -> session.v1.ArchiveBacklogItemResponse
+	22, // 71: session.v1.BacklogService.TransitionBacklogItemStatus:output_type -> session.v1.TransitionBacklogItemStatusResponse
+	24, // 72: session.v1.BacklogService.SpawnSessionFromItem:output_type -> session.v1.SpawnSessionFromItemResponse
+	26, // 73: session.v1.BacklogService.AttachSessionToItem:output_type -> session.v1.AttachSessionToItemResponse
+	28, // 74: session.v1.BacklogService.TriggerTriage:output_type -> session.v1.TriggerTriageResponse
+	30, // 75: session.v1.BacklogService.ApprovePlan:output_type -> session.v1.ApprovePlanResponse
+	32, // 76: session.v1.BacklogService.SuggestNextItem:output_type -> session.v1.SuggestNextItemResponse
+	34, // 77: session.v1.BacklogService.OverrideVerdict:output_type -> session.v1.OverrideVerdictResponse
+	36, // 78: session.v1.BacklogService.TriggerReReview:output_type -> session.v1.TriggerReReviewResponse
+	38, // 79: session.v1.BacklogService.TriggerSync:output_type -> session.v1.TriggerSyncResponse
+	40, // 80: session.v1.BacklogService.CreateItemSource:output_type -> session.v1.CreateItemSourceResponse
+	42, // 81: session.v1.BacklogService.ListItemSources:output_type -> session.v1.ListItemSourcesResponse
+	44, // 82: session.v1.BacklogService.UpdateItemSource:output_type -> session.v1.UpdateItemSourceResponse
+	46, // 83: session.v1.BacklogService.DeleteItemSource:output_type -> session.v1.DeleteItemSourceResponse
+	48, // 84: session.v1.BacklogService.GetSyncHistory:output_type -> session.v1.GetSyncHistoryResponse
+	66, // [66:85] is the sub-list for method output_type
+	47, // [47:66] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_session_v1_backlog_proto_init() }
@@ -3324,7 +3421,7 @@ func file_session_v1_backlog_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_session_v1_backlog_proto_rawDesc), len(file_session_v1_backlog_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   48,
+			NumMessages:   49,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/session/v1/backlog.proto
+++ b/proto/session/v1/backlog.proto
@@ -71,6 +71,15 @@ message ItemSession {
   TriageResult triage_result = 12;
 }
 
+// BacklogStatusEvent records a single status transition for a backlog item.
+message BacklogStatusEvent {
+  string id = 1;
+  string from_status = 2;
+  string to_status = 3;
+  string triggered_by = 4; // "user" or "system"
+  google.protobuf.Timestamp created_at = 5;
+}
+
 // BacklogItem represents a unit of work in the backlog.
 message BacklogItem {
   string id = 1;
@@ -92,6 +101,7 @@ message BacklogItem {
   google.protobuf.Timestamp updated_at = 17;
   repeated ItemSession item_sessions = 18;
   string source_id = 19;
+  repeated BacklogStatusEvent status_events = 20;
 }
 
 // ItemSource represents an external plugin source that syncs items into the

--- a/server/dependencies.go
+++ b/server/dependencies.go
@@ -686,6 +686,7 @@ func BuildRuntimeDeps(_ tmux.TmuxServerReady, svc *ServiceDeps, cfg *config.Conf
 	}
 
 	backlogSvc := services.NewBacklogService(storage, sessionService, cfg, workflowEngine)
+	backlogSvc.SetSessionStopper(sessionService)
 	sessionService.SetBacklogLifecycleListener(backlogLifecycleListener)
 	sessionService.SetFeatureController("backlog", backlogCtrl)
 

--- a/server/services/backlog_service.go
+++ b/server/services/backlog_service.go
@@ -23,7 +23,7 @@ import (
 
 // SessionCreator allows BacklogService to spawn sessions without importing handler internals.
 type SessionCreator interface {
-	CreateDirectorySession(ctx context.Context, title, path, appendSystemPrompt string, tags []string, oneShot bool) (*session.Instance, error)
+	CreateDirectorySession(ctx context.Context, title, path, prompt string, tags []string, oneShot bool) (*session.Instance, error)
 }
 
 // SessionStopper allows BacklogService to kill live sessions.

--- a/server/services/backlog_service.go
+++ b/server/services/backlog_service.go
@@ -26,6 +26,21 @@ type SessionCreator interface {
 	CreateDirectorySession(ctx context.Context, title, path, appendSystemPrompt string, tags []string, oneShot bool) (*session.Instance, error)
 }
 
+// SessionStopper allows BacklogService to kill live sessions.
+// It is nil-safe: BacklogService degrades gracefully when not wired.
+type SessionStopper interface {
+	StopSessionByUUID(ctx context.Context, sessionUUID string) error
+	// KillTmuxSessionByTitle kills a tmux session by its title, regardless of
+	// whether the Instance is still tracked in memory. Used to clear stale tmux
+	// sessions before re-triggering so the fresh session gets its --append-system-prompt.
+	KillTmuxSessionByTitle(ctx context.Context, title string) error
+	// IsSessionLive returns true if the session UUID is currently tracked in the
+	// live in-memory poller. Used to distinguish genuinely-running sessions from
+	// sessions that exited but whose DB records were not closed (e.g. after a
+	// server restart that killed the underlying process).
+	IsSessionLive(sessionUUID string) bool
+}
+
 // itemSourceBackend is a narrow interface for item source persistence; satisfied by *session.Storage.
 type itemSourceBackend interface {
 	CreateItemSource(ctx context.Context, data session.ItemSourceData) (*session.ItemSourceData, error)
@@ -37,6 +52,7 @@ type BacklogService struct {
 	storage        *session.Storage
 	sourceBackend  itemSourceBackend
 	sessionCreator SessionCreator
+	sessionStopper SessionStopper
 	cfg            *config.Config
 	engine         session.WorkflowEngine
 	// worktreeMu serializes context-file writes to the same worktree path so that
@@ -63,6 +79,11 @@ func NewBacklogService(storage *session.Storage, creator SessionCreator, cfg *co
 		cfg:            cfg,
 		engine:         engine,
 	}
+}
+
+// SetSessionStopper wires the optional session stopper used to kill orphaned sessions on re-triage.
+func (s *BacklogService) SetSessionStopper(stopper SessionStopper) {
+	s.sessionStopper = stopper
 }
 
 // encryptAndMergeToken produces a token config JSON string suitable for storage.
@@ -275,6 +296,21 @@ func backlogItemToProto(item *session.BacklogItemData) *sessionv1.BacklogItem {
 			protoSessions[i] = itemSessionToProto(is)
 		}
 		p.ItemSessions = protoSessions
+	}
+
+	// Populate status events when they were eagerly loaded.
+	if len(item.StatusEvents) > 0 {
+		protoEvents := make([]*sessionv1.BacklogStatusEvent, len(item.StatusEvents))
+		for i, ev := range item.StatusEvents {
+			protoEvents[i] = &sessionv1.BacklogStatusEvent{
+				Id:          ev.ID.String(),
+				FromStatus:  ev.FromStatus,
+				ToStatus:    ev.ToStatus,
+				TriggeredBy: ev.TriggeredBy,
+				CreatedAt:   timestamppb.New(ev.CreatedAt),
+			}
+		}
+		p.StatusEvents = protoEvents
 	}
 
 	return p
@@ -1049,12 +1085,41 @@ func (s *BacklogService) TriggerTriage(
 			fmt.Errorf("set repo_path before triggering triage"))
 	}
 
-	// 3a. Double-trigger guard: check for an existing running triage session.
+	// 3a. Orphan-aware guard: if an open triage session exists, check whether it is
+	// genuinely still running. A session is orphaned (and safe to replace) when:
+	//   (a) the item has already advanced past "idea" (triage cycle completed), OR
+	//   (b) the session UUID is not live in memory (e.g. process died after a restart).
+	// Orphaned sessions are tombstoned so the re-trigger can proceed; only genuinely
+	// live sessions block with CodeAlreadyExists.
 	existingSessions, _ := s.storage.ListItemSessions(ctx, req.Msg.ItemId)
 	for _, is := range existingSessions {
-		if is.SessionRole == string(session.SessionRoleTriage) && is.EndedAt == nil {
-			return nil, connect.NewError(connect.CodeAlreadyExists,
-				fmt.Errorf("triage session already running for item %s", req.Msg.ItemId))
+		if is.SessionRole != string(session.SessionRoleTriage) || is.EndedAt != nil {
+			continue
+		}
+		// Open triage session found. Check if it's orphaned.
+		// started_at=NULL means the session was created but never confirmed running — always treat as orphaned.
+		neverStarted := is.StartedAt == nil
+		notLive := neverStarted || s.sessionStopper == nil || !s.sessionStopper.IsSessionLive(is.SessionUUID)
+		statusAdvanced := item.Status != string(session.BacklogStatusIdea)
+		if notLive || statusAdvanced {
+			now := time.Now()
+			_ = s.storage.UpdateItemSessionEnded(ctx, is.ID.String(), now)
+			if s.sessionStopper != nil {
+				_ = s.sessionStopper.StopSessionByUUID(ctx, is.SessionUUID)
+			}
+			continue
+		}
+		return nil, connect.NewError(connect.CodeAlreadyExists,
+			fmt.Errorf("triage session already running for item %s", req.Msg.ItemId))
+	}
+
+	// 3b. If re-triggering on a "ready" item, move it back to "idea" so the UI
+	// correctly reflects that the item is under evaluation again.
+	if item.Status == string(session.BacklogStatusReady) {
+		if _, transErr := s.storage.TransitionBacklogItemStatus(ctx, req.Msg.ItemId,
+			session.BacklogStatusIdea, nil); transErr != nil {
+			log.ErrorLog.Printf("[TriggerTriage] failed to reset status to idea: %v", transErr)
+			// Non-fatal — continue with triage spawn.
 		}
 	}
 
@@ -1062,6 +1127,19 @@ func (s *BacklogService) TriggerTriage(
 	slug := slugify(item.Title)
 	artifactRelPath := filepath.Join("docs", "tasks", slug)
 	artifactAbsPath := filepath.Join(item.RepoPath, artifactRelPath)
+
+	// 4.5 Kill any stale tmux session with the same deterministic name. The tmux
+	// session name is derived from the title ("triage:<slug>") and is reused across
+	// triggers. If the old session is still alive in tmux (e.g. the in-memory Instance
+	// was already removed after a server restart), TmuxSession.Start() will reattach
+	// to it instead of creating a fresh session — silently skipping the new
+	// --append-system-prompt injection. Killing by title before spawning ensures a
+	// clean slate.
+	if s.sessionStopper != nil {
+		if killErr := s.sessionStopper.KillTmuxSessionByTitle(ctx, "triage:"+slug); killErr != nil {
+			log.ErrorLog.Printf("[TriggerTriage] failed to kill stale tmux session: %v", killErr)
+		}
+	}
 
 	// 5. Create artifact dir.
 	if mkErr := os.MkdirAll(artifactAbsPath, 0o755); mkErr != nil {

--- a/server/services/backlog_service_test.go
+++ b/server/services/backlog_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,21 @@ type mockSessionCreator struct {
 	err   error
 }
 
+// mockSessionStopper implements SessionStopper for tests.
+type mockSessionStopper struct {
+	liveUUIDs map[string]bool
+}
+
+func (m *mockSessionStopper) IsSessionLive(uuid string) bool {
+	return m.liveUUIDs[uuid]
+}
+
+func (m *mockSessionStopper) StopSessionByUUID(_ context.Context, _ string) error { return nil }
+
+func (m *mockSessionStopper) KillTmuxSessionByTitle(_ context.Context, _ string) error {
+	return nil
+}
+
 type mockCreateCall struct {
 	title  string
 	path   string
@@ -26,8 +42,8 @@ type mockCreateCall struct {
 	oneShot bool
 }
 
-func (m *mockSessionCreator) CreateDirectorySession(_ context.Context, title, path, appendSystemPrompt string, tags []string, oneShot bool) (*session.Instance, error) {
-	m.calls = append(m.calls, mockCreateCall{title: title, path: path, prompt: appendSystemPrompt, tags: tags, oneShot: oneShot})
+func (m *mockSessionCreator) CreateDirectorySession(_ context.Context, title, path, prompt string, tags []string, oneShot bool) (*session.Instance, error) {
+	m.calls = append(m.calls, mockCreateCall{title: title, path: path, prompt: prompt, tags: tags, oneShot: oneShot})
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -351,24 +367,29 @@ func TestCreateBacklogItem_SkipsTriageWhenRepoPathEmpty(t *testing.T) {
 // TriggerTriage returns CodeAlreadyExists.
 func TestTriggerTriage_DoubleTriggerGuard(t *testing.T) {
 	storage := createTestStorage(t)
+	const liveUUID = "00000000-0000-0000-0000-000000000001"
+	stopper := &mockSessionStopper{liveUUIDs: map[string]bool{liveUUID: true}}
 	svc := NewBacklogService(storage, nil, nil, nil)
+	svc.SetSessionStopper(stopper)
 
 	// Create an item with a repo path so TriggerTriage can reach the guard.
 	createResp, err := svc.CreateBacklogItem(t.Context(), connect.NewRequest(&sessionv1.CreateBacklogItemRequest{
-		Title:     "item for double-trigger test",
-		RepoPath:  t.TempDir(),
+		Title:      "item for double-trigger test",
+		RepoPath:   t.TempDir(),
 		SkipTriage: true,
 	}))
 	require.NoError(t, err)
 	itemID := createResp.Msg.Item.Id
 
 	// Manually insert a triage ItemSession with no ended_at (simulates a running triage).
-	_, isErr := storage.CreateItemSession(t.Context(), session.ItemSessionData{
+	is, isErr := storage.CreateItemSession(t.Context(), session.ItemSessionData{
 		ItemID:      itemID,
-		SessionUUID: "00000000-0000-0000-0000-000000000001",
+		SessionUUID: liveUUID,
 		SessionRole: string(session.SessionRoleTriage),
 	})
 	require.NoError(t, isErr)
+	// Mark it as started so the orphan guard treats it as genuinely live.
+	require.NoError(t, storage.UpdateItemSessionStarted(t.Context(), is.ID.String(), time.Now()))
 
 	// TriggerTriage should refuse because a triage session is already running.
 	_, trigErr := svc.TriggerTriage(t.Context(), connect.NewRequest(&sessionv1.TriggerTriageRequest{

--- a/server/services/session_service.go
+++ b/server/services/session_service.go
@@ -982,9 +982,18 @@ func (s *SessionService) UpdateSession(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("session id is required"))
 	}
 
-	instances, err := s.storage.LoadInstances()
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", err))
+	// Use the live poller list to avoid LoadInstances side-effects (Start() on Active
+	// sessions) that can silently drop sessions if tmux is unavailable, which would then
+	// clobber the poller's complete list via SetInstances.
+	var instances []*session.Instance
+	if s.reviewQueuePoller != nil {
+		instances = s.reviewQueuePoller.GetInstances()
+	} else {
+		var loadErr error
+		instances, loadErr = s.loadInstancesWithWiring()
+		if loadErr != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", loadErr))
+		}
 	}
 
 	// Find the instance to update
@@ -1096,12 +1105,6 @@ func (s *SessionService) UpdateSession(
 	instances[instanceIndex] = instance
 	if err := s.storage.SaveInstances(instances); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to save instance: %w", err))
-	}
-
-	// CRITICAL: Update the ReviewQueuePoller's instance references after updating session
-	if s.reviewQueuePoller != nil {
-		s.reviewQueuePoller.SetInstances(instances)
-		log.Info("[ReviewQueue] updated poller instance references after UpdateSession", "session", instance.Title)
 	}
 
 	// Publish events based on what was updated
@@ -1913,9 +1916,17 @@ func (s *SessionService) RenameSession(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("new title is required"))
 	}
 
-	instances, err := s.loadInstancesWithWiring()
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", err))
+	// Use the live poller list for the same reason as UpdateSession: avoid LoadInstances
+	// side-effects that can drop sessions and clobber the poller list via SetInstances.
+	var instances []*session.Instance
+	if s.reviewQueuePoller != nil {
+		instances = s.reviewQueuePoller.GetInstances()
+	} else {
+		var loadErr error
+		instances, loadErr = s.loadInstancesWithWiring()
+		if loadErr != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load instances: %w", loadErr))
+		}
 	}
 
 	// Find the instance to rename
@@ -1955,12 +1966,6 @@ func (s *SessionService) RenameSession(
 		// Try to rollback the rename
 		instance.Title = oldTitle
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to save renamed instance: %w", err))
-	}
-
-	// Update the ReviewQueuePoller's instance references after renaming
-	if s.reviewQueuePoller != nil {
-		s.reviewQueuePoller.SetInstances(instances)
-		log.Info("[ReviewQueue] updated poller instance references after RenameSession", "from", oldTitle, "to", req.Msg.NewTitle)
 	}
 
 	// Publish SessionUpdated event

--- a/server/services/session_service.go
+++ b/server/services/session_service.go
@@ -524,22 +524,22 @@ func (s *SessionService) SpawnReviewSession(ctx context.Context, item *ent.Backl
 
 // CreateDirectorySession satisfies the services.SessionCreator interface so that
 // BacklogService can spawn sessions without importing SessionService directly.
-// It creates a directory-type session with the given title, path, system prompt,
+// It creates a directory-type session with the given title, path, initial prompt,
 // tags, and oneShot flag, wires it into the live poller, and returns the Instance.
-func (s *SessionService) CreateDirectorySession(ctx context.Context, title, path, appendSystemPrompt string, tags []string, oneShot bool) (*session.Instance, error) {
+func (s *SessionService) CreateDirectorySession(ctx context.Context, title, path, prompt string, tags []string, oneShot bool) (*session.Instance, error) {
 	cfg := config.LoadConfig()
 	resolved := config.ResolveDefaults(cfg, path, "")
 	opts := session.InstanceOptions{
-		Title:              title,
-		Path:               path,
-		Program:            resolved.Program,
-		AutoYes:            true, // automated sessions must not block on permission prompts
-		SessionType:        session.SessionTypeDirectory,
-		AppendSystemPrompt: appendSystemPrompt,
-		Tags:               tags,
-		OneShot:            oneShot,
-		MCPServerURL:       s.mcpServerURL,
-		CreateIfMissing:    true,
+		Title:           title,
+		Path:            path,
+		Program:         resolved.Program,
+		AutoYes:         true, // automated sessions must not block on permission prompts
+		SessionType:     session.SessionTypeDirectory,
+		Prompt:          prompt,
+		Tags:            tags,
+		OneShot:         oneShot,
+		MCPServerURL:    s.mcpServerURL,
+		CreateIfMissing: true,
 	}
 	instance, err := session.NewInstance(opts)
 	if err != nil {

--- a/server/services/session_service.go
+++ b/server/services/session_service.go
@@ -342,6 +342,64 @@ func (s *SessionService) FindLiveInstance(id string) *session.Instance {
 	return s.reviewQueuePoller.FindInstance(id)
 }
 
+// StopSessionByUUID satisfies the BacklogService.SessionStopper interface.
+// It kills the live tmux session identified by UUID (best-effort; errors are non-fatal).
+func (s *SessionService) StopSessionByUUID(ctx context.Context, sessionUUID string) error {
+	inst := s.FindLiveInstance(sessionUUID)
+	if inst == nil {
+		return nil // already gone
+	}
+	if err := inst.Kill(); err != nil {
+		log.Warn("StopSessionByUUID: kill failed", "uuid", sessionUUID, "err", err)
+		return err
+	}
+	return nil
+}
+
+// IsSessionLive satisfies the BacklogService.SessionStopper interface.
+// It returns true if the session UUID is currently tracked in the live in-memory poller.
+func (s *SessionService) IsSessionLive(sessionUUID string) bool {
+	return s.FindLiveInstance(sessionUUID) != nil
+}
+
+// KillTmuxSessionByTitle satisfies the BacklogService.SessionStopper interface.
+// It kills the tmux session whose name is derived from title using the same sanitization
+// as initTmuxSession (whitespace stripped, "." and ":" replaced with "_", "staplersquad_"
+// prefix). This handles the case where the Instance is no longer tracked in memory
+// but the underlying tmux session is still alive.
+func (s *SessionService) KillTmuxSessionByTitle(ctx context.Context, title string) error {
+	name := stapleSquadTmuxName(title)
+	killCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	cmd := safeexec.CommandContext(killCtx, "tmux", "kill-session", "-t", name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		combined := strings.ToLower(string(out))
+		if strings.Contains(combined, "can't find session") ||
+			strings.Contains(combined, "no server running") ||
+			strings.Contains(combined, "error connecting to") {
+			return nil // session already gone — not an error
+		}
+		return fmt.Errorf("tmux kill-session %q: %w (output: %s)", name, err, out)
+	}
+	return nil
+}
+
+// stapleSquadTmuxName computes the sanitized tmux session name for a given title,
+// matching the logic in session/tmux.toStaplerSquadTmuxNameWithPrefix.
+func stapleSquadTmuxName(title string) string {
+	var sb strings.Builder
+	for _, r := range title {
+		if r != ' ' && r != '\t' && r != '\n' && r != '\r' {
+			sb.WriteRune(r)
+		}
+	}
+	sanitized := sb.String()
+	sanitized = strings.ReplaceAll(sanitized, ".", "_")
+	sanitized = strings.ReplaceAll(sanitized, ":", "_")
+	return "staplersquad_" + sanitized
+}
+
 // GetApprovalStore returns the approval store for wiring up the HTTP hook handler.
 func (s *SessionService) GetApprovalStore() *ApprovalStore {
 	return s.approvalStore

--- a/server/services/session_service_test.go
+++ b/server/services/session_service_test.go
@@ -51,6 +51,18 @@ func addPausedSession(t *testing.T, fix *forkTestFixture, title string) {
 	}
 	err := fix.storage.AddInstance(inst)
 	require.NoError(t, err, "addPausedSession: failed to persist %q", title)
+
+	// Load back from storage so FromInstanceData sets started=true (required for
+	// SaveInstances to persist subsequent mutations via the live poller path).
+	loaded, err := fix.storage.LoadInstances()
+	require.NoError(t, err, "addPausedSession: failed to reload after persist")
+	for _, li := range loaded {
+		if li.Title == title {
+			addInstanceToPoller(fix.poller, li)
+			return
+		}
+	}
+	t.Fatalf("addPausedSession: could not find %q after reload", title)
 }
 
 // --------------------------------------------------------------------------
@@ -429,6 +441,15 @@ func TestUpdateSession_TagsUpdate_Replaces(t *testing.T) {
 	}
 	err := fix.storage.AddInstance(inst)
 	require.NoError(t, err)
+	// Load back so started=true; required for SaveInstances to persist mutations.
+	loaded, err := fix.storage.LoadInstances()
+	require.NoError(t, err)
+	for _, li := range loaded {
+		if li.Title == "tagged-session" {
+			addInstanceToPoller(fix.poller, li)
+			break
+		}
+	}
 
 	// Replace tags with a new set.
 	resp, err := fix.svc.UpdateSession(context.Background(), connect.NewRequest(&sessionv1.UpdateSessionRequest{

--- a/session/backlog_integration_test.go
+++ b/session/backlog_integration_test.go
@@ -288,11 +288,11 @@ func TestBacklogIntegration_IT006_ReviewSessionExitDoesNotTransition(t *testing.
 	require.NoError(t, err)
 	require.Equal(t, string(BacklogStatusReview), fetchedItem.Status, "review session exit should not transition item")
 
-	// 5. Verify ItemSession.EndedAt was NOT set (recursion guard)
+	// 5. Verify ItemSession.EndedAt IS set (exit is recorded for all roles)
 	repo := storage.repo.(*EntRepository)
 	fetchedIS, err := repo.GetItemSession(ctx, createdIS.ID.String())
 	require.NoError(t, err)
-	require.Nil(t, fetchedIS.EndedAt, "review session exit should not set EndedAt (recursion guard)")
+	require.NotNil(t, fetchedIS.EndedAt, "review session exit should set EndedAt")
 }
 
 // IT-007: Multiple ItemSessions for same item

--- a/session/backlog_lifecycle.go
+++ b/session/backlog_lifecycle.go
@@ -106,14 +106,15 @@ func (l *BacklogLifecycleListener) onSessionExited(sessionUUID string) {
 		return
 	}
 
-	// Recursion guard: only drive transitions for work sessions.
-	if is.SessionRole != SessionRoleWork {
-		return
-	}
-
+	// Record end time for all session roles (triage, review, work).
 	now := time.Now()
 	if err := l.storage.UpdateItemSessionEnded(ctx, is.ID.String(), now); err != nil {
 		log.ErrorLog.Printf("[BacklogLifecycle] UpdateItemSessionEnded(%s) error: %v", is.ID, err)
+	}
+
+	// Only drive in_progress→review/done transitions for work sessions.
+	if is.SessionRole != SessionRoleWork {
+		return
 	}
 
 	// BacklogItem edge is eager-loaded by GetItemSessionBySessionUUID.

--- a/session/backlog_lifecycle_test.go
+++ b/session/backlog_lifecycle_test.go
@@ -251,11 +251,11 @@ func TestBacklogLifecycleListener_OnSessionExited_ReviewSession_NoTransition(t *
 	require.NoError(t, err)
 	require.Equal(t, string(BacklogStatusInProgress), fetchedItem.Status)
 
-	// Verify that the ItemSession EndedAt was NOT set (review sessions are guarded).
+	// Verify that the ItemSession EndedAt IS set (exit is recorded for all roles).
 	repo := storage.repo.(*EntRepository)
 	fetchedIS, err := repo.GetItemSession(ctx, createdIS.ID.String())
 	require.NoError(t, err)
-	require.Nil(t, fetchedIS.EndedAt, "review session should not have EndedAt set (recursion guard)")
+	require.NotNil(t, fetchedIS.EndedAt, "review session should have EndedAt recorded when it exits")
 }
 
 // TestBacklogLifecycleListener_OnSessionExited_NotFound_NoError

--- a/session/detection/asterism_test.go
+++ b/session/detection/asterism_test.go
@@ -4,17 +4,38 @@ import (
 	"testing"
 )
 
-// TestClaude_AsterismActive_SingleLine verifies that ✻ Verb... lines are
-// classified as StatusActive (AC-1).
+// TestClaude_AsterismActive_SingleLine verifies that spinner-frame + Verb... lines are
+// classified as StatusActive across all known frame characters.
 func TestClaude_AsterismActive_SingleLine(t *testing.T) {
 	sd := NewStatusDetector()
 	cases := []struct {
 		name  string
 		input string
 	}{
-		{"basic spinner", "✻ Perambulating..."},
-		{"with timing", "✻ Perambulating... (1h 5m 37s · ↑ 5.4k tokens)"},
-		{"other verb", "✻ Cogitating..."},
+		// Modern ✻ (U+273B ASTERISM) — primary current frame
+		{"asterism basic", "✻ Perambulating..."},
+		{"asterism with timing", "✻ Perambulating... (1h 5m 37s · ↑ 5.4k tokens)"},
+		{"asterism unicode ellipsis", "✻ Cogitating…"},
+		// Other macOS bounce-cycle frames: · ✢ ✳ ✶ ✻ ✽
+		{"middle dot frame", "· Herding…"},
+		{"four teardrop frame ✢", "✢ Spelunking…"},
+		{"eight spoked asterisk ✳", "✳ Ruminating…"},
+		{"six pointed star ✶", "✶ Wandering…"},
+		{"eight pointed pinwheel ✽", "✽ Tinkering…"},
+		// Reduced-motion static frame ● (U+25CF BLACK CIRCLE)
+		{"reduced motion frame", "● Working…"},
+		// Legacy * (U+002A ASTERISK)
+		{"asterisk legacy", "* Moonwalking..."},
+		// Verbs with accented chars (Go RE2 \w misses é, è, etc.)
+		{"accented flambe", "✻ Flambéing…"},
+		{"accented saute", "✻ Sautéing…"},
+		// Hyphenated verbs
+		{"hyphenated dilly", "✻ Dilly-dallying…"},
+		{"hyphenated razzle", "✻ Razzle-dazzling…"},
+		// Apostrophe-truncated
+		{"apostrophe beboppin", "✻ Beboppin'…"},
+		// Extended thinking suffix — ellipsis is on the verb, suffix is parenthetical
+		{"thinking some more suffix", "✻ Moonwalking… (43s · thinking some more)"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -26,7 +47,7 @@ func TestClaude_AsterismActive_SingleLine(t *testing.T) {
 	}
 }
 
-// TestClaude_AsteriskActive_NoRegression verifies the existing * prefix still works (AC-1 non-regression).
+// TestClaude_AsteriskActive_NoRegression verifies the existing * prefix still works.
 func TestClaude_AsteriskActive_NoRegression(t *testing.T) {
 	sd := NewStatusDetector()
 	cases := []string{
@@ -38,6 +59,31 @@ func TestClaude_AsteriskActive_NoRegression(t *testing.T) {
 		if got != StatusActive && got != StatusProcessing {
 			t.Errorf("Detect(%q) = %s, want StatusActive (regression)", input, got)
 		}
+	}
+}
+
+// TestClaude_SpinnerFrame_NoFalsePositive verifies that spinner-like chars in
+// non-active contexts don't trigger the pattern.
+func TestClaude_SpinnerFrame_NoFalsePositive(t *testing.T) {
+	sd := NewStatusDetector()
+	cases := []struct {
+		name  string
+		input string
+	}{
+		// · as separator mid-line in timing string — must NOT match
+		{"middle dot separator in timing", "(8m 39s · ↓ 834 tokens)"},
+		// lowercase after frame — real spinner verbs are always capitalized
+		{"lowercase after frame", "✻ perambulating..."},
+		// ◉ (FISHEYE) is completion-only — must NOT match Active
+		{"fisheye active line", "◉ Working…"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sd.Detect([]byte(tc.input))
+			if got == StatusActive {
+				t.Errorf("Detect(%q) = StatusActive, expected no match (false positive)", tc.input)
+			}
+		})
 	}
 }
 

--- a/session/detection/asterism_test.go
+++ b/session/detection/asterism_test.go
@@ -1,0 +1,109 @@
+package detection
+
+import (
+	"testing"
+)
+
+// TestClaude_AsterismActive_SingleLine verifies that ✻ Verb... lines are
+// classified as StatusActive (AC-1).
+func TestClaude_AsterismActive_SingleLine(t *testing.T) {
+	sd := NewStatusDetector()
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"basic spinner", "✻ Perambulating..."},
+		{"with timing", "✻ Perambulating... (1h 5m 37s · ↑ 5.4k tokens)"},
+		{"other verb", "✻ Cogitating..."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sd.Detect([]byte(tc.input))
+			if got != StatusActive && got != StatusProcessing {
+				t.Errorf("Detect(%q) = %s, want StatusActive or StatusProcessing", tc.input, got)
+			}
+		})
+	}
+}
+
+// TestClaude_AsteriskActive_NoRegression verifies the existing * prefix still works (AC-1 non-regression).
+func TestClaude_AsteriskActive_NoRegression(t *testing.T) {
+	sd := NewStatusDetector()
+	cases := []string{
+		"* Moonwalking... (4m 18s · ↓ 2.0k tokens · thinking)",
+		"* Ebbing...",
+	}
+	for _, input := range cases {
+		got := sd.Detect([]byte(input))
+		if got != StatusActive && got != StatusProcessing {
+			t.Errorf("Detect(%q) = %s, want StatusActive (regression)", input, got)
+		}
+	}
+}
+
+// TestClaude_AsterismCompletion_IsSuccess verifies that ✻ PastTenseVerb for N → StatusSuccess (AC-2).
+func TestClaude_AsterismCompletion_IsSuccess(t *testing.T) {
+	sd := NewStatusDetector()
+	cases := []string{
+		"✻ Perambulated for 1h 5m",
+		"✻ Synthesized for 30s",
+		"◉ Baked for 10s",
+	}
+	for _, input := range cases {
+		got := sd.Detect([]byte(input))
+		if got != StatusSuccess {
+			t.Errorf("Detect(%q) = %s, want StatusSuccess", input, got)
+		}
+	}
+}
+
+// TestClaude_AsterismCompletion_NotActive verifies completion lines are never Active (AC-3 variant).
+func TestClaude_AsterismCompletion_NotActive(t *testing.T) {
+	sd := NewStatusDetector()
+	cases := []string{
+		"✻ Perambulated for 1h 5m",
+		"✻ Synthesized for 30s",
+	}
+	for _, input := range cases {
+		got := sd.Detect([]byte(input))
+		if got == StatusActive {
+			t.Errorf("Detect(%q) = StatusActive, completion line must not be Active", input)
+		}
+	}
+}
+
+// TestClaude_ScrollbackFalsePositive_ActiveThenIdle verifies that old spinner lines
+// in scrollback don't override a current idle prompt (AC-3).
+func TestClaude_ScrollbackFalsePositive_ActiveThenIdle(t *testing.T) {
+	sd := NewStatusDetector()
+	lines := []string{
+		"✻ Perambulating... (5m 12s · ↑ 3.2k tokens)",
+		" └ some tool output",
+		"",
+		"✻ Perambulated for 5m 12s",
+		"",
+		"> ▌",
+		"? for shortcuts",
+	}
+	got, _ := sd.DetectWithContextFromLines(lines)
+	if got != StatusIdle && got != StatusReady {
+		t.Errorf("DetectWithContextFromLines with stale scrollback: got %s, want StatusIdle or StatusReady", got)
+	}
+}
+
+// TestClaude_AsterismPattern_NoAiderFalsePositive confirms the ✻ pattern doesn't
+// produce unexpected results for Aider-style bullet output.
+// The real regression guard is snapshot_test.go/aider_active.txt.
+func TestClaude_AsterismPattern_NoAiderFalsePositive(t *testing.T) {
+	sd := NewStatusDetector()
+	aiderOutputs := []string{
+		" Updating /path/to/file...",
+		" Applying patch to foo.go...",
+		" Installing dependencies...",
+	}
+	for _, input := range aiderOutputs {
+		// These may or may not match Active - the snapshot test is the real guard.
+		// This test just ensures the detector doesn't panic on such inputs.
+		_ = sd.Detect([]byte(input))
+	}
+}

--- a/session/detection/detector.go
+++ b/session/detection/detector.go
@@ -551,8 +551,8 @@ func getDefaultPatterns() StatusPatterns {
 			},
 			{
 				Name:        "claude_thinking_verb",
-				Pattern:     `(?m)^\*\s+\w+[…\.]{1,3}`,
-				Description: "Claude thinking state with random verb (Moonwalking…, Ebbing..., etc.)",
+				Pattern:     `(?m)^[*✻]\s+\w+[…\.]{1,3}`,
+				Description: "Claude thinking state with random verb -  or ✻ prefix (Moonwalking..., Perambulating..., etc.)",
 				Priority:    26,
 			},
 			{

--- a/session/detection/detector.go
+++ b/session/detection/detector.go
@@ -550,9 +550,12 @@ func getDefaultPatterns() StatusPatterns {
 				Priority:    25,
 			},
 			{
-				Name:        "claude_thinking_verb",
-				Pattern:     `(?m)^[*✻]\s+\w+[…\.]{1,3}`,
-				Description: "Claude thinking state with random verb -  or ✻ prefix (Moonwalking..., Perambulating..., etc.)",
+				Name: "claude_thinking_verb",
+				// Full macOS spinner frame set: · ✢ ✳ ✶ ✻ ✽ (bounce cycle), * (legacy), ● (reduced-motion).
+				// Verb char class extends \w with hyphens (Dilly-dallying), apostrophes (Beboppin'),
+				// and Latin-1 accented chars (Flambéing, Sautéing) — Go RE2 \w = [0-9A-Za-z_] only.
+				Pattern:     `(?m)^[·✢✳✶✻✽●*]\s+[A-Z][a-zA-Z'\-éèêàâùûôîïëüöäÿæœ]*(?:…|\.{1,3})`,
+				Description: "Claude thinking state with random verb — any spinner frame + capitalized verb + ellipsis",
 				Priority:    26,
 			},
 			{

--- a/session/detection/snapshot_test.go
+++ b/session/detection/snapshot_test.go
@@ -122,6 +122,18 @@ var snapshotTests = []snapshotTest{
 		program:     "any",
 		description: "Markdown blockquote with numbered list (> 1. item) — must NOT trigger InputRequired",
 	},
+	{
+		fixture:     "claude_asterism_active.txt",
+		expected:    StatusActive,
+		program:     "claude",
+		description: "Claude Code active with ✻ asterism spinner (✻ Perambulating... format)",
+	},
+	{
+		fixture:     "claude_asterism_success.txt",
+		expected:    StatusSuccess,
+		program:     "claude",
+		description: "Claude Code after ✻ completion line followed by ? for shortcuts (success state in full-text scan)",
+	},
 }
 
 // TestSnapshotDetection runs the detector against each fixture file and

--- a/session/detection/testdata/claude_asterism_active.txt
+++ b/session/detection/testdata/claude_asterism_active.txt
@@ -1,0 +1,5 @@
+✻ Perambulating... (1h 5m 37s · ↑ 5.4k tokens)
+ └ Tip: Use /btw to ask a quick side question without interrupting Claude's current work
+
+> ▌
+esc to interrupt 10% until auto-compact

--- a/session/detection/testdata/claude_asterism_success.txt
+++ b/session/detection/testdata/claude_asterism_success.txt
@@ -1,0 +1,4 @@
+✻ Perambulated for 1h 5m
+
+> ▌
+? for shortcuts

--- a/session/ent_repository_backlog.go
+++ b/session/ent_repository_backlog.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/tstapler/stapler-squad/session/ent"
 	"github.com/tstapler/stapler-squad/session/ent/backlogitem"
+	"github.com/tstapler/stapler-squad/session/ent/backlogstatusevent"
 	"github.com/tstapler/stapler-squad/session/ent/itemsource"
 )
 
@@ -37,6 +38,10 @@ func backlogItemToData(item *ent.BacklogItem) BacklogItemData {
 	// Resolve source ID from the eager-loaded edge when available.
 	if item.Edges.Source != nil {
 		data.SourceID = item.Edges.Source.ID.String()
+	}
+	// Propagate eagerly-loaded status events when present.
+	if item.Edges.StatusEvents != nil {
+		data.StatusEvents = item.Edges.StatusEvents
 	}
 	return data
 }
@@ -111,6 +116,9 @@ func (r *EntRepository) GetBacklogItem(ctx context.Context, id string) (*Backlog
 	item, err := r.client.BacklogItem.Query().
 		Where(backlogitem.ID(parsedID)).
 		WithSource().
+		WithStatusEvents(func(q *ent.BacklogStatusEventQuery) {
+			q.Order(ent.Asc(backlogstatusevent.FieldCreatedAt))
+		}).
 		Only(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
@@ -297,6 +305,18 @@ func (r *EntRepository) TransitionBacklogItemStatus(ctx context.Context, id stri
 		}
 		return nil, fmt.Errorf("failed to transition backlog item %s status: %w", id, err)
 	}
+
+	// Append an immutable audit record for this transition.
+	if _, evErr := r.client.BacklogStatusEvent.Create().
+		SetItemID(parsedID).
+		SetFromStatus(current.Status).
+		SetToStatus(string(toStatus)).
+		SetTriggeredBy(TriggeredBySystem).
+		Save(ctx); evErr != nil {
+		// Non-fatal: audit log failure should not block the transition itself.
+		_ = evErr
+	}
+
 	result := backlogItemToData(item)
 	return &result, nil
 }

--- a/session/instance_tmux.go
+++ b/session/instance_tmux.go
@@ -38,6 +38,9 @@ func (i *Instance) buildLaunchCommand(claudeSessionID string) string {
 	if i.AutoYes && strings.Contains(program, "claude") {
 		program = program + " -y"
 	}
+	if i.OneShot && strings.Contains(program, "claude") {
+		program = program + " -p"
+	}
 	if i.Prompt != "" && claudeSessionID == "" && strings.Contains(program, "claude") {
 		program = fmt.Sprintf("%s %q", program, i.Prompt)
 	}

--- a/session/repository.go
+++ b/session/repository.go
@@ -263,6 +263,9 @@ type BacklogItemData struct {
 	// ItemSessions holds the eagerly-loaded item sessions for this backlog item.
 	// Only populated when explicitly loaded by the caller (e.g. GetBacklogItem).
 	ItemSessions []*ent.ItemSession
+	// StatusEvents holds the eagerly-loaded status transition history.
+	// Only populated when explicitly loaded by the caller (e.g. GetBacklogItem).
+	StatusEvents []*ent.BacklogStatusEvent
 }
 
 // BacklogItemFilter controls which items ListBacklogItems returns.

--- a/session/review_queue_reactive_test.go
+++ b/session/review_queue_reactive_test.go
@@ -1,0 +1,134 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tstapler/stapler-squad/session/detection"
+	"github.com/tstapler/stapler-squad/testutil/wait"
+)
+
+// reactiveTestStatusProvider implements StatusProvider for reactive queue tests.
+type reactiveTestStatusProvider struct {
+	statusByTitle map[string]InstanceStatusInfo
+}
+
+func (m *reactiveTestStatusProvider) GetStatus(inst *Instance) InstanceStatusInfo {
+	if info, ok := m.statusByTitle[inst.Title]; ok {
+		return info
+	}
+	return InstanceStatusInfo{}
+}
+
+func (m *reactiveTestStatusProvider) GetController(title string) (*ClaudeController, bool) {
+	return nil, false
+}
+
+// TestReactiveQueueManager_StatusChange_AddsToQueue verifies that CheckSession
+// adds an idle session to the review queue immediately (AC-4).
+func TestReactiveQueueManager_StatusChange_AddsToQueue(t *testing.T) {
+	t.Parallel()
+
+	queue := NewReviewQueue()
+	statusProvider := &reactiveTestStatusProvider{
+		statusByTitle: make(map[string]InstanceStatusInfo),
+	}
+
+	cfg := DefaultReviewQueuePollerConfig()
+	cfg.PollInterval = 50 * time.Millisecond
+	cfg.SlowPollInterval = 100 * time.Millisecond
+	cfg.IdleThreshold = 10 * time.Millisecond
+
+	poller := NewReviewQueuePollerWithConfig(queue, statusProvider, nil, cfg)
+
+	inst := &Instance{
+		Title:  "reactive-test",
+		Status: Active,
+	}
+	inst.started = true
+	inst.LastMeaningfulOutput = time.Now().Add(-10 * time.Second)
+
+	poller.AddInstance(inst)
+
+	idleContent := "✻ Perambulated for 1h 5m\n\n> ▌\n? for shortcuts"
+	poller.injectCachedContent(inst.Title, idleContent)
+
+	statusProvider.statusByTitle[inst.Title] = InstanceStatusInfo{
+		BasicStatus:        Active,
+		IsControllerActive: false,
+		ClaudeStatus:       detection.StatusIdle,
+	}
+
+	poller.CheckSession(inst)
+
+	err := wait.WaitForCondition(func() bool {
+		_, exists := queue.Get(inst.Title)
+		return exists
+	}, wait.WaitConfig{
+		Timeout:      200 * time.Millisecond,
+		PollInterval: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Errorf("session not added to review queue within 200ms after CheckSession call: %v", err)
+	}
+}
+
+// TestReactiveQueueManager_ActiveSession_RemovedFromQueue verifies that a session
+// with active content and recent user response is removed from the queue (AC-4 / UR-5).
+func TestReactiveQueueManager_ActiveSession_RemovedFromQueue(t *testing.T) {
+	t.Parallel()
+
+	queue := NewReviewQueue()
+	statusProvider := &reactiveTestStatusProvider{
+		statusByTitle: make(map[string]InstanceStatusInfo),
+	}
+
+	cfg := DefaultReviewQueuePollerConfig()
+	cfg.PollInterval = 50 * time.Millisecond
+	poller := NewReviewQueuePollerWithConfig(queue, statusProvider, nil, cfg)
+
+	inst := &Instance{
+		Title:  "active-test",
+		Status: Active,
+	}
+	inst.started = true
+	inst.LastMeaningfulOutput = time.Now()
+
+	queue.Add(&ReviewItem{
+		SessionID:    inst.Title,
+		SessionName:  inst.Title,
+		Reason:       ReasonIdleTimeout,
+		Priority:     PriorityLow,
+		DetectedAt:   time.Now().Add(-1 * time.Minute),
+		LastActivity: time.Now().Add(-1 * time.Minute),
+	})
+
+	poller.AddInstance(inst)
+
+	activeContent := "✻ Perambulating... (30s · ↑ 1.2k tokens)\n\n> ▌\nesc to interrupt"
+	poller.injectCachedContent(inst.Title, activeContent)
+
+	inst.LastUserResponse = time.Now().Add(-100 * time.Millisecond)
+
+	statusProvider.statusByTitle[inst.Title] = InstanceStatusInfo{
+		BasicStatus:        Active,
+		IsControllerActive: true,
+		ClaudeStatus:       detection.StatusActive,
+		IdleState: detection.IdleStateInfo{
+			State: detection.IdleStateActive,
+		},
+	}
+
+	poller.CheckSession(inst)
+
+	err := wait.WaitForCondition(func() bool {
+		_, exists := queue.Get(inst.Title)
+		return !exists
+	}, wait.WaitConfig{
+		Timeout:      200 * time.Millisecond,
+		PollInterval: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Errorf("active session not removed from review queue within 200ms after CheckSession call: %v", err)
+	}
+}

--- a/web-app/src/app/backlog/backlog.css.ts
+++ b/web-app/src/app/backlog/backlog.css.ts
@@ -153,7 +153,9 @@ export const listPane = style({
 });
 
 export const detailPane = style({
-  width: "420px",
+  // width is set via inline style (resizable)
+  minWidth: "240px",
+  maxWidth: "800px",
   borderLeft: `1px solid ${vars.color.borderColor}`,
   flexShrink: 0,
   overflow: "hidden",
@@ -163,7 +165,7 @@ export const detailPane = style({
     "(max-width: 768px)": {
       position: "fixed",
       inset: 0,
-      width: "100%",
+      width: "100% !important" as "inherit",
       zIndex: "500",
       background: vars.color.modalBackground,
     },
@@ -288,7 +290,7 @@ export const modalBox = style({
   borderRadius: vars.radii.lg,
   padding: vars.space["6"],
   width: "100%",
-  maxWidth: "580px",
+  maxWidth: "720px",
   maxHeight: "90vh",
   overflowY: "auto",
   boxShadow: vars.shadow.lg,

--- a/web-app/src/app/backlog/page.tsx
+++ b/web-app/src/app/backlog/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 // +feature: backlog:list-page
 
-import { useState, useEffect, useCallback, Suspense } from "react";
+import { useState, useEffect, useCallback, useRef, Suspense } from "react";
+import { resizeHandle as resizeHandleCss } from "@/styles/pane/resizeHandle.css";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAnalytics } from "@/lib/analytics";
 import { usePageView } from "@/lib/analytics/usePageView";
@@ -167,6 +168,27 @@ function BacklogPageInner() {
   // Sort
   const [sortCol, setSortCol] = useState<SortColumn>("updatedAt");
   const [sortAsc, setSortAsc] = useState(false);
+
+  // Detail pane resize
+  const [detailWidth, setDetailWidth] = useState(420);
+  const dragRef = useRef({ active: false, startX: 0, startWidth: 0 });
+
+  const handleResizePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
+    dragRef.current = { active: true, startX: e.clientX, startWidth: detailWidth };
+  }, [detailWidth]);
+
+  const handleResizePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current.active) return;
+    const delta = dragRef.current.startX - e.clientX;
+    setDetailWidth(Math.max(240, Math.min(800, dragRef.current.startWidth + delta)));
+  }, []);
+
+  const handleResizePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    dragRef.current.active = false;
+    (e.currentTarget as HTMLDivElement).releasePointerCapture(e.pointerId);
+  }, []);
 
   // New-item modal
   const [showForm, setShowForm] = useState(false);
@@ -422,12 +444,27 @@ function BacklogPageInner() {
 
         {/* Detail pane */}
         {selectedItemId && (
-          <aside className={styles.detailPane} aria-label="Item detail">
-            <BacklogItemDetail
-              itemId={selectedItemId}
-              onClose={handleDetailClose}
+          <>
+            <div
+              className={resizeHandleCss({ direction: "vertical" })}
+              style={{ touchAction: "none" }}
+              aria-label="Resize detail panel"
+              onPointerDown={handleResizePointerDown}
+              onPointerMove={handleResizePointerMove}
+              onPointerUp={handleResizePointerUp}
+              onPointerCancel={handleResizePointerUp}
             />
-          </aside>
+            <aside
+              className={styles.detailPane}
+              style={{ width: detailWidth }}
+              aria-label="Item detail"
+            >
+              <BacklogItemDetail
+                itemId={selectedItemId}
+                onClose={handleDetailClose}
+              />
+            </aside>
+          </>
         )}
       </div>
 

--- a/web-app/src/components/backlog/BacklogItemDetail.css.ts
+++ b/web-app/src/components/backlog/BacklogItemDetail.css.ts
@@ -386,6 +386,59 @@ export const artifactsPath = style({
   wordBreak: "break-all",
 });
 
+export const workflowTimeline = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: 0,
+  paddingLeft: vars.space["2"],
+  borderLeft: `2px solid ${vars.color.borderSubtle}`,
+});
+
+export const workflowEvent = style({
+  display: "flex",
+  alignItems: "baseline",
+  gap: vars.space["3"],
+  padding: `${vars.space["1"]} ${vars.space["2"]}`,
+  position: "relative",
+  fontSize: vars.fontSize.sm,
+  "::before": {
+    content: '""',
+    position: "absolute",
+    left: `calc(-1 * ${vars.space["2"]} - 1px)`,
+    top: "50%",
+    transform: "translateY(-50%)",
+    width: "8px",
+    height: "8px",
+    borderRadius: "50%",
+    background: vars.color.borderSubtle,
+    border: `2px solid ${vars.color.modalBackground}`,
+  },
+});
+
+export const workflowEventFrom = style({
+  color: vars.color.textMuted,
+  fontSize: vars.fontSize.xs,
+  flexShrink: 0,
+});
+
+export const workflowEventArrow = style({
+  color: vars.color.textMuted,
+  flexShrink: 0,
+});
+
+export const workflowEventTo = style({
+  fontWeight: 600,
+  color: vars.color.textPrimary,
+  flexShrink: 0,
+});
+
+export const workflowEventMeta = style({
+  marginLeft: "auto",
+  color: vars.color.textMuted,
+  fontSize: vars.fontSize.xs,
+  whiteSpace: "nowrap",
+});
+
 export const loadingState = style({
   display: "flex",
   alignItems: "center",
@@ -393,6 +446,63 @@ export const loadingState = style({
   padding: vars.space["12"],
   color: vars.color.textMuted,
   fontSize: vars.fontSize.sm,
+});
+
+export const planSummary = style({
+  fontSize: vars.fontSize.sm,
+  color: vars.color.textSecondary,
+  lineHeight: "1.6",
+  marginBottom: vars.space["3"],
+});
+
+export const planTaskList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: vars.space["1"],
+  marginTop: vars.space["2"],
+});
+
+export const planTask = style({
+  display: "flex",
+  alignItems: "baseline",
+  gap: vars.space["2"],
+  fontSize: vars.fontSize.sm,
+  padding: `${vars.space["1"]} 0`,
+  borderBottom: `1px solid ${vars.color.borderSubtle}`,
+  selectors: {
+    "&:last-child": {
+      borderBottom: "none",
+    },
+  },
+});
+
+export const planTaskText = style({
+  flex: 1,
+  color: vars.color.textPrimary,
+});
+
+export const planTaskMeta = style({
+  display: "flex",
+  gap: vars.space["2"],
+  flexShrink: 0,
+});
+
+export const planTaskBadge = style({
+  fontSize: vars.fontSize.xs,
+  padding: `2px ${vars.space["2"]}`,
+  borderRadius: vars.radii.sm,
+  background: vars.color.hoverBackground,
+  color: vars.color.textMuted,
+  whiteSpace: "nowrap",
+});
+
+export const sessionEndedBadge = style({
+  fontSize: vars.fontSize.xs,
+  padding: `1px ${vars.space["1"]}`,
+  borderRadius: vars.radii.sm,
+  background: vars.color.hoverBackground,
+  color: vars.color.textMuted,
+  marginLeft: vars.space["2"],
 });
 
 export const errorState = style({

--- a/web-app/src/components/backlog/BacklogItemDetail.tsx
+++ b/web-app/src/components/backlog/BacklogItemDetail.tsx
@@ -468,7 +468,7 @@ export function BacklogItemDetail({ itemId, onClose }: BacklogItemDetailProps) {
           </div>
         )}
 
-        {/* Triage Review Panel */}
+        {/* Triage Review Panel — only shown while still in idea status */}
         {item.triageStatus === "completed" &&
           item.status === "idea" &&
           item.triageResult && (
@@ -482,6 +482,27 @@ export function BacklogItemDetail({ itemId, onClose }: BacklogItemDetailProps) {
               />
             </div>
           )}
+
+        {/* Planning record — read-only triage result for items past idea status */}
+        {item.triageResult && item.status !== "idea" && (
+          <div className={styles.section}>
+            <h3 className={styles.sectionTitle}>Planning</h3>
+            <p className={styles.planSummary}>{item.triageResult.summary}</p>
+            {item.triageResult.tasks && item.triageResult.tasks.length > 0 && (
+              <div className={styles.planTaskList}>
+                {item.triageResult.tasks.map((t, i) => (
+                  <div key={i} className={styles.planTask}>
+                    <span className={styles.planTaskText}>{t.text}</span>
+                    <span className={styles.planTaskMeta}>
+                      {t.estimate && <span className={styles.planTaskBadge}>{t.estimate}</span>}
+                      {t.category && <span className={styles.planTaskBadge}>{t.category}</span>}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Triage failed banner */}
         {item.triageStatus === "failed" && item.status === "idea" && (
@@ -543,16 +564,14 @@ export function BacklogItemDetail({ itemId, onClose }: BacklogItemDetailProps) {
                 >
                   Mark Ready
                 </button>
-                {item.triageStatus !== "running" && (
-                  <button
-                    className={styles.actionButton}
-                    onClick={() => handleAction("trigger_triage")}
-                    disabled={actionLoading}
-                    data-testid="backlog-action-trigger-triage"
-                  >
-                    Trigger Triage
-                  </button>
-                )}
+                <button
+                  className={styles.actionButton}
+                  onClick={() => handleAction("trigger_triage")}
+                  disabled={actionLoading}
+                  data-testid="backlog-action-trigger-triage"
+                >
+                  Trigger Triage
+                </button>
               </>
             )}
 
@@ -660,38 +679,82 @@ export function BacklogItemDetail({ itemId, onClose }: BacklogItemDetailProps) {
           <div className={styles.section}>
             <h3 className={styles.sectionTitle}>Sessions ({item.linkedSessions.length})</h3>
             <div className={styles.sessionList} role="list" aria-label="Linked sessions">
-              {item.linkedSessions.map((s) => (
-                <a
-                  key={s.sessionId}
-                  className={styles.sessionRow}
-                  href={`/?session=${s.sessionId}`}
-                  role="listitem"
-                  title="Open in terminal"
-                  style={{ textDecoration: "none" }}
-                >
-                  <span className={styles.sessionId} title={s.sessionId}>
-                    {s.sessionId}
-                  </span>
-                  <span className={styles.sessionRole}>{s.role}</span>
-                  {s.startedAt && (
-                    <span className={styles.sessionDate}>{formatDate(s.startedAt)}</span>
-                  )}
-                </a>
-              ))}
+              {item.linkedSessions.map((s) => {
+                // A session without endedAt that isn't in the active phase for this
+                // item's current status is a stale/orphaned record — label it ended.
+                const statusToRole: Record<string, string> = {
+                  idea: "triage",
+                  in_progress: "work",
+                  review: "review",
+                };
+                const isOrphan = !s.endedAt && s.role !== statusToRole[item.status];
+                return (
+                  <a
+                    key={s.sessionId}
+                    className={styles.sessionRow}
+                    href={`/?session=${s.sessionId}`}
+                    role="listitem"
+                    title="Open in terminal"
+                    style={{ textDecoration: "none" }}
+                  >
+                    <span className={styles.sessionId} title={s.sessionId}>
+                      {s.sessionId}
+                    </span>
+                    <span className={styles.sessionRole}>{s.role}</span>
+                    {s.startedAt && (
+                      <span className={styles.sessionDate}>{formatDate(s.startedAt)}</span>
+                    )}
+                    {isOrphan && (
+                      <span className={styles.sessionEndedBadge}>ended</span>
+                    )}
+                  </a>
+                );
+              })}
             </div>
 
-            {/* Session monitor for the most recent active session */}
+            {/* Session monitor for the most recent active session.
+                A session is only considered active if the item is in the
+                matching lifecycle phase — prevents ghost "RUNNING" tiles for
+                sessions that died without setting endedAt. */}
             {(() => {
-              const active = [...item.linkedSessions].reverse().find((s) => !s.endedAt);
+              const statusToRole: Record<string, string> = {
+                idea: "triage",
+                in_progress: "work",
+                review: "review",
+              };
+              const expectedRole = statusToRole[item.status];
+              const active = [...item.linkedSessions]
+                .reverse()
+                .find((s) => !s.endedAt && s.role === expectedRole);
               if (!active) return null;
               return (
                 <SessionMonitor
                   sessionId={active.sessionId}
                   sessionRole={active.role}
-                  isRunning={!active.endedAt}
+                  isRunning={true}
                 />
               );
             })()}
+          </div>
+        )}
+
+        {/* Workflow / Status History */}
+        {item.statusEvents.length > 0 && (
+          <div className={styles.section}>
+            <h3 className={styles.sectionTitle}>Workflow</h3>
+            <div className={styles.workflowTimeline} role="list" aria-label="Status history">
+              {item.statusEvents.map((ev) => (
+                <div key={ev.id} className={styles.workflowEvent} role="listitem">
+                  <span className={styles.workflowEventFrom}>{ev.fromStatus.replace("_", " ")}</span>
+                  <span className={styles.workflowEventArrow}>→</span>
+                  <span className={styles.workflowEventTo}>{ev.toStatus.replace("_", " ")}</span>
+                  <span className={styles.workflowEventMeta}>
+                    {ev.createdAt ? formatDate(ev.createdAt) : ""}
+                    {ev.triggeredBy === "user" ? " · user" : ""}
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
         )}
 

--- a/web-app/src/components/backlog/BacklogItemForm.css.ts
+++ b/web-app/src/components/backlog/BacklogItemForm.css.ts
@@ -254,7 +254,7 @@ export const errorMessage = style({
 
 export const twoColumn = style({
   display: "grid",
-  gridTemplateColumns: "1fr 1fr",
+  gridTemplateColumns: "2fr 1fr",
   gap: vars.space["3"],
   "@media": {
     "(max-width: 480px)": {

--- a/web-app/src/components/backlog/TriageReviewPanel.test.tsx
+++ b/web-app/src/components/backlog/TriageReviewPanel.test.tsx
@@ -39,6 +39,7 @@ function makeItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
     planApproved: false,
     acCriteria: [],
     linkedSessions: [],
+    statusEvents: [],
     triageStatus: "completed",
     triageResult: TRIAGE_RESULT_WITH_SUGGESTIONS,
     ...overrides,

--- a/web-app/src/components/sessions/PathCompletionDropdown.tsx
+++ b/web-app/src/components/sessions/PathCompletionDropdown.tsx
@@ -49,6 +49,7 @@ function EntryItem({
         .join(" ")}
       role="option"
       aria-selected={index === selectedIndex}
+      title={entry.path}
       onMouseDown={(e) => {
         e.preventDefault();
         onSelect(entry);

--- a/web-app/src/components/ui/RepoPathInput.css.ts
+++ b/web-app/src/components/ui/RepoPathInput.css.ts
@@ -19,6 +19,7 @@ export const input = style({
   outline: "none",
   transition: "border-color 0.15s ease",
   boxSizing: "border-box",
+  textOverflow: "ellipsis",
   ":focus": {
     borderColor: vars.color.inputFocusBorder,
     boxShadow: `0 0 0 2px ${vars.color.accentBg}`,

--- a/web-app/src/components/ui/RepoPathInput.tsx
+++ b/web-app/src/components/ui/RepoPathInput.tsx
@@ -19,6 +19,11 @@ interface RepoPathInputProps {
 
 const MAX_HISTORY = 5;
 
+function tildeAbbreviate(p: string): string {
+  const m = p.match(/^(\/(?:Users|home)\/[^/]+)(\/.*)?$/);
+  return m ? `~${m[2] ?? ""}` : p;
+}
+
 export function RepoPathInput({
   id: idProp,
   value,
@@ -51,7 +56,7 @@ export function RepoPathInput({
     const historySet = new Set(history);
 
     const historyEntries: CompletionEntry[] = history.map((p) => ({
-      name: p,
+      name: tildeAbbreviate(p),
       path: p,
       isDirectory: true,
       isHistory: true,
@@ -141,6 +146,7 @@ export function RepoPathInput({
         onFocus={() => setOpen(true)}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
+        title={value || undefined}
         required={required}
         aria-required={required || undefined}
         aria-invalid={error ? true : undefined}

--- a/web-app/src/gen/session/v1/backlog_pb.ts
+++ b/web-app/src/gen/session/v1/backlog_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file session/v1/backlog.proto.
  */
 export const file_session_v1_backlog: GenFile = /*@__PURE__*/
-  fileDesc("ChhzZXNzaW9uL3YxL2JhY2tsb2cucHJvdG8SCnNlc3Npb24udjEiOgoLQWNDcml0ZXJpb24SDQoFaW5kZXgYASABKAUSDAoEdGV4dBgCIAEoCRIOCgZzdGF0dXMYAyABKAkiTgoQQ3JpdGVyaW9uVmVyZGljdBIXCg9jcml0ZXJpb25faW5kZXgYASABKAUSDwoHb3V0Y29tZRgCIAEoCRIQCghldmlkZW5jZRgDIAEoCSLOAgoNUmV2aWV3VmVyZGljdBIKCgJpZBgBIAEoCRIXCg9vdmVyYWxsX291dGNvbWUYAiABKAkSMwoNcGVyX2NyaXRlcmlvbhgDIAMoCzIcLnNlc3Npb24udjEuQ3JpdGVyaW9uVmVyZGljdBIPCgdzdW1tYXJ5GAQgASgJEhEKCWRpZmZfaGFzaBgFIAEoCRIYChBkaWZmX3Rva2VuX2NvdW50GAYgASgFEhYKDmRpZmZfdHJ1bmNhdGVkGAcgASgIEhMKC292ZXJyaWRlX2J5GAggASgJEhcKD292ZXJyaWRlX3JlYXNvbhgJIAEoCRIvCgtvdmVycmlkZV9hdBgKIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKY3JlYXRlZF9hdBgLIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiMwoQVHJpYWdlU3VnZ2VzdGlvbhIMCgR0ZXh0GAEgASgJEhEKCXJhdGlvbmFsZRgCIAEoCSI+CgpUcmlhZ2VUYXNrEgwKBHRleHQYASABKAkSEAoIZXN0aW1hdGUYAiABKAkSEAoIY2F0ZWdvcnkYAyABKAkilwEKDFRyaWFnZVJlc3VsdBIPCgdzdW1tYXJ5GAEgASgJEjEKC3N1Z2dlc3Rpb25zGAIgAygLMhwuc2Vzc2lvbi52MS5UcmlhZ2VTdWdnZXN0aW9uEhwKFGNsYXJpZnlpbmdfcXVlc3Rpb25zGAMgAygJEiUKBXRhc2tzGAQgAygLMhYuc2Vzc2lvbi52MS5UcmlhZ2VUYXNrIuIDCgtJdGVtU2Vzc2lvbhIKCgJpZBgBIAEoCRIUCgxzZXNzaW9uX3V1aWQYAiABKAkSFAoMc2Vzc2lvbl9yb2xlGAMgASgJEi4KCnN0YXJ0ZWRfYXQYBCABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEiwKCGVuZGVkX2F0GAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIbChNsYXN0X2NvbW1pdF9tZXNzYWdlGAYgASgJEjIKDmxhc3RfY29tbWl0X2F0GAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIgChhjb21taXRfY291bnRfc2luY2Vfc3Bhd24YCCABKAUSNgoSbGFzdF9maWxlX3RvdWNoX2F0GAkgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIuCgpjcmVhdGVkX2F0GAogASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIxCg5yZXZpZXdfdmVyZGljdBgLIAEoCzIZLnNlc3Npb24udjEuUmV2aWV3VmVyZGljdBIvCg10cmlhZ2VfcmVzdWx0GAwgASgLMhguc2Vzc2lvbi52MS5UcmlhZ2VSZXN1bHQiuwQKC0JhY2tsb2dJdGVtEgoKAmlkGAEgASgJEg0KBXRpdGxlGAIgASgJEhMKC2Rlc2NyaXB0aW9uGAMgASgJEjQKE2FjY2VwdGFuY2VfY3JpdGVyaWEYBCADKAsyFy5zZXNzaW9uLnYxLkFjQ3JpdGVyaW9uEhAKCHByaW9yaXR5GAUgASgFEg4KBnN0YXR1cxgGIAEoCRIRCglyZXBvX3BhdGgYByABKAkSGAoQc2tpcF9yZXZpZXdfZ2F0ZRgIIAEoCBIVCg1za2lwX3BsYW5uaW5nGAkgASgIEhUKDXBsYW5fYXBwcm92ZWQYCiABKAgSNAoQcGxhbl9hcHByb3ZlZF9hdBgLIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASGwoTcGxhbl9hcnRpZmFjdHNfcGF0aBgMIAEoCRINCgVub3RlcxgNIAEoCRITCgtleHRlcm5hbF9pZBgOIAEoCRIvCgthcmNoaXZlZF9hdBgPIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKY3JlYXRlZF9hdBgQIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKdXBkYXRlZF9hdBgRIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoNaXRlbV9zZXNzaW9ucxgSIAMoCzIXLnNlc3Npb24udjEuSXRlbVNlc3Npb24SEQoJc291cmNlX2lkGBMgASgJIoACCgpJdGVtU291cmNlEgoKAmlkGAEgASgJEhEKCXBsdWdpbl9pZBgCIAEoCRIUCgxkaXNwbGF5X25hbWUYAyABKAkSDwoHZW5hYmxlZBgEIAEoCBIyCg5sYXN0X3N5bmNlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASGAoQdG9rZW5fY29uZmlndXJlZBgGIAEoCBIuCgpjcmVhdGVkX2F0GAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIuCgp1cGRhdGVkX2F0GAggASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCLxAQoPU291cmNlU3luY0V2ZW50EgoKAmlkGAEgASgJEi4KCnN0YXJ0ZWRfYXQYAiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEi8KC2ZpbmlzaGVkX2F0GAMgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIVCg1pdGVtc19jcmVhdGVkGAQgASgFEhUKDWl0ZW1zX3VwZGF0ZWQYBSABKAUSFQoNaXRlbXNfc2tpcHBlZBgGIAEoBRIVCg1pdGVtc19lcnJvcmVkGAcgASgFEhUKDWVycm9yX21lc3NhZ2UYCCABKAki7gEKGENyZWF0ZUJhY2tsb2dJdGVtUmVxdWVzdBINCgV0aXRsZRgBIAEoCRITCgtkZXNjcmlwdGlvbhgCIAEoCRI0ChNhY2NlcHRhbmNlX2NyaXRlcmlhGAMgAygLMhcuc2Vzc2lvbi52MS5BY0NyaXRlcmlvbhIQCghwcmlvcml0eRgEIAEoBRIYChBza2lwX3Jldmlld19nYXRlGAUgASgIEhUKDXNraXBfcGxhbm5pbmcYBiABKAgSEQoJcmVwb19wYXRoGAcgASgJEg0KBW5vdGVzGAggASgJEhMKC3NraXBfdHJpYWdlGAkgASgIIlwKGUNyZWF0ZUJhY2tsb2dJdGVtUmVzcG9uc2USJQoEaXRlbRgBIAEoCzIXLnNlc3Npb24udjEuQmFja2xvZ0l0ZW0SGAoQdHJpYWdlX3RyaWdnZXJlZBgCIAEoCCIoChVHZXRCYWNrbG9nSXRlbVJlcXVlc3QSDwoHaXRlbV9pZBgBIAEoCSI/ChZHZXRCYWNrbG9nSXRlbVJlc3BvbnNlEiUKBGl0ZW0YASABKAsyFy5zZXNzaW9uLnYxLkJhY2tsb2dJdGVtImYKF0xpc3RCYWNrbG9nSXRlbXNSZXF1ZXN0Eg4KBnN0YXR1cxgBIAMoCRIQCghwcmlvcml0eRgCIAMoBRIPCgdzb3J0X2J5GAMgASgJEhgKEGluY2x1ZGVfdGVybWluYWwYBCABKAgiQgoYTGlzdEJhY2tsb2dJdGVtc1Jlc3BvbnNlEiYKBWl0ZW1zGAEgAygLMhcuc2Vzc2lvbi52MS5CYWNrbG9nSXRlbSK8AgoYVXBkYXRlQmFja2xvZ0l0ZW1SZXF1ZXN0Eg8KB2l0ZW1faWQYASABKAkSDQoFdGl0bGUYAiABKAkSEwoLZGVzY3JpcHRpb24YAyABKAkSNAoTYWNjZXB0YW5jZV9jcml0ZXJpYRgEIAMoCzIXLnNlc3Npb24udjEuQWNDcml0ZXJpb24SEAoIcHJpb3JpdHkYBSABKAUSGAoQc2tpcF9yZXZpZXdfZ2F0ZRgGIAEoCBIVCg1za2lwX3BsYW5uaW5nGAcgASgIEhEKCXJlcG9fcGF0aBgIIAEoCRINCgVub3RlcxgJIAEoCRIXCg9leHBlY3RlZF9zdGF0dXMYCiABKAkSNwoTZXhwZWN0ZWRfdXBkYXRlZF9hdBgLIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiQgoZVXBkYXRlQmFja2xvZ0l0ZW1SZXNwb25zZRIlCgRpdGVtGAEgASgLMhcuc2Vzc2lvbi52MS5CYWNrbG9nSXRlbSIsChlBcmNoaXZlQmFja2xvZ0l0ZW1SZXF1ZXN0Eg8KB2l0ZW1faWQYASABKAkiQwoaQXJjaGl2ZUJhY2tsb2dJdGVtUmVzcG9uc2USJQoEaXRlbRgBIAEoCzIXLnNlc3Npb24udjEuQmFja2xvZ0l0ZW0itwEKIlRyYW5zaXRpb25CYWNrbG9nSXRlbVN0YXR1c1JlcXVlc3QSDwoHaXRlbV9pZBgBIAEoCRIVCg10YXJnZXRfc3RhdHVzGAIgASgJEhcKD2V4cGVjdGVkX3N0YXR1cxgDIAEoCRI3ChNleHBlY3RlZF91cGRhdGVkX2F0GAQgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIXCg9vdmVycmlkZV9yZWFzb24YBSABKAkiTAojVHJhbnNpdGlvbkJhY2tsb2dJdGVtU3RhdHVzUmVzcG9uc2USJQoEaXRlbRgBIAEoCzIXLnNlc3Npb24udjEuQmFja2xvZ0l0ZW0iLgobU3Bhd25TZXNzaW9uRnJvbUl0ZW1SZXF1ZXN0Eg8KB2l0ZW1faWQYASABKAkiYwocU3Bhd25TZXNzaW9uRnJvbUl0ZW1SZXNwb25zZRIUCgxzZXNzaW9uX3V1aWQYASABKAkSLQoMaXRlbV9zZXNzaW9uGAIgASgLMhcuc2Vzc2lvbi52MS5JdGVtU2Vzc2lvbiJDChpBdHRhY2hTZXNzaW9uVG9JdGVtUmVxdWVzdBIPCgdpdGVtX2lkGAEgASgJEhQKDHNlc3Npb25fdXVpZBgCIAEoCSJMChtBdHRhY2hTZXNzaW9uVG9JdGVtUmVzcG9uc2USLQoMaXRlbV9zZXNzaW9uGAEgASgLMhcuc2Vzc2lvbi52MS5JdGVtU2Vzc2lvbiInChRUcmlnZ2VyVHJpYWdlUmVxdWVzdBIPCgdpdGVtX2lkGAEgASgJIkYKFVRyaWdnZXJUcmlhZ2VSZXNwb25zZRItCgxpdGVtX3Nlc3Npb24YASABKAsyFy5zZXNzaW9uLnYxLkl0ZW1TZXNzaW9uIiUKEkFwcHJvdmVQbGFuUmVxdWVzdBIPCgdpdGVtX2lkGAEgASgJIjwKE0FwcHJvdmVQbGFuUmVzcG9uc2USJQoEaXRlbRgBIAEoCzIXLnNlc3Npb24udjEuQmFja2xvZ0l0ZW0iGAoWU3VnZ2VzdE5leHRJdGVtUmVxdWVzdCJvChdTdWdnZXN0TmV4dEl0ZW1SZXNwb25zZRItCgxpdGVtX3Nlc3Npb24YASABKAsyFy5zZXNzaW9uLnYxLkl0ZW1TZXNzaW9uEiUKBGl0ZW0YAiABKAsyFy5zZXNzaW9uLnYxLkJhY2tsb2dJdGVtIl0KFk92ZXJyaWRlVmVyZGljdFJlcXVlc3QSFwoPaXRlbV9zZXNzaW9uX2lkGAEgASgJEhEKCXRvX3N0YXR1cxgCIAEoCRIXCg9vdmVycmlkZV9yZWFzb24YAyABKAkiQAoXT3ZlcnJpZGVWZXJkaWN0UmVzcG9uc2USJQoEaXRlbRgBIAEoCzIXLnNlc3Npb24udjEuQmFja2xvZ0l0ZW0iKQoWVHJpZ2dlclJlUmV2aWV3UmVxdWVzdBIPCgdpdGVtX2lkGAEgASgJIkgKF1RyaWdnZXJSZVJldmlld1Jlc3BvbnNlEi0KDGl0ZW1fc2Vzc2lvbhgBIAEoCzIXLnNlc3Npb24udjEuSXRlbVNlc3Npb24iJwoSVHJpZ2dlclN5bmNSZXF1ZXN0EhEKCXNvdXJjZV9pZBgBIAEoCSIVChNUcmlnZ2VyU3luY1Jlc3BvbnNlImYKF0NyZWF0ZUl0ZW1Tb3VyY2VSZXF1ZXN0EhEKCXBsdWdpbl9pZBgBIAEoCRIUCgxkaXNwbGF5X25hbWUYAiABKAkSEwoLY29uZmlnX2pzb24YAyABKAkSDQoFdG9rZW4YBCABKAkiQgoYQ3JlYXRlSXRlbVNvdXJjZVJlc3BvbnNlEiYKBnNvdXJjZRgBIAEoCzIWLnNlc3Npb24udjEuSXRlbVNvdXJjZSIYChZMaXN0SXRlbVNvdXJjZXNSZXF1ZXN0IkIKF0xpc3RJdGVtU291cmNlc1Jlc3BvbnNlEicKB3NvdXJjZXMYASADKAsyFi5zZXNzaW9uLnYxLkl0ZW1Tb3VyY2UiYgoXVXBkYXRlSXRlbVNvdXJjZVJlcXVlc3QSEQoJc291cmNlX2lkGAEgASgJEhQKDGRpc3BsYXlfbmFtZRgCIAEoCRIPCgdlbmFibGVkGAMgASgIEg0KBXRva2VuGAQgASgJIkIKGFVwZGF0ZUl0ZW1Tb3VyY2VSZXNwb25zZRImCgZzb3VyY2UYASABKAsyFi5zZXNzaW9uLnYxLkl0ZW1Tb3VyY2UiLAoXRGVsZXRlSXRlbVNvdXJjZVJlcXVlc3QSEQoJc291cmNlX2lkGAEgASgJIhoKGERlbGV0ZUl0ZW1Tb3VyY2VSZXNwb25zZSIqChVHZXRTeW5jSGlzdG9yeVJlcXVlc3QSEQoJc291cmNlX2lkGAEgASgJIkUKFkdldFN5bmNIaXN0b3J5UmVzcG9uc2USKwoGZXZlbnRzGAEgAygLMhsuc2Vzc2lvbi52MS5Tb3VyY2VTeW5jRXZlbnQyxw4KDkJhY2tsb2dTZXJ2aWNlEmIKEUNyZWF0ZUJhY2tsb2dJdGVtEiQuc2Vzc2lvbi52MS5DcmVhdGVCYWNrbG9nSXRlbVJlcXVlc3QaJS5zZXNzaW9uLnYxLkNyZWF0ZUJhY2tsb2dJdGVtUmVzcG9uc2UiABJZCg5HZXRCYWNrbG9nSXRlbRIhLnNlc3Npb24udjEuR2V0QmFja2xvZ0l0ZW1SZXF1ZXN0GiIuc2Vzc2lvbi52MS5HZXRCYWNrbG9nSXRlbVJlc3BvbnNlIgASXwoQTGlzdEJhY2tsb2dJdGVtcxIjLnNlc3Npb24udjEuTGlzdEJhY2tsb2dJdGVtc1JlcXVlc3QaJC5zZXNzaW9uLnYxLkxpc3RCYWNrbG9nSXRlbXNSZXNwb25zZSIAEmIKEVVwZGF0ZUJhY2tsb2dJdGVtEiQuc2Vzc2lvbi52MS5VcGRhdGVCYWNrbG9nSXRlbVJlcXVlc3QaJS5zZXNzaW9uLnYxLlVwZGF0ZUJhY2tsb2dJdGVtUmVzcG9uc2UiABJlChJBcmNoaXZlQmFja2xvZ0l0ZW0SJS5zZXNzaW9uLnYxLkFyY2hpdmVCYWNrbG9nSXRlbVJlcXVlc3QaJi5zZXNzaW9uLnYxLkFyY2hpdmVCYWNrbG9nSXRlbVJlc3BvbnNlIgASgAEKG1RyYW5zaXRpb25CYWNrbG9nSXRlbVN0YXR1cxIuLnNlc3Npb24udjEuVHJhbnNpdGlvbkJhY2tsb2dJdGVtU3RhdHVzUmVxdWVzdBovLnNlc3Npb24udjEuVHJhbnNpdGlvbkJhY2tsb2dJdGVtU3RhdHVzUmVzcG9uc2UiABJrChRTcGF3blNlc3Npb25Gcm9tSXRlbRInLnNlc3Npb24udjEuU3Bhd25TZXNzaW9uRnJvbUl0ZW1SZXF1ZXN0Giguc2Vzc2lvbi52MS5TcGF3blNlc3Npb25Gcm9tSXRlbVJlc3BvbnNlIgASaAoTQXR0YWNoU2Vzc2lvblRvSXRlbRImLnNlc3Npb24udjEuQXR0YWNoU2Vzc2lvblRvSXRlbVJlcXVlc3QaJy5zZXNzaW9uLnYxLkF0dGFjaFNlc3Npb25Ub0l0ZW1SZXNwb25zZSIAElYKDVRyaWdnZXJUcmlhZ2USIC5zZXNzaW9uLnYxLlRyaWdnZXJUcmlhZ2VSZXF1ZXN0GiEuc2Vzc2lvbi52MS5UcmlnZ2VyVHJpYWdlUmVzcG9uc2UiABJQCgtBcHByb3ZlUGxhbhIeLnNlc3Npb24udjEuQXBwcm92ZVBsYW5SZXF1ZXN0Gh8uc2Vzc2lvbi52MS5BcHByb3ZlUGxhblJlc3BvbnNlIgASXAoPU3VnZ2VzdE5leHRJdGVtEiIuc2Vzc2lvbi52MS5TdWdnZXN0TmV4dEl0ZW1SZXF1ZXN0GiMuc2Vzc2lvbi52MS5TdWdnZXN0TmV4dEl0ZW1SZXNwb25zZSIAElwKD092ZXJyaWRlVmVyZGljdBIiLnNlc3Npb24udjEuT3ZlcnJpZGVWZXJkaWN0UmVxdWVzdBojLnNlc3Npb24udjEuT3ZlcnJpZGVWZXJkaWN0UmVzcG9uc2UiABJcCg9UcmlnZ2VyUmVSZXZpZXcSIi5zZXNzaW9uLnYxLlRyaWdnZXJSZVJldmlld1JlcXVlc3QaIy5zZXNzaW9uLnYxLlRyaWdnZXJSZVJldmlld1Jlc3BvbnNlIgASUAoLVHJpZ2dlclN5bmMSHi5zZXNzaW9uLnYxLlRyaWdnZXJTeW5jUmVxdWVzdBofLnNlc3Npb24udjEuVHJpZ2dlclN5bmNSZXNwb25zZSIAEl8KEENyZWF0ZUl0ZW1Tb3VyY2USIy5zZXNzaW9uLnYxLkNyZWF0ZUl0ZW1Tb3VyY2VSZXF1ZXN0GiQuc2Vzc2lvbi52MS5DcmVhdGVJdGVtU291cmNlUmVzcG9uc2UiABJcCg9MaXN0SXRlbVNvdXJjZXMSIi5zZXNzaW9uLnYxLkxpc3RJdGVtU291cmNlc1JlcXVlc3QaIy5zZXNzaW9uLnYxLkxpc3RJdGVtU291cmNlc1Jlc3BvbnNlIgASXwoQVXBkYXRlSXRlbVNvdXJjZRIjLnNlc3Npb24udjEuVXBkYXRlSXRlbVNvdXJjZVJlcXVlc3QaJC5zZXNzaW9uLnYxLlVwZGF0ZUl0ZW1Tb3VyY2VSZXNwb25zZSIAEl8KEERlbGV0ZUl0ZW1Tb3VyY2USIy5zZXNzaW9uLnYxLkRlbGV0ZUl0ZW1Tb3VyY2VSZXF1ZXN0GiQuc2Vzc2lvbi52MS5EZWxldGVJdGVtU291cmNlUmVzcG9uc2UiABJZCg5HZXRTeW5jSGlzdG9yeRIhLnNlc3Npb24udjEuR2V0U3luY0hpc3RvcnlSZXF1ZXN0GiIuc2Vzc2lvbi52MS5HZXRTeW5jSGlzdG9yeVJlc3BvbnNlIgBCrAEKDmNvbS5zZXNzaW9uLnYxQgxCYWNrbG9nUHJvdG9QAVpDZ2l0aHViLmNvbS90c3RhcGxlci9zdGFwbGVyLXNxdWFkL2dlbi9wcm90by9nby9zZXNzaW9uL3YxO3Nlc3Npb252MaICA1NYWKoCClNlc3Npb24uVjHKAgpTZXNzaW9uXFYx4gIWU2Vzc2lvblxWMVxHUEJNZXRhZGF0YeoCC1Nlc3Npb246OlYxYgZwcm90bzM", [file_google_protobuf_timestamp]);
+  fileDesc("ChhzZXNzaW9uL3YxL2JhY2tsb2cucHJvdG8SCnNlc3Npb24udjEiOgoLQWNDcml0ZXJpb24SDQoFaW5kZXgYASABKAUSDAoEdGV4dBgCIAEoCRIOCgZzdGF0dXMYAyABKAkiTgoQQ3JpdGVyaW9uVmVyZGljdBIXCg9jcml0ZXJpb25faW5kZXgYASABKAUSDwoHb3V0Y29tZRgCIAEoCRIQCghldmlkZW5jZRgDIAEoCSLOAgoNUmV2aWV3VmVyZGljdBIKCgJpZBgBIAEoCRIXCg9vdmVyYWxsX291dGNvbWUYAiABKAkSMwoNcGVyX2NyaXRlcmlvbhgDIAMoCzIcLnNlc3Npb24udjEuQ3JpdGVyaW9uVmVyZGljdBIPCgdzdW1tYXJ5GAQgASgJEhEKCWRpZmZfaGFzaBgFIAEoCRIYChBkaWZmX3Rva2VuX2NvdW50GAYgASgFEhYKDmRpZmZfdHJ1bmNhdGVkGAcgASgIEhMKC292ZXJyaWRlX2J5GAggASgJEhcKD292ZXJyaWRlX3JlYXNvbhgJIAEoCRIvCgtvdmVycmlkZV9hdBgKIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoKY3JlYXRlZF9hdBgLIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiMwoQVHJpYWdlU3VnZ2VzdGlvbhIMCgR0ZXh0GAEgASgJEhEKCXJhdGlvbmFsZRgCIAEoCSI+CgpUcmlhZ2VUYXNrEgwKBHRleHQYASABKAkSEAoIZXN0aW1hdGUYAiABKAkSEAoIY2F0ZWdvcnkYAyABKAkilwEKDFRyaWFnZVJlc3VsdBIPCgdzdW1tYXJ5GAEgASgJEjEKC3N1Z2dlc3Rpb25zGAIgAygLMhwuc2Vzc2lvbi52MS5UcmlhZ2VTdWdnZXN0aW9uEhwKFGNsYXJpZnlpbmdfcXVlc3Rpb25zGAMgAygJEiUKBXRhc2tzGAQgAygLMhYuc2Vzc2lvbi52MS5UcmlhZ2VUYXNrIuIDCgtJdGVtU2Vzc2lvbhIKCgJpZBgBIAEoCRIUCgxzZXNzaW9uX3V1aWQYAiABKAkSFAoMc2Vzc2lvbl9yb2xlGAMgASgJEi4KCnN0YXJ0ZWRfYXQYBCABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEiwKCGVuZGVkX2F0GAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIbChNsYXN0X2NvbW1pdF9tZXNzYWdlGAYgASgJEjIKDmxhc3RfY29tbWl0X2F0GAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIgChhjb21taXRfY291bnRfc2luY2Vfc3Bhd24YCCABKAUSNgoSbGFzdF9maWxlX3RvdWNoX2F0GAkgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIuCgpjcmVhdGVkX2F0GAogASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIxCg5yZXZpZXdfdmVyZGljdBgLIAEoCzIZLnNlc3Npb24udjEuUmV2aWV3VmVyZGljdBIvCg10cmlhZ2VfcmVzdWx0GAwgASgLMhguc2Vzc2lvbi52MS5UcmlhZ2VSZXN1bHQijgEKEkJhY2tsb2dTdGF0dXNFdmVudBIKCgJpZBgBIAEoCRITCgtmcm9tX3N0YXR1cxgCIAEoCRIRCgl0b19zdGF0dXMYAyABKAkSFAoMdHJpZ2dlcmVkX2J5GAQgASgJEi4KCmNyZWF0ZWRfYXQYBSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIvIECgtCYWNrbG9nSXRlbRIKCgJpZBgBIAEoCRINCgV0aXRsZRgCIAEoCRITCgtkZXNjcmlwdGlvbhgDIAEoCRI0ChNhY2NlcHRhbmNlX2NyaXRlcmlhGAQgAygLMhcuc2Vzc2lvbi52MS5BY0NyaXRlcmlvbhIQCghwcmlvcml0eRgFIAEoBRIOCgZzdGF0dXMYBiABKAkSEQoJcmVwb19wYXRoGAcgASgJEhgKEHNraXBfcmV2aWV3X2dhdGUYCCABKAgSFQoNc2tpcF9wbGFubmluZxgJIAEoCBIVCg1wbGFuX2FwcHJvdmVkGAogASgIEjQKEHBsYW5fYXBwcm92ZWRfYXQYCyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEhsKE3BsYW5fYXJ0aWZhY3RzX3BhdGgYDCABKAkSDQoFbm90ZXMYDSABKAkSEwoLZXh0ZXJuYWxfaWQYDiABKAkSLwoLYXJjaGl2ZWRfYXQYDyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEi4KCmNyZWF0ZWRfYXQYECABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEi4KCnVwZGF0ZWRfYXQYESABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEi4KDWl0ZW1fc2Vzc2lvbnMYEiADKAsyFy5zZXNzaW9uLnYxLkl0ZW1TZXNzaW9uEhEKCXNvdXJjZV9pZBgTIAEoCRI1Cg1zdGF0dXNfZXZlbnRzGBQgAygLMh4uc2Vzc2lvbi52MS5CYWNrbG9nU3RhdHVzRXZlbnQigAIKCkl0ZW1Tb3VyY2USCgoCaWQYASABKAkSEQoJcGx1Z2luX2lkGAIgASgJEhQKDGRpc3BsYXlfbmFtZRgDIAEoCRIPCgdlbmFibGVkGAQgASgIEjIKDmxhc3Rfc3luY2VkX2F0GAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIYChB0b2tlbl9jb25maWd1cmVkGAYgASgIEi4KCmNyZWF0ZWRfYXQYByABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEi4KCnVwZGF0ZWRfYXQYCCABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIvEBCg9Tb3VyY2VTeW5jRXZlbnQSCgoCaWQYASABKAkSLgoKc3RhcnRlZF9hdBgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLwoLZmluaXNoZWRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEhUKDWl0ZW1zX2NyZWF0ZWQYBCABKAUSFQoNaXRlbXNfdXBkYXRlZBgFIAEoBRIVCg1pdGVtc19za2lwcGVkGAYgASgFEhUKDWl0ZW1zX2Vycm9yZWQYByABKAUSFQoNZXJyb3JfbWVzc2FnZRgIIAEoCSLuAQoYQ3JlYXRlQmFja2xvZ0l0ZW1SZXF1ZXN0Eg0KBXRpdGxlGAEgASgJEhMKC2Rlc2NyaXB0aW9uGAIgASgJEjQKE2FjY2VwdGFuY2VfY3JpdGVyaWEYAyADKAsyFy5zZXNzaW9uLnYxLkFjQ3JpdGVyaW9uEhAKCHByaW9yaXR5GAQgASgFEhgKEHNraXBfcmV2aWV3X2dhdGUYBSABKAgSFQoNc2tpcF9wbGFubmluZxgGIAEoCBIRCglyZXBvX3BhdGgYByABKAkSDQoFbm90ZXMYCCABKAkSEwoLc2tpcF90cmlhZ2UYCSABKAgiXAoZQ3JlYXRlQmFja2xvZ0l0ZW1SZXNwb25zZRIlCgRpdGVtGAEgASgLMhcuc2Vzc2lvbi52MS5CYWNrbG9nSXRlbRIYChB0cmlhZ2VfdHJpZ2dlcmVkGAIgASgIIigKFUdldEJhY2tsb2dJdGVtUmVxdWVzdBIPCgdpdGVtX2lkGAEgASgJIj8KFkdldEJhY2tsb2dJdGVtUmVzcG9uc2USJQoEaXRlbRgBIAEoCzIXLnNlc3Npb24udjEuQmFja2xvZ0l0ZW0iZgoXTGlzdEJhY2tsb2dJdGVtc1JlcXVlc3QSDgoGc3RhdHVzGAEgAygJEhAKCHByaW9yaXR5GAIgAygFEg8KB3NvcnRfYnkYAyABKAkSGAoQaW5jbHVkZV90ZXJtaW5hbBgEIAEoCCJCChhMaXN0QmFja2xvZ0l0ZW1zUmVzcG9uc2USJgoFaXRlbXMYASADKAsyFy5zZXNzaW9uLnYxLkJhY2tsb2dJdGVtIrwCChhVcGRhdGVCYWNrbG9nSXRlbVJlcXVlc3QSDwoHaXRlbV9pZBgBIAEoCRINCgV0aXRsZRgCIAEoCRITCgtkZXNjcmlwdGlvbhgDIAEoCRI0ChNhY2NlcHRhbmNlX2NyaXRlcmlhGAQgAygLMhcuc2Vzc2lvbi52MS5BY0NyaXRlcmlvbhIQCghwcmlvcml0eRgFIAEoBRIYChBza2lwX3Jldmlld19nYXRlGAYgASgIEhUKDXNraXBfcGxhbm5pbmcYByABKAgSEQoJcmVwb19wYXRoGAggASgJEg0KBW5vdGVzGAkgASgJEhcKD2V4cGVjdGVkX3N0YXR1cxgKIAEoCRI3ChNleHBlY3RlZF91cGRhdGVkX2F0GAsgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJCChlVcGRhdGVCYWNrbG9nSXRlbVJlc3BvbnNlEiUKBGl0ZW0YASABKAsyFy5zZXNzaW9uLnYxLkJhY2tsb2dJdGVtIiwKGUFyY2hpdmVCYWNrbG9nSXRlbVJlcXVlc3QSDwoHaXRlbV9pZBgBIAEoCSJDChpBcmNoaXZlQmFja2xvZ0l0ZW1SZXNwb25zZRIlCgRpdGVtGAEgASgLMhcuc2Vzc2lvbi52MS5CYWNrbG9nSXRlbSK3AQoiVHJhbnNpdGlvbkJhY2tsb2dJdGVtU3RhdHVzUmVxdWVzdBIPCgdpdGVtX2lkGAEgASgJEhUKDXRhcmdldF9zdGF0dXMYAiABKAkSFwoPZXhwZWN0ZWRfc3RhdHVzGAMgASgJEjcKE2V4cGVjdGVkX3VwZGF0ZWRfYXQYBCABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEhcKD292ZXJyaWRlX3JlYXNvbhgFIAEoCSJMCiNUcmFuc2l0aW9uQmFja2xvZ0l0ZW1TdGF0dXNSZXNwb25zZRIlCgRpdGVtGAEgASgLMhcuc2Vzc2lvbi52MS5CYWNrbG9nSXRlbSIuChtTcGF3blNlc3Npb25Gcm9tSXRlbVJlcXVlc3QSDwoHaXRlbV9pZBgBIAEoCSJjChxTcGF3blNlc3Npb25Gcm9tSXRlbVJlc3BvbnNlEhQKDHNlc3Npb25fdXVpZBgBIAEoCRItCgxpdGVtX3Nlc3Npb24YAiABKAsyFy5zZXNzaW9uLnYxLkl0ZW1TZXNzaW9uIkMKGkF0dGFjaFNlc3Npb25Ub0l0ZW1SZXF1ZXN0Eg8KB2l0ZW1faWQYASABKAkSFAoMc2Vzc2lvbl91dWlkGAIgASgJIkwKG0F0dGFjaFNlc3Npb25Ub0l0ZW1SZXNwb25zZRItCgxpdGVtX3Nlc3Npb24YASABKAsyFy5zZXNzaW9uLnYxLkl0ZW1TZXNzaW9uIicKFFRyaWdnZXJUcmlhZ2VSZXF1ZXN0Eg8KB2l0ZW1faWQYASABKAkiRgoVVHJpZ2dlclRyaWFnZVJlc3BvbnNlEi0KDGl0ZW1fc2Vzc2lvbhgBIAEoCzIXLnNlc3Npb24udjEuSXRlbVNlc3Npb24iJQoSQXBwcm92ZVBsYW5SZXF1ZXN0Eg8KB2l0ZW1faWQYASABKAkiPAoTQXBwcm92ZVBsYW5SZXNwb25zZRIlCgRpdGVtGAEgASgLMhcuc2Vzc2lvbi52MS5CYWNrbG9nSXRlbSIYChZTdWdnZXN0TmV4dEl0ZW1SZXF1ZXN0Im8KF1N1Z2dlc3ROZXh0SXRlbVJlc3BvbnNlEi0KDGl0ZW1fc2Vzc2lvbhgBIAEoCzIXLnNlc3Npb24udjEuSXRlbVNlc3Npb24SJQoEaXRlbRgCIAEoCzIXLnNlc3Npb24udjEuQmFja2xvZ0l0ZW0iXQoWT3ZlcnJpZGVWZXJkaWN0UmVxdWVzdBIXCg9pdGVtX3Nlc3Npb25faWQYASABKAkSEQoJdG9fc3RhdHVzGAIgASgJEhcKD292ZXJyaWRlX3JlYXNvbhgDIAEoCSJAChdPdmVycmlkZVZlcmRpY3RSZXNwb25zZRIlCgRpdGVtGAEgASgLMhcuc2Vzc2lvbi52MS5CYWNrbG9nSXRlbSIpChZUcmlnZ2VyUmVSZXZpZXdSZXF1ZXN0Eg8KB2l0ZW1faWQYASABKAkiSAoXVHJpZ2dlclJlUmV2aWV3UmVzcG9uc2USLQoMaXRlbV9zZXNzaW9uGAEgASgLMhcuc2Vzc2lvbi52MS5JdGVtU2Vzc2lvbiInChJUcmlnZ2VyU3luY1JlcXVlc3QSEQoJc291cmNlX2lkGAEgASgJIhUKE1RyaWdnZXJTeW5jUmVzcG9uc2UiZgoXQ3JlYXRlSXRlbVNvdXJjZVJlcXVlc3QSEQoJcGx1Z2luX2lkGAEgASgJEhQKDGRpc3BsYXlfbmFtZRgCIAEoCRITCgtjb25maWdfanNvbhgDIAEoCRINCgV0b2tlbhgEIAEoCSJCChhDcmVhdGVJdGVtU291cmNlUmVzcG9uc2USJgoGc291cmNlGAEgASgLMhYuc2Vzc2lvbi52MS5JdGVtU291cmNlIhgKFkxpc3RJdGVtU291cmNlc1JlcXVlc3QiQgoXTGlzdEl0ZW1Tb3VyY2VzUmVzcG9uc2USJwoHc291cmNlcxgBIAMoCzIWLnNlc3Npb24udjEuSXRlbVNvdXJjZSJiChdVcGRhdGVJdGVtU291cmNlUmVxdWVzdBIRCglzb3VyY2VfaWQYASABKAkSFAoMZGlzcGxheV9uYW1lGAIgASgJEg8KB2VuYWJsZWQYAyABKAgSDQoFdG9rZW4YBCABKAkiQgoYVXBkYXRlSXRlbVNvdXJjZVJlc3BvbnNlEiYKBnNvdXJjZRgBIAEoCzIWLnNlc3Npb24udjEuSXRlbVNvdXJjZSIsChdEZWxldGVJdGVtU291cmNlUmVxdWVzdBIRCglzb3VyY2VfaWQYASABKAkiGgoYRGVsZXRlSXRlbVNvdXJjZVJlc3BvbnNlIioKFUdldFN5bmNIaXN0b3J5UmVxdWVzdBIRCglzb3VyY2VfaWQYASABKAkiRQoWR2V0U3luY0hpc3RvcnlSZXNwb25zZRIrCgZldmVudHMYASADKAsyGy5zZXNzaW9uLnYxLlNvdXJjZVN5bmNFdmVudDLHDgoOQmFja2xvZ1NlcnZpY2USYgoRQ3JlYXRlQmFja2xvZ0l0ZW0SJC5zZXNzaW9uLnYxLkNyZWF0ZUJhY2tsb2dJdGVtUmVxdWVzdBolLnNlc3Npb24udjEuQ3JlYXRlQmFja2xvZ0l0ZW1SZXNwb25zZSIAElkKDkdldEJhY2tsb2dJdGVtEiEuc2Vzc2lvbi52MS5HZXRCYWNrbG9nSXRlbVJlcXVlc3QaIi5zZXNzaW9uLnYxLkdldEJhY2tsb2dJdGVtUmVzcG9uc2UiABJfChBMaXN0QmFja2xvZ0l0ZW1zEiMuc2Vzc2lvbi52MS5MaXN0QmFja2xvZ0l0ZW1zUmVxdWVzdBokLnNlc3Npb24udjEuTGlzdEJhY2tsb2dJdGVtc1Jlc3BvbnNlIgASYgoRVXBkYXRlQmFja2xvZ0l0ZW0SJC5zZXNzaW9uLnYxLlVwZGF0ZUJhY2tsb2dJdGVtUmVxdWVzdBolLnNlc3Npb24udjEuVXBkYXRlQmFja2xvZ0l0ZW1SZXNwb25zZSIAEmUKEkFyY2hpdmVCYWNrbG9nSXRlbRIlLnNlc3Npb24udjEuQXJjaGl2ZUJhY2tsb2dJdGVtUmVxdWVzdBomLnNlc3Npb24udjEuQXJjaGl2ZUJhY2tsb2dJdGVtUmVzcG9uc2UiABKAAQobVHJhbnNpdGlvbkJhY2tsb2dJdGVtU3RhdHVzEi4uc2Vzc2lvbi52MS5UcmFuc2l0aW9uQmFja2xvZ0l0ZW1TdGF0dXNSZXF1ZXN0Gi8uc2Vzc2lvbi52MS5UcmFuc2l0aW9uQmFja2xvZ0l0ZW1TdGF0dXNSZXNwb25zZSIAEmsKFFNwYXduU2Vzc2lvbkZyb21JdGVtEicuc2Vzc2lvbi52MS5TcGF3blNlc3Npb25Gcm9tSXRlbVJlcXVlc3QaKC5zZXNzaW9uLnYxLlNwYXduU2Vzc2lvbkZyb21JdGVtUmVzcG9uc2UiABJoChNBdHRhY2hTZXNzaW9uVG9JdGVtEiYuc2Vzc2lvbi52MS5BdHRhY2hTZXNzaW9uVG9JdGVtUmVxdWVzdBonLnNlc3Npb24udjEuQXR0YWNoU2Vzc2lvblRvSXRlbVJlc3BvbnNlIgASVgoNVHJpZ2dlclRyaWFnZRIgLnNlc3Npb24udjEuVHJpZ2dlclRyaWFnZVJlcXVlc3QaIS5zZXNzaW9uLnYxLlRyaWdnZXJUcmlhZ2VSZXNwb25zZSIAElAKC0FwcHJvdmVQbGFuEh4uc2Vzc2lvbi52MS5BcHByb3ZlUGxhblJlcXVlc3QaHy5zZXNzaW9uLnYxLkFwcHJvdmVQbGFuUmVzcG9uc2UiABJcCg9TdWdnZXN0TmV4dEl0ZW0SIi5zZXNzaW9uLnYxLlN1Z2dlc3ROZXh0SXRlbVJlcXVlc3QaIy5zZXNzaW9uLnYxLlN1Z2dlc3ROZXh0SXRlbVJlc3BvbnNlIgASXAoPT3ZlcnJpZGVWZXJkaWN0EiIuc2Vzc2lvbi52MS5PdmVycmlkZVZlcmRpY3RSZXF1ZXN0GiMuc2Vzc2lvbi52MS5PdmVycmlkZVZlcmRpY3RSZXNwb25zZSIAElwKD1RyaWdnZXJSZVJldmlldxIiLnNlc3Npb24udjEuVHJpZ2dlclJlUmV2aWV3UmVxdWVzdBojLnNlc3Npb24udjEuVHJpZ2dlclJlUmV2aWV3UmVzcG9uc2UiABJQCgtUcmlnZ2VyU3luYxIeLnNlc3Npb24udjEuVHJpZ2dlclN5bmNSZXF1ZXN0Gh8uc2Vzc2lvbi52MS5UcmlnZ2VyU3luY1Jlc3BvbnNlIgASXwoQQ3JlYXRlSXRlbVNvdXJjZRIjLnNlc3Npb24udjEuQ3JlYXRlSXRlbVNvdXJjZVJlcXVlc3QaJC5zZXNzaW9uLnYxLkNyZWF0ZUl0ZW1Tb3VyY2VSZXNwb25zZSIAElwKD0xpc3RJdGVtU291cmNlcxIiLnNlc3Npb24udjEuTGlzdEl0ZW1Tb3VyY2VzUmVxdWVzdBojLnNlc3Npb24udjEuTGlzdEl0ZW1Tb3VyY2VzUmVzcG9uc2UiABJfChBVcGRhdGVJdGVtU291cmNlEiMuc2Vzc2lvbi52MS5VcGRhdGVJdGVtU291cmNlUmVxdWVzdBokLnNlc3Npb24udjEuVXBkYXRlSXRlbVNvdXJjZVJlc3BvbnNlIgASXwoQRGVsZXRlSXRlbVNvdXJjZRIjLnNlc3Npb24udjEuRGVsZXRlSXRlbVNvdXJjZVJlcXVlc3QaJC5zZXNzaW9uLnYxLkRlbGV0ZUl0ZW1Tb3VyY2VSZXNwb25zZSIAElkKDkdldFN5bmNIaXN0b3J5EiEuc2Vzc2lvbi52MS5HZXRTeW5jSGlzdG9yeVJlcXVlc3QaIi5zZXNzaW9uLnYxLkdldFN5bmNIaXN0b3J5UmVzcG9uc2UiAEKsAQoOY29tLnNlc3Npb24udjFCDEJhY2tsb2dQcm90b1ABWkNnaXRodWIuY29tL3RzdGFwbGVyL3N0YXBsZXItc3F1YWQvZ2VuL3Byb3RvL2dvL3Nlc3Npb24vdjE7c2Vzc2lvbnYxogIDU1hYqgIKU2Vzc2lvbi5WMcoCClNlc3Npb25cVjHiAhZTZXNzaW9uXFYxXEdQQk1ldGFkYXRh6gILU2Vzc2lvbjo6VjFiBnByb3RvMw", [file_google_protobuf_timestamp]);
 
 /**
  * AcCriterion represents a single acceptance criterion for a backlog item.
@@ -314,6 +314,47 @@ export const ItemSessionSchema: GenMessage<ItemSession> = /*@__PURE__*/
   messageDesc(file_session_v1_backlog, 6);
 
 /**
+ * BacklogStatusEvent records a single status transition for a backlog item.
+ *
+ * @generated from message session.v1.BacklogStatusEvent
+ */
+export type BacklogStatusEvent = Message<"session.v1.BacklogStatusEvent"> & {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id: string;
+
+  /**
+   * @generated from field: string from_status = 2;
+   */
+  fromStatus: string;
+
+  /**
+   * @generated from field: string to_status = 3;
+   */
+  toStatus: string;
+
+  /**
+   * "user" or "system"
+   *
+   * @generated from field: string triggered_by = 4;
+   */
+  triggeredBy: string;
+
+  /**
+   * @generated from field: google.protobuf.Timestamp created_at = 5;
+   */
+  createdAt?: Timestamp;
+};
+
+/**
+ * Describes the message session.v1.BacklogStatusEvent.
+ * Use `create(BacklogStatusEventSchema)` to create a new message.
+ */
+export const BacklogStatusEventSchema: GenMessage<BacklogStatusEvent> = /*@__PURE__*/
+  messageDesc(file_session_v1_backlog, 7);
+
+/**
  * BacklogItem represents a unit of work in the backlog.
  *
  * @generated from message session.v1.BacklogItem
@@ -413,6 +454,11 @@ export type BacklogItem = Message<"session.v1.BacklogItem"> & {
    * @generated from field: string source_id = 19;
    */
   sourceId: string;
+
+  /**
+   * @generated from field: repeated session.v1.BacklogStatusEvent status_events = 20;
+   */
+  statusEvents: BacklogStatusEvent[];
 };
 
 /**
@@ -420,7 +466,7 @@ export type BacklogItem = Message<"session.v1.BacklogItem"> & {
  * Use `create(BacklogItemSchema)` to create a new message.
  */
 export const BacklogItemSchema: GenMessage<BacklogItem> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 7);
+  messageDesc(file_session_v1_backlog, 8);
 
 /**
  * ItemSource represents an external plugin source that syncs items into the
@@ -475,7 +521,7 @@ export type ItemSource = Message<"session.v1.ItemSource"> & {
  * Use `create(ItemSourceSchema)` to create a new message.
  */
 export const ItemSourceSchema: GenMessage<ItemSource> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 8);
+  messageDesc(file_session_v1_backlog, 9);
 
 /**
  * SourceSyncEvent records the result of a single sync run for an ItemSource.
@@ -529,7 +575,7 @@ export type SourceSyncEvent = Message<"session.v1.SourceSyncEvent"> & {
  * Use `create(SourceSyncEventSchema)` to create a new message.
  */
 export const SourceSyncEventSchema: GenMessage<SourceSyncEvent> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 9);
+  messageDesc(file_session_v1_backlog, 10);
 
 /**
  * @generated from message session.v1.CreateBacklogItemRequest
@@ -586,7 +632,7 @@ export type CreateBacklogItemRequest = Message<"session.v1.CreateBacklogItemRequ
  * Use `create(CreateBacklogItemRequestSchema)` to create a new message.
  */
 export const CreateBacklogItemRequestSchema: GenMessage<CreateBacklogItemRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 10);
+  messageDesc(file_session_v1_backlog, 11);
 
 /**
  * @generated from message session.v1.CreateBacklogItemResponse
@@ -608,7 +654,7 @@ export type CreateBacklogItemResponse = Message<"session.v1.CreateBacklogItemRes
  * Use `create(CreateBacklogItemResponseSchema)` to create a new message.
  */
 export const CreateBacklogItemResponseSchema: GenMessage<CreateBacklogItemResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 11);
+  messageDesc(file_session_v1_backlog, 12);
 
 /**
  * @generated from message session.v1.GetBacklogItemRequest
@@ -625,7 +671,7 @@ export type GetBacklogItemRequest = Message<"session.v1.GetBacklogItemRequest"> 
  * Use `create(GetBacklogItemRequestSchema)` to create a new message.
  */
 export const GetBacklogItemRequestSchema: GenMessage<GetBacklogItemRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 12);
+  messageDesc(file_session_v1_backlog, 13);
 
 /**
  * @generated from message session.v1.GetBacklogItemResponse
@@ -642,7 +688,7 @@ export type GetBacklogItemResponse = Message<"session.v1.GetBacklogItemResponse"
  * Use `create(GetBacklogItemResponseSchema)` to create a new message.
  */
 export const GetBacklogItemResponseSchema: GenMessage<GetBacklogItemResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 13);
+  messageDesc(file_session_v1_backlog, 14);
 
 /**
  * @generated from message session.v1.ListBacklogItemsRequest
@@ -674,7 +720,7 @@ export type ListBacklogItemsRequest = Message<"session.v1.ListBacklogItemsReques
  * Use `create(ListBacklogItemsRequestSchema)` to create a new message.
  */
 export const ListBacklogItemsRequestSchema: GenMessage<ListBacklogItemsRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 14);
+  messageDesc(file_session_v1_backlog, 15);
 
 /**
  * @generated from message session.v1.ListBacklogItemsResponse
@@ -691,7 +737,7 @@ export type ListBacklogItemsResponse = Message<"session.v1.ListBacklogItemsRespo
  * Use `create(ListBacklogItemsResponseSchema)` to create a new message.
  */
 export const ListBacklogItemsResponseSchema: GenMessage<ListBacklogItemsResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 15);
+  messageDesc(file_session_v1_backlog, 16);
 
 /**
  * @generated from message session.v1.UpdateBacklogItemRequest
@@ -758,7 +804,7 @@ export type UpdateBacklogItemRequest = Message<"session.v1.UpdateBacklogItemRequ
  * Use `create(UpdateBacklogItemRequestSchema)` to create a new message.
  */
 export const UpdateBacklogItemRequestSchema: GenMessage<UpdateBacklogItemRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 16);
+  messageDesc(file_session_v1_backlog, 17);
 
 /**
  * @generated from message session.v1.UpdateBacklogItemResponse
@@ -775,7 +821,7 @@ export type UpdateBacklogItemResponse = Message<"session.v1.UpdateBacklogItemRes
  * Use `create(UpdateBacklogItemResponseSchema)` to create a new message.
  */
 export const UpdateBacklogItemResponseSchema: GenMessage<UpdateBacklogItemResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 17);
+  messageDesc(file_session_v1_backlog, 18);
 
 /**
  * @generated from message session.v1.ArchiveBacklogItemRequest
@@ -792,7 +838,7 @@ export type ArchiveBacklogItemRequest = Message<"session.v1.ArchiveBacklogItemRe
  * Use `create(ArchiveBacklogItemRequestSchema)` to create a new message.
  */
 export const ArchiveBacklogItemRequestSchema: GenMessage<ArchiveBacklogItemRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 18);
+  messageDesc(file_session_v1_backlog, 19);
 
 /**
  * @generated from message session.v1.ArchiveBacklogItemResponse
@@ -809,7 +855,7 @@ export type ArchiveBacklogItemResponse = Message<"session.v1.ArchiveBacklogItemR
  * Use `create(ArchiveBacklogItemResponseSchema)` to create a new message.
  */
 export const ArchiveBacklogItemResponseSchema: GenMessage<ArchiveBacklogItemResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 19);
+  messageDesc(file_session_v1_backlog, 20);
 
 /**
  * @generated from message session.v1.TransitionBacklogItemStatusRequest
@@ -846,7 +892,7 @@ export type TransitionBacklogItemStatusRequest = Message<"session.v1.TransitionB
  * Use `create(TransitionBacklogItemStatusRequestSchema)` to create a new message.
  */
 export const TransitionBacklogItemStatusRequestSchema: GenMessage<TransitionBacklogItemStatusRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 20);
+  messageDesc(file_session_v1_backlog, 21);
 
 /**
  * @generated from message session.v1.TransitionBacklogItemStatusResponse
@@ -863,7 +909,7 @@ export type TransitionBacklogItemStatusResponse = Message<"session.v1.Transition
  * Use `create(TransitionBacklogItemStatusResponseSchema)` to create a new message.
  */
 export const TransitionBacklogItemStatusResponseSchema: GenMessage<TransitionBacklogItemStatusResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 21);
+  messageDesc(file_session_v1_backlog, 22);
 
 /**
  * @generated from message session.v1.SpawnSessionFromItemRequest
@@ -880,7 +926,7 @@ export type SpawnSessionFromItemRequest = Message<"session.v1.SpawnSessionFromIt
  * Use `create(SpawnSessionFromItemRequestSchema)` to create a new message.
  */
 export const SpawnSessionFromItemRequestSchema: GenMessage<SpawnSessionFromItemRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 22);
+  messageDesc(file_session_v1_backlog, 23);
 
 /**
  * @generated from message session.v1.SpawnSessionFromItemResponse
@@ -902,7 +948,7 @@ export type SpawnSessionFromItemResponse = Message<"session.v1.SpawnSessionFromI
  * Use `create(SpawnSessionFromItemResponseSchema)` to create a new message.
  */
 export const SpawnSessionFromItemResponseSchema: GenMessage<SpawnSessionFromItemResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 23);
+  messageDesc(file_session_v1_backlog, 24);
 
 /**
  * @generated from message session.v1.AttachSessionToItemRequest
@@ -924,7 +970,7 @@ export type AttachSessionToItemRequest = Message<"session.v1.AttachSessionToItem
  * Use `create(AttachSessionToItemRequestSchema)` to create a new message.
  */
 export const AttachSessionToItemRequestSchema: GenMessage<AttachSessionToItemRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 24);
+  messageDesc(file_session_v1_backlog, 25);
 
 /**
  * @generated from message session.v1.AttachSessionToItemResponse
@@ -941,7 +987,7 @@ export type AttachSessionToItemResponse = Message<"session.v1.AttachSessionToIte
  * Use `create(AttachSessionToItemResponseSchema)` to create a new message.
  */
 export const AttachSessionToItemResponseSchema: GenMessage<AttachSessionToItemResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 25);
+  messageDesc(file_session_v1_backlog, 26);
 
 /**
  * @generated from message session.v1.TriggerTriageRequest
@@ -958,7 +1004,7 @@ export type TriggerTriageRequest = Message<"session.v1.TriggerTriageRequest"> & 
  * Use `create(TriggerTriageRequestSchema)` to create a new message.
  */
 export const TriggerTriageRequestSchema: GenMessage<TriggerTriageRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 26);
+  messageDesc(file_session_v1_backlog, 27);
 
 /**
  * @generated from message session.v1.TriggerTriageResponse
@@ -975,7 +1021,7 @@ export type TriggerTriageResponse = Message<"session.v1.TriggerTriageResponse"> 
  * Use `create(TriggerTriageResponseSchema)` to create a new message.
  */
 export const TriggerTriageResponseSchema: GenMessage<TriggerTriageResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 27);
+  messageDesc(file_session_v1_backlog, 28);
 
 /**
  * @generated from message session.v1.ApprovePlanRequest
@@ -992,7 +1038,7 @@ export type ApprovePlanRequest = Message<"session.v1.ApprovePlanRequest"> & {
  * Use `create(ApprovePlanRequestSchema)` to create a new message.
  */
 export const ApprovePlanRequestSchema: GenMessage<ApprovePlanRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 28);
+  messageDesc(file_session_v1_backlog, 29);
 
 /**
  * @generated from message session.v1.ApprovePlanResponse
@@ -1009,7 +1055,7 @@ export type ApprovePlanResponse = Message<"session.v1.ApprovePlanResponse"> & {
  * Use `create(ApprovePlanResponseSchema)` to create a new message.
  */
 export const ApprovePlanResponseSchema: GenMessage<ApprovePlanResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 29);
+  messageDesc(file_session_v1_backlog, 30);
 
 /**
  * @generated from message session.v1.SuggestNextItemRequest
@@ -1022,7 +1068,7 @@ export type SuggestNextItemRequest = Message<"session.v1.SuggestNextItemRequest"
  * Use `create(SuggestNextItemRequestSchema)` to create a new message.
  */
 export const SuggestNextItemRequestSchema: GenMessage<SuggestNextItemRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 30);
+  messageDesc(file_session_v1_backlog, 31);
 
 /**
  * @generated from message session.v1.SuggestNextItemResponse
@@ -1046,7 +1092,7 @@ export type SuggestNextItemResponse = Message<"session.v1.SuggestNextItemRespons
  * Use `create(SuggestNextItemResponseSchema)` to create a new message.
  */
 export const SuggestNextItemResponseSchema: GenMessage<SuggestNextItemResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 31);
+  messageDesc(file_session_v1_backlog, 32);
 
 /**
  * @generated from message session.v1.OverrideVerdictRequest
@@ -1073,7 +1119,7 @@ export type OverrideVerdictRequest = Message<"session.v1.OverrideVerdictRequest"
  * Use `create(OverrideVerdictRequestSchema)` to create a new message.
  */
 export const OverrideVerdictRequestSchema: GenMessage<OverrideVerdictRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 32);
+  messageDesc(file_session_v1_backlog, 33);
 
 /**
  * @generated from message session.v1.OverrideVerdictResponse
@@ -1090,7 +1136,7 @@ export type OverrideVerdictResponse = Message<"session.v1.OverrideVerdictRespons
  * Use `create(OverrideVerdictResponseSchema)` to create a new message.
  */
 export const OverrideVerdictResponseSchema: GenMessage<OverrideVerdictResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 33);
+  messageDesc(file_session_v1_backlog, 34);
 
 /**
  * @generated from message session.v1.TriggerReReviewRequest
@@ -1107,7 +1153,7 @@ export type TriggerReReviewRequest = Message<"session.v1.TriggerReReviewRequest"
  * Use `create(TriggerReReviewRequestSchema)` to create a new message.
  */
 export const TriggerReReviewRequestSchema: GenMessage<TriggerReReviewRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 34);
+  messageDesc(file_session_v1_backlog, 35);
 
 /**
  * @generated from message session.v1.TriggerReReviewResponse
@@ -1124,7 +1170,7 @@ export type TriggerReReviewResponse = Message<"session.v1.TriggerReReviewRespons
  * Use `create(TriggerReReviewResponseSchema)` to create a new message.
  */
 export const TriggerReReviewResponseSchema: GenMessage<TriggerReReviewResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 35);
+  messageDesc(file_session_v1_backlog, 36);
 
 /**
  * @generated from message session.v1.TriggerSyncRequest
@@ -1141,7 +1187,7 @@ export type TriggerSyncRequest = Message<"session.v1.TriggerSyncRequest"> & {
  * Use `create(TriggerSyncRequestSchema)` to create a new message.
  */
 export const TriggerSyncRequestSchema: GenMessage<TriggerSyncRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 36);
+  messageDesc(file_session_v1_backlog, 37);
 
 /**
  * @generated from message session.v1.TriggerSyncResponse
@@ -1154,7 +1200,7 @@ export type TriggerSyncResponse = Message<"session.v1.TriggerSyncResponse"> & {
  * Use `create(TriggerSyncResponseSchema)` to create a new message.
  */
 export const TriggerSyncResponseSchema: GenMessage<TriggerSyncResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 37);
+  messageDesc(file_session_v1_backlog, 38);
 
 /**
  * @generated from message session.v1.CreateItemSourceRequest
@@ -1186,7 +1232,7 @@ export type CreateItemSourceRequest = Message<"session.v1.CreateItemSourceReques
  * Use `create(CreateItemSourceRequestSchema)` to create a new message.
  */
 export const CreateItemSourceRequestSchema: GenMessage<CreateItemSourceRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 38);
+  messageDesc(file_session_v1_backlog, 39);
 
 /**
  * @generated from message session.v1.CreateItemSourceResponse
@@ -1203,7 +1249,7 @@ export type CreateItemSourceResponse = Message<"session.v1.CreateItemSourceRespo
  * Use `create(CreateItemSourceResponseSchema)` to create a new message.
  */
 export const CreateItemSourceResponseSchema: GenMessage<CreateItemSourceResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 39);
+  messageDesc(file_session_v1_backlog, 40);
 
 /**
  * @generated from message session.v1.ListItemSourcesRequest
@@ -1216,7 +1262,7 @@ export type ListItemSourcesRequest = Message<"session.v1.ListItemSourcesRequest"
  * Use `create(ListItemSourcesRequestSchema)` to create a new message.
  */
 export const ListItemSourcesRequestSchema: GenMessage<ListItemSourcesRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 40);
+  messageDesc(file_session_v1_backlog, 41);
 
 /**
  * @generated from message session.v1.ListItemSourcesResponse
@@ -1233,7 +1279,7 @@ export type ListItemSourcesResponse = Message<"session.v1.ListItemSourcesRespons
  * Use `create(ListItemSourcesResponseSchema)` to create a new message.
  */
 export const ListItemSourcesResponseSchema: GenMessage<ListItemSourcesResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 41);
+  messageDesc(file_session_v1_backlog, 42);
 
 /**
  * @generated from message session.v1.UpdateItemSourceRequest
@@ -1265,7 +1311,7 @@ export type UpdateItemSourceRequest = Message<"session.v1.UpdateItemSourceReques
  * Use `create(UpdateItemSourceRequestSchema)` to create a new message.
  */
 export const UpdateItemSourceRequestSchema: GenMessage<UpdateItemSourceRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 42);
+  messageDesc(file_session_v1_backlog, 43);
 
 /**
  * @generated from message session.v1.UpdateItemSourceResponse
@@ -1282,7 +1328,7 @@ export type UpdateItemSourceResponse = Message<"session.v1.UpdateItemSourceRespo
  * Use `create(UpdateItemSourceResponseSchema)` to create a new message.
  */
 export const UpdateItemSourceResponseSchema: GenMessage<UpdateItemSourceResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 43);
+  messageDesc(file_session_v1_backlog, 44);
 
 /**
  * @generated from message session.v1.DeleteItemSourceRequest
@@ -1299,7 +1345,7 @@ export type DeleteItemSourceRequest = Message<"session.v1.DeleteItemSourceReques
  * Use `create(DeleteItemSourceRequestSchema)` to create a new message.
  */
 export const DeleteItemSourceRequestSchema: GenMessage<DeleteItemSourceRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 44);
+  messageDesc(file_session_v1_backlog, 45);
 
 /**
  * @generated from message session.v1.DeleteItemSourceResponse
@@ -1312,7 +1358,7 @@ export type DeleteItemSourceResponse = Message<"session.v1.DeleteItemSourceRespo
  * Use `create(DeleteItemSourceResponseSchema)` to create a new message.
  */
 export const DeleteItemSourceResponseSchema: GenMessage<DeleteItemSourceResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 45);
+  messageDesc(file_session_v1_backlog, 46);
 
 /**
  * @generated from message session.v1.GetSyncHistoryRequest
@@ -1329,7 +1375,7 @@ export type GetSyncHistoryRequest = Message<"session.v1.GetSyncHistoryRequest"> 
  * Use `create(GetSyncHistoryRequestSchema)` to create a new message.
  */
 export const GetSyncHistoryRequestSchema: GenMessage<GetSyncHistoryRequest> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 46);
+  messageDesc(file_session_v1_backlog, 47);
 
 /**
  * @generated from message session.v1.GetSyncHistoryResponse
@@ -1346,7 +1392,7 @@ export type GetSyncHistoryResponse = Message<"session.v1.GetSyncHistoryResponse"
  * Use `create(GetSyncHistoryResponseSchema)` to create a new message.
  */
 export const GetSyncHistoryResponseSchema: GenMessage<GetSyncHistoryResponse> = /*@__PURE__*/
-  messageDesc(file_session_v1_backlog, 47);
+  messageDesc(file_session_v1_backlog, 48);
 
 /**
  * BacklogService manages backlog items and their lifecycle through AI-assisted

--- a/web-app/src/lib/hooks/useBacklogService.ts
+++ b/web-app/src/lib/hooks/useBacklogService.ts
@@ -10,6 +10,7 @@ import {
   AcCriterion as AcCriterionProto,
   ItemSession as ItemSessionProto,
   TriageTask as TriageTaskProto,
+  BacklogStatusEvent as BacklogStatusEventProto,
 } from "@/gen/session/v1/backlog_pb";
 
 // ---------------------------------------------------------------------------
@@ -88,6 +89,16 @@ export interface BacklogItem {
   triageStatus?: "running" | "completed" | "failed";
   /** Triage result from the most recent triage session (populated when triageStatus === "completed") */
   triageResult?: TriageResult;
+  /** Status transition history for this item (audit log) */
+  statusEvents: StatusEvent[];
+}
+
+export interface StatusEvent {
+  id: string;
+  fromStatus: string;
+  toStatus: string;
+  triggeredBy: string;
+  createdAt?: string;
 }
 
 export interface BacklogItemInput {
@@ -170,6 +181,16 @@ function mapItemSession(s: ItemSessionProto): LinkedSession {
   return session;
 }
 
+function mapStatusEvent(e: BacklogStatusEventProto): StatusEvent {
+  return {
+    id: e.id,
+    fromStatus: e.fromStatus,
+    toStatus: e.toStatus,
+    triggeredBy: e.triggeredBy,
+    createdAt: e.createdAt ? new Date(Number(e.createdAt.seconds) * 1000).toISOString() : undefined,
+  };
+}
+
 function mapBacklogItem(p: BacklogItemProto): BacklogItem {
   const linkedSessions = (p.itemSessions ?? []).map(mapItemSession);
 
@@ -194,16 +215,22 @@ function mapBacklogItem(p: BacklogItemProto): BacklogItem {
     }
   }
 
-  // Derive triageStatus from linked sessions: running if a triage session has no endedAt.
+  // Derive triageStatus from linked sessions.
   // P12 fix: only mark "completed" if the session ended AND has a non-empty summary.
-  // A session that ended without storing a result (e.g. crashed) shows as "failed".
+  // Orphan detection: a triage session without endedAt is only "running" while the item
+  // is in "idea" status. If the item has advanced (ready, in_progress, etc.) the session
+  // died without cleanly recording its end — treat it as "failed" so the UI doesn't show
+  // a loading indicator for a session that no longer exists.
+  const itemStatus = (p.status || "idea") as BacklogItemStatus;
   let triageStatus: BacklogItem["triageStatus"];
   const triageSession = linkedSessions.filter((s) => s.role === "triage").at(-1);
   if (triageSession) {
     if (triageSession.endedAt) {
       triageStatus = triageSession.triageResult?.summary ? "completed" : "failed";
-    } else {
+    } else if (itemStatus === "idea") {
       triageStatus = "running";
+    } else {
+      triageStatus = "failed";
     }
   }
 
@@ -230,6 +257,7 @@ function mapBacklogItem(p: BacklogItemProto): BacklogItem {
     gateCriteria,
     triageStatus,
     triageResult,
+    statusEvents: (p.statusEvents ?? []).map(mapStatusEvent),
   };
 }
 

--- a/web-app/src/lib/hooks/useSessionRepoPaths.ts
+++ b/web-app/src/lib/hooks/useSessionRepoPaths.ts
@@ -4,14 +4,14 @@ import { useMemo } from "react";
 import { useAppSelector } from "@/lib/store";
 import { selectAllSessions } from "@/lib/store/sessionsSlice";
 
-/** Returns deduplicated list of working directory paths from all known sessions. */
+/** Returns deduplicated list of repo root paths from all known sessions. */
 export function useSessionRepoPaths(): string[] {
   const sessions = useAppSelector(selectAllSessions);
   return useMemo(() => {
     const seen = new Set<string>();
     const paths: string[] = [];
     for (const s of sessions) {
-      const p = s.workingDir;
+      const p = s.path;
       if (p && !seen.has(p)) {
         seen.add(p);
         paths.push(p);


### PR DESCRIPTION
## Summary

- Extends `claude_thinking_verb` Active pattern from `^*` to `^[*✻]` to match both `*` (U+002A, old) and `✻` (U+273B, current) Claude Code spinner prefixes
- Sessions showing `✻ Perambulating...` are now classified as `StatusActive` instead of unknown
- Completion lines (`✻ Perambulated for Nh`) continue to classify as `StatusSuccess` via the higher-priority `verb_duration_completion` pattern — no change needed there

## What broke

Claude Code switched its spinner prefix from `*` to `✻` (U+273B ASTERISM). The existing regex `(?m)^*\s+\w+[…\.]{1,3}` only matched `*`, so active sessions with the new prefix were invisible to the detector. The review queue would never surface them as idle after completion.

## Changes

| File | Change |
|---|---|
| `session/detection/detector.go` | `^*` → `^[*✻]` in `claude_thinking_verb` Active pattern |
| `session/detection/testdata/claude_asterism_active.txt` | New fixture: `✻ Perambulating...` terminal capture |
| `session/detection/testdata/claude_asterism_success.txt` | New fixture: `✻ Perambulated for 1h 5m` completion state |
| `session/detection/snapshot_test.go` | Two new snapshot test entries |
| `session/detection/asterism_test.go` | 6 unit tests covering AC-1 through AC-3 |
| `session/review_queue_reactive_test.go` | 2 integration tests validating queue updates within 200ms |

## Test plan

- [x] `TestClaude_AsterismActive_SingleLine` — `✻ Verb...` → StatusActive (3 cases)
- [x] `TestClaude_AsteriskActive_NoRegression` — `* Verb...` still StatusActive
- [x] `TestClaude_AsterismCompletion_IsSuccess` — `✻ PastVerb for N` → StatusSuccess
- [x] `TestClaude_AsterismCompletion_NotActive` — completion lines ≠ StatusActive
- [x] `TestClaude_ScrollbackFalsePositive_ActiveThenIdle` — old spinner in scrollback doesn't override current idle prompt
- [x] `TestReactiveQueueManager_StatusChange_AddsToQueue` — idle session added to queue within 200ms
- [x] `TestReactiveQueueManager_ActiveSession_RemovedFromQueue` — active session removed from queue within 200ms
- [x] All existing snapshot tests (Aider, OpenCode, existing Claude fixtures) pass
- [x] `make quick-check` (1997 tests) ✅