### PR TITLE
fix: backlog/triage sessions die on launch (shell injection + flag-parsing crash)

### DIFF
--- a/session/instance_tmux.go
+++ b/session/instance_tmux.go
@@ -102,7 +102,10 @@ func shellQuote(s string) string {
 func (i *Instance) buildClaudeCommand(base, claudeSessionID string) string {
 	parts := []string{base}
 	if claudeSessionID != "" {
-		parts = append(parts, "--resume", claudeSessionID)
+		// claudeSessionID traces back to the client-supplied resume_id RPC field
+		// (CreateSessionRequest) with no format validation, so it needs the same
+		// shell-quoting as the other interpolated flag values.
+		parts = append(parts, "--resume", shellQuote(claudeSessionID))
 	}
 	if i.MCPServerURL != "" {
 		parts = append(parts, i.claudeMCPConfigFlag())
@@ -131,11 +134,18 @@ func (i *Instance) buildClaudeCommand(base, claudeSessionID string) string {
 }
 
 // claudeMCPConfigFlag returns the --mcp-config flag string for this instance.
+// %q here escapes MCPServerURL/UUID as JSON string values, a distinct job
+// from shell-quoting; the whole JSON payload is then wrapped once with
+// shellQuote so the outer shell-quoting isn't a hand-rolled second
+// implementation of the same job shellQuote already does correctly.
 func (i *Instance) claudeMCPConfigFlag() string {
+	var cfg string
 	if i.UUID != "" {
-		return fmt.Sprintf(`--mcp-config '{"mcpServers":{"stapler-squad":{"type":"http","url":%q,"headers":{"X-Stapler-Session-UUID":%q}}}}'`, i.MCPServerURL, i.UUID)
+		cfg = fmt.Sprintf(`{"mcpServers":{"stapler-squad":{"type":"http","url":%q,"headers":{"X-Stapler-Session-UUID":%q}}}}`, i.MCPServerURL, i.UUID)
+	} else {
+		cfg = fmt.Sprintf(`{"mcpServers":{"stapler-squad":{"type":"http","url":%q}}}`, i.MCPServerURL)
 	}
-	return fmt.Sprintf(`--mcp-config '{"mcpServers":{"stapler-squad":{"type":"http","url":%q}}}'`, i.MCPServerURL)
+	return "--mcp-config " + shellQuote(cfg)
 }
 
 // initTmuxSession creates (or reuses) the tmux.TmuxSession object without starting it.

--- a/session/instance_tmux.go
+++ b/session/instance_tmux.go
@@ -87,6 +87,15 @@ func (i *Instance) buildLaunchCommand(claudeSessionID string) string {
 	return cmd
 }
 
+// shellQuote POSIX-single-quotes s for safe interpolation into a shell command
+// string. tmux launches the assembled command through a shell, and Go's %q
+// produces double quotes, which do NOT suppress backtick/$(...)/$VAR
+// expansion. Single quotes do: the only special case is a literal single
+// quote, escaped by closing the quoted string, emitting \', and reopening.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 // buildClaudeCommand assembles the full claude invocation with all instance flags.
 // It is only called when the program is proven to be claude (via programKind),
 // so no isClaude guards are needed here.
@@ -99,13 +108,13 @@ func (i *Instance) buildClaudeCommand(base, claudeSessionID string) string {
 		parts = append(parts, i.claudeMCPConfigFlag())
 	}
 	if i.AppendSystemPrompt != "" {
-		parts = append(parts, "--append-system-prompt", fmt.Sprintf("%q", i.AppendSystemPrompt))
+		parts = append(parts, "--append-system-prompt", shellQuote(i.AppendSystemPrompt))
 	}
 	if i.AllowedTools != "" {
-		parts = append(parts, "--allowedTools", fmt.Sprintf("%q", i.AllowedTools))
+		parts = append(parts, "--allowedTools", shellQuote(i.AllowedTools))
 	}
 	if i.PermissionMode != "" {
-		parts = append(parts, "--permission-mode", fmt.Sprintf("%q", i.PermissionMode))
+		parts = append(parts, "--permission-mode", shellQuote(i.PermissionMode))
 	}
 	if i.AutoYes {
 		parts = append(parts, "--dangerously-skip-permissions")
@@ -114,7 +123,9 @@ func (i *Instance) buildClaudeCommand(base, claudeSessionID string) string {
 		parts = append(parts, "-p", "--output-format", "json")
 	}
 	if i.Prompt != "" && (claudeSessionID == "" || i.OneShot) {
-		parts = append(parts, fmt.Sprintf("%q", i.Prompt))
+		// "--" stops claude from parsing a prompt that begins with "--" (e.g. the
+		// backlog prompt's "--- BACKLOG ITEM DATA ---") as CLI flags.
+		parts = append(parts, "--", shellQuote(i.Prompt))
 	}
 	return strings.Join(parts, " ")
 }

--- a/session/instance_tmux_test.go
+++ b/session/instance_tmux_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -89,6 +90,62 @@ func TestBuildLaunchCommand_ClaudeEnvWrapper(t *testing.T) {
 	}
 	if len(got) == 0 {
 		t.Error("expected non-empty command")
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", "''"},
+		{"plain", "do something", "'do something'"},
+		{"single_quote", "it's here", `'it'\''s here'`},
+		{"backtick", "run `whoami`", "'run `whoami`'"},
+		{"dollar_paren", "run $(whoami)", "'run $(whoami)'"},
+		{"dollar_var", "echo $HOME", "'echo $HOME'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shellQuote(tc.input)
+			if got != tc.want {
+				t.Errorf("shellQuote(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildClaudeCommand_PromptWithShellMetacharactersIsSafe(t *testing.T) {
+	// Regression test for the backlog/triage launch bug: the backlog prompt is
+	// full of backtick-wrapped tokens and begins with "--- BACKLOG ITEM DATA ---".
+	// Both must be neutralized: single-quoting stops backtick/$()/$VAR expansion,
+	// and the "--" separator stops claude from parsing the leading "--" as a flag.
+	prompt := "--- BACKLOG ITEM DATA ---\nRun `/backlog/done-0` when finished, or $(rm -rf /) if you dare."
+	inst := &Instance{Program: "claude", Prompt: prompt}
+	got := inst.buildLaunchCommand("")
+
+	want := "claude -- " + shellQuote(prompt)
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if !strings.Contains(got, " -- ") {
+		t.Errorf("expected a bare -- separator before the prompt, got %q", got)
+	}
+	if strings.Contains(got, "%!q") {
+		t.Errorf("prompt was not properly formatted: %q", got)
+	}
+}
+
+func TestBuildClaudeCommand_AppendSystemPromptWithShellMetacharactersIsSafe(t *testing.T) {
+	inst := &Instance{
+		Program:            "claude",
+		AppendSystemPrompt: "be `helpful` and $(honest)",
+	}
+	got := inst.buildLaunchCommand("")
+	want := "claude --append-system-prompt " + shellQuote(inst.AppendSystemPrompt)
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 

--- a/session/instance_tmux_test.go
+++ b/session/instance_tmux_test.go
@@ -76,7 +76,7 @@ func TestBuildLaunchCommand_NonClaudeProgramUnmodified(t *testing.T) {
 func TestBuildLaunchCommand_ClaudeSessionResume(t *testing.T) {
 	inst := &Instance{Program: "claude"}
 	got := inst.buildLaunchCommand("conv-abc123")
-	expected := "claude --resume conv-abc123"
+	expected := "claude --resume 'conv-abc123'"
 	if got != expected {
 		t.Errorf("got %q, want %q", got, expected)
 	}
@@ -105,6 +105,9 @@ func TestShellQuote(t *testing.T) {
 		{"backtick", "run `whoami`", "'run `whoami`'"},
 		{"dollar_paren", "run $(whoami)", "'run $(whoami)'"},
 		{"dollar_var", "echo $HOME", "'echo $HOME'"},
+		{"only_single_quote", "'", `''\'''`},
+		{"newline", "line one\nline two", "'line one\nline two'"},
+		{"backtick_and_quote", "don't `touch /tmp/pwned`", "'don'\\''t `touch /tmp/pwned`'"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -121,11 +124,13 @@ func TestBuildClaudeCommand_PromptWithShellMetacharactersIsSafe(t *testing.T) {
 	// full of backtick-wrapped tokens and begins with "--- BACKLOG ITEM DATA ---".
 	// Both must be neutralized: single-quoting stops backtick/$()/$VAR expansion,
 	// and the "--" separator stops claude from parsing the leading "--" as a flag.
+	// want is a hand-written literal (not shellQuote(prompt)) so this test doesn't
+	// just re-verify shellQuote against itself.
 	prompt := "--- BACKLOG ITEM DATA ---\nRun `/backlog/done-0` when finished, or $(rm -rf /) if you dare."
 	inst := &Instance{Program: "claude", Prompt: prompt}
 	got := inst.buildLaunchCommand("")
 
-	want := "claude -- " + shellQuote(prompt)
+	want := "claude -- '" + prompt + "'"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -143,7 +148,45 @@ func TestBuildClaudeCommand_AppendSystemPromptWithShellMetacharactersIsSafe(t *t
 		AppendSystemPrompt: "be `helpful` and $(honest)",
 	}
 	got := inst.buildLaunchCommand("")
-	want := "claude --append-system-prompt " + shellQuote(inst.AppendSystemPrompt)
+	// Hand-written literal, not shellQuote(inst.AppendSystemPrompt), for the same
+	// non-circularity reason as the Prompt test above.
+	want := "claude --append-system-prompt 'be `helpful` and $(honest)'"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildClaudeCommand_AllowedToolsWithShellMetacharactersIsSafe(t *testing.T) {
+	inst := &Instance{
+		Program:      "claude",
+		AllowedTools: "Bash(`whoami`),Bash($(id))",
+	}
+	got := inst.buildLaunchCommand("")
+	want := "claude --allowedTools 'Bash(`whoami`),Bash($(id))'"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildClaudeCommand_PermissionModeWithShellMetacharactersIsSafe(t *testing.T) {
+	inst := &Instance{
+		Program:        "claude",
+		PermissionMode: "plan; `touch /tmp/pwned`",
+	}
+	got := inst.buildLaunchCommand("")
+	want := "claude --permission-mode 'plan; `touch /tmp/pwned`'"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildClaudeCommand_ResumeIdWithShellMetacharactersIsSafe(t *testing.T) {
+	// claudeSessionID comes from the client-supplied resume_id RPC field with no
+	// format validation, so it needs the same shell-quoting as any other
+	// interpolated flag value.
+	inst := &Instance{Program: "claude"}
+	got := inst.buildLaunchCommand("abc`touch /tmp/pwned`123")
+	want := "claude --resume 'abc`touch /tmp/pwned`123'"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

Fixes #148. Backlog/triage-spawned sessions died on launch: the claude launch command is assembled as a string that tmux runs through a shell, and several instance fields were interpolated with Go's `%q` (double quotes), which does **not** suppress shell backtick/`$(...)`/`$VAR` expansion. Backlog prompts are full of backtick-wrapped tokens (`` `/backlog/done-N` ``, etc.), so the shell executed them as commands instead of handing the text to claude. Separately, backlog prompts begin with `--- BACKLOG ITEM DATA ---`, which claude's CLI arg parser rejected as an unrecognized flag.

## Fix

Added `shellQuote` (POSIX single-quoting, matching the style already used for `--mcp-config`) and applied it everywhere a claude flag value is interpolated into the shell-executed launch command: `--append-system-prompt`, `--allowedTools`, `--permission-mode`, `--resume`, and the positional prompt. Inserted a bare `--` before the positional prompt so a leading `--` in prompt text is treated as data, not flags.

Verified against the real `claude` CLI that:
- `--` is respected as an end-of-options separator (a leading-`--` string after it is not parsed as a flag)
- `--append-system-prompt-file` exists (confirms the CLI does support file-based inputs elsewhere, informing the decision below)
- A generated launch command containing a `$(touch /tmp/PWNED)` payload, executed through a real shell, does **not** create the file — no command substitution occurs, and the full multi-line, leading-`--` prompt arrives as a single intact argument.

## Why shell-quoting instead of writing the prompt to a file

The issue's own "Option A" (write the prompt to a temp file, sidestepping shell interpolation and `ARG_MAX` entirely) was considered. `claude` has file-based flags for `--append-system-prompt-file`/`--system-prompt-file`, but no equivalent for the main positional prompt, and using stdin for the initial *interactive*-mode prompt was judged riskier/less-tested than shell-quoting. Went with the issue's "Option B" (shell-quote + `--` separator), consistent with the existing `--mcp-config` quoting style already in this file.

## Review

Ran the project's standard 4-agent review (Testing, Code Quality, Architecture, Security) before pushing. Two independent agents (Security, Code Quality) converged on the same finding the first commit missed: `--resume <claudeSessionID>` was still interpolated **unquoted** in the same function, and `claudeSessionID` traces back to the client-supplied `resume_id` field on `CreateSessionRequest` with no format validation — the identical vulnerability class, unpatched, one field over. Fixed in a second commit, along with:
- `claudeMCPConfigFlag` hand-rolled its own shell quoting instead of reusing `shellQuote` — refactored to build the JSON first, then wrap once with `shellQuote` (not currently exploitable since `MCPServerURL`/`UUID` aren't attacker-supplied today, but same latent-gap class).
- Missing regression tests for `--allowedTools`/`--permission-mode` shell-safety (a partial revert of just those two lines would have passed the full suite silently).
- Reworked two existing regression tests to assert against hand-written literals instead of calling `shellQuote()` again, so they don't just verify the function against itself.
- Added `only-single-quote`, embedded-newline, and combined backtick+quote cases to `TestShellQuote`.

Confirmed `session/claude_command_builder.go`'s separate `--resume` code path is unaffected: it validates the session ID against a strict UUID v4 regex before use (safe by construction) and isn't wired into any production call site today anyway.

### Deferred (out of scope for this PR, flagging for a follow-up)

- `i.CLIFlags` is concatenated onto the launch command with **no** quoting at all (`session/instance_tmux.go` in `buildLaunchCommand`), sourced from the client-supplied `cli_flags` RPC field. Wrapping it in a single `shellQuote()` call would collapse its intentionally-multi-token semantics (e.g. `--model opus --verbose`) into one opaque argument, so this needs either an allow-list validator or a move to argv-based (shlex-tokenized) exec rather than a one-line patch. Real exploitable surface, but a different fix shape — recommend a tracked follow-up issue rather than rushing it into this PR.

## Related (not addressed here, per the original issue)

The issue also flagged two lower-priority, separate problems: `repo_path` silently treated as a local path even when it's a GitHub URL, and backlog spawn using `CreateDirectorySession` (shared working tree) instead of an isolated worktree per item. Both are out of scope for this narrow fix.

## Test plan

- [x] `go build ./...`
- [x] `go test ./session/...` (full package, all green)
- [x] `make lint` (0 issues)
- [x] Empirically verified against the real `claude` binary (`--` separator behavior, `--append-system-prompt-file` acceptance)
- [x] Empirically verified via `sh -c` that a `$(...)` payload in a backlog-shaped prompt does not execute
- [x] New regression tests: `TestShellQuote` (9 cases), `TestBuildClaudeCommand_{Prompt,AppendSystemPrompt,AllowedTools,PermissionMode,ResumeId}WithShellMetacharactersIsSafe`