### PR TITLE
fix(terminal): correctly scan OSC/DCS escape sequences to stop render artifacts

### DIFF
--- a/pkg/analytics/escape_code_parser.go
+++ b/pkg/analytics/escape_code_parser.go
@@ -361,8 +361,10 @@ func (p *EscapeCodeParser) parseCSI(data []byte, offset int) (*ParsedEscapeCode,
 			end++
 			continue
 		}
-		// Terminator: letter
-		if (b >= 0x40 && b <= 0x5A) || (b >= 0x61 && b <= 0x7A) {
+		// Terminator: final byte per ECMA-48 (0x40-0x7E), not just letters —
+		// e.g. '@' (Insert Character) and '~' (used by many real xterm
+		// sequences) are valid CSI final bytes outside the A-Z/a-z range.
+		if b >= 0x40 && b <= 0x7E {
 			end++
 			rawBytes := data[offset:end]
 			category, description := p.categorizeCSI(rawBytes, isPrivate, hasParams)

--- a/pkg/analytics/escape_code_parser_test.go
+++ b/pkg/analytics/escape_code_parser_test.go
@@ -69,6 +69,23 @@ func TestParseCSISequences(t *testing.T) {
 			wantCat:  CategoryScroll,
 			wantDesc: "Set Scroll Region (1;24)",
 		},
+		{
+			// '@' (0x40) is a valid CSI final byte (Insert Character, ICH),
+			// not a letter — regression guard for the terminator range.
+			name:     "insert character",
+			input:    []byte("\x1b[5@"),
+			wantCat:  CategoryErase,
+			wantDesc: "Insert Characters (5)",
+		},
+		{
+			// '~' (0x7E) is a valid CSI final byte used by many real xterm
+			// sequences (Delete key, function keys, etc.) — regression
+			// guard for the terminator range extending past 'z' (0x7A).
+			name:     "tilde-terminated sequence",
+			input:    []byte("\x1b[3~"),
+			wantCat:  CategoryCSI,
+			wantDesc: "CSI ~ (3)",
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/terminal/delta.go
+++ b/server/terminal/delta.go
@@ -261,6 +261,7 @@ func splitIntoBytesLines(output []byte) [][]byte {
 // visible characters. Used for calculating cursor position.
 func stripANSIBytes(b []byte) []byte {
 	var result bytes.Buffer
+	result.Grow(len(b))
 	for i := 0; i < len(b); {
 		if b[i] == '\x1b' {
 			i += scanEscapeSequence(b, i)

--- a/server/terminal/delta.go
+++ b/server/terminal/delta.go
@@ -256,28 +256,18 @@ func splitIntoBytesLines(output []byte) [][]byte {
 	return lines
 }
 
-// stripANSIBytes removes ANSI escape sequences from raw bytes.
-// Used for calculating cursor position based on visible characters.
+// stripANSIBytes removes ANSI/DEC escape sequences (CSI, OSC, DCS/PM/APC/SOS,
+// charset designation, and simple escapes) from raw bytes, leaving only
+// visible characters. Used for calculating cursor position.
 func stripANSIBytes(b []byte) []byte {
 	var result bytes.Buffer
-	inEscape := false
-
-	for i := 0; i < len(b); i++ {
+	for i := 0; i < len(b); {
 		if b[i] == '\x1b' {
-			inEscape = true
+			i += scanEscapeSequence(b, i)
 			continue
 		}
-
-		if inEscape {
-			// End of escape sequence
-			if b[i] >= 'A' && b[i] <= 'Z' || b[i] >= 'a' && b[i] <= 'z' {
-				inEscape = false
-			}
-			continue
-		}
-
 		result.WriteByte(b[i])
+		i++
 	}
-
 	return result.Bytes()
 }

--- a/server/terminal/delta_test.go
+++ b/server/terminal/delta_test.go
@@ -309,6 +309,24 @@ func TestStripANSIBytes(t *testing.T) {
 			input:    "",
 			expected: "",
 		},
+		{
+			// OSC window-title sequence whose payload contains a letter
+			// ("my") before the real BEL terminator. A naive "any letter
+			// ends the escape" scanner stops at the 'm' in "my" and leaks
+			// "y title" + BEL into the visible count.
+			input:    "\x1b]0;my title\x07Hello",
+			expected: "Hello",
+		},
+		{
+			// OSC 8 hyperlink, terminated with ST (ESC \) instead of BEL.
+			input:    "\x1b]8;;https://example.com\x1b\\Link\x1b]8;;\x1b\\ done",
+			expected: "Link done",
+		},
+		{
+			// DCS sequence terminated with ST.
+			input:    "\x1bPq#0;2;0;0;0\x1b\\Sixel",
+			expected: "Sixel",
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/terminal/delta_test.go
+++ b/server/terminal/delta_test.go
@@ -327,6 +327,12 @@ func TestStripANSIBytes(t *testing.T) {
 			input:    "\x1bPq#0;2;0;0;0\x1b\\Sixel",
 			expected: "Sixel",
 		},
+		{
+			// '@' (Insert Character) and '~' (used by many real xterm
+			// sequences) are valid CSI final bytes that are not letters.
+			input:    "\x1b[5@Insert\x1b[3~Tilde",
+			expected: "InsertTilde",
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/terminal/escape_scan.go
+++ b/server/terminal/escape_scan.go
@@ -1,0 +1,93 @@
+package terminal
+
+// scanEscapeSequence returns the number of bytes, starting at b[start] (which
+// must be the ESC byte 0x1b), that make up one complete ANSI/DEC escape
+// sequence. It follows the same termination rules used by
+// pkg/analytics/escape_code_parser.go:
+//
+//   - CSI (ESC [ ...)            terminates on a letter (A-Z, a-z)
+//   - OSC (ESC ] ...)            terminates on BEL (0x07) or ST (ESC \)
+//   - DCS/PM/APC/SOS
+//     (ESC P/^/_/X ...)          terminate on ST (ESC \) or single-byte ST (0x9C)
+//   - charset designation (ESC (, ), *, or + then a designator byte) is 3 bytes
+//   - other simple escapes (ESC 7, ESC M, ESC c, C1-range second bytes, ...) are 2 bytes
+//
+// Treating any letter as a universal terminator (the previous behavior of
+// this package) is only correct for CSI: OSC/DCS/PM/APC/SOS payloads (window
+// titles, hyperlink URLs, base64 data, ...) routinely contain a letter well
+// before their real terminator, which caused the tail of those payloads to
+// be misread as visible terminal content.
+//
+// If a sequence runs off the end of b before it terminates, the remaining
+// bytes are treated as consumed rather than risk splitting a sequence that
+// is simply incomplete in this chunk. If b[start+1] is not a recognized
+// sequence-type byte, only the stray ESC itself is consumed so the
+// following byte is processed normally.
+func scanEscapeSequence(b []byte, start int) int {
+	if start >= len(b) || b[start] != '\x1b' {
+		return 0
+	}
+	if start+1 >= len(b) {
+		return len(b) - start
+	}
+
+	switch b[start+1] {
+	case '[':
+		return scanCSI(b, start)
+	case ']':
+		return scanUntilTerminator(b, start, true /* allowBEL */)
+	case 'P', '^', '_', 'X':
+		return scanUntilTerminator(b, start, false /* allowBEL */)
+	case '(', ')', '*', '+':
+		if start+2 < len(b) {
+			return 3
+		}
+		return len(b) - start
+	case '7', '8', 'D', 'E', 'H', 'M', 'N', 'O', 'Z', 'c':
+		return 2
+	default:
+		if b[start+1] >= 0x40 && b[start+1] <= 0x5F {
+			return 2
+		}
+		return 1
+	}
+}
+
+// scanCSI scans a CSI sequence (ESC [ params... intermediates... final) and
+// returns the total byte count from start, or the number of remaining bytes
+// if the sequence is unterminated.
+func scanCSI(b []byte, start int) int {
+	i := start + 2
+	for i < len(b) {
+		c := b[i]
+		switch {
+		case c >= 0x30 && c <= 0x3F, c >= 0x20 && c <= 0x2F:
+			i++
+		case (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'):
+			return i - start + 1
+		default:
+			// Not a valid CSI byte: treat the malformed prefix as consumed.
+			return i - start
+		}
+	}
+	return len(b) - start
+}
+
+// scanUntilTerminator scans an OSC/DCS/PM/APC/SOS sequence, terminating on
+// ST (ESC \) or, when allowBEL is true, also on BEL (0x07); DCS/PM/APC/SOS
+// additionally accept a single-byte ST (0x9C). Returns the total byte count
+// from start, or the number of remaining bytes if unterminated.
+func scanUntilTerminator(b []byte, start int, allowBEL bool) int {
+	for i := start + 2; i < len(b); i++ {
+		if allowBEL && b[i] == 0x07 {
+			return i - start + 1
+		}
+		if b[i] == '\x1b' && i+1 < len(b) && b[i+1] == '\\' {
+			return i - start + 2
+		}
+		if !allowBEL && b[i] == 0x9C {
+			return i - start + 1
+		}
+	}
+	return len(b) - start
+}

--- a/server/terminal/escape_scan.go
+++ b/server/terminal/escape_scan.go
@@ -1,22 +1,30 @@
 package terminal
 
+// maxUnterminatedScan caps how far scanUntilTerminator looks for a terminator
+// before giving up, mirroring pkg/analytics/escape_code_parser.go's OSC bound.
+// Without this, a pathological or truncated OSC/DCS payload (untrusted PTY
+// output) could force an unbounded scan.
+const maxUnterminatedScan = 65536
+
 // scanEscapeSequence returns the number of bytes, starting at b[start] (which
 // must be the ESC byte 0x1b), that make up one complete ANSI/DEC escape
 // sequence. It follows the same termination rules used by
 // pkg/analytics/escape_code_parser.go:
 //
-//   - CSI (ESC [ ...)            terminates on a letter (A-Z, a-z)
+//   - CSI (ESC [ ...)            terminates on a final byte in 0x40-0x7E
+//     (e.g. 'm' for SGR, '@' for Insert Character, 'h'/'l' for mode set/reset)
 //   - OSC (ESC ] ...)            terminates on BEL (0x07) or ST (ESC \)
 //   - DCS/PM/APC/SOS
 //     (ESC P/^/_/X ...)          terminate on ST (ESC \) or single-byte ST (0x9C)
 //   - charset designation (ESC (, ), *, or + then a designator byte) is 3 bytes
-//   - other simple escapes (ESC 7, ESC M, ESC c, C1-range second bytes, ...) are 2 bytes
+//   - other simple escapes (ESC 7, ESC 8, ESC c, C1-range second bytes, ...) are 2 bytes
 //
 // Treating any letter as a universal terminator (the previous behavior of
-// this package) is only correct for CSI: OSC/DCS/PM/APC/SOS payloads (window
-// titles, hyperlink URLs, base64 data, ...) routinely contain a letter well
-// before their real terminator, which caused the tail of those payloads to
-// be misread as visible terminal content.
+// this package) is wrong in two ways: it's too permissive for OSC/DCS/PM/APC/SOS,
+// whose payloads (window titles, hyperlink URLs, base64 data, ...) routinely
+// contain a letter well before their real terminator; and it's too strict for
+// CSI, which per ECMA-48 also terminates on non-letter bytes like '@' (0x40,
+// Insert Character) and '~' (0x7E, used by many real xterm sequences).
 //
 // If a sequence runs off the end of b before it terminates, the remaining
 // bytes are treated as consumed rather than risk splitting a sequence that
@@ -43,9 +51,11 @@ func scanEscapeSequence(b []byte, start int) int {
 			return 3
 		}
 		return len(b) - start
-	case '7', '8', 'D', 'E', 'H', 'M', 'N', 'O', 'Z', 'c':
+	case '7', '8', 'c':
 		return 2
 	default:
+		// C1-range second bytes (0x40-0x5F) are all simple two-byte escapes
+		// (index, next-line, reverse-index, single shifts, etc).
 		if b[start+1] >= 0x40 && b[start+1] <= 0x5F {
 			return 2
 		}
@@ -55,19 +65,28 @@ func scanEscapeSequence(b []byte, start int) int {
 
 // scanCSI scans a CSI sequence (ESC [ params... intermediates... final) and
 // returns the total byte count from start, or the number of remaining bytes
-// if the sequence is unterminated.
+// if the sequence is unterminated. If an invalid byte is encountered before a
+// terminator, only the ESC is treated as consumed (matching the "give up and
+// let the rest be reprocessed as ordinary bytes" behavior of
+// pkg/analytics/escape_code_parser.go's parseCSI on the same input) rather
+// than swallowing the partially-scanned parameter bytes.
 func scanCSI(b []byte, start int) int {
 	i := start + 2
 	for i < len(b) {
 		c := b[i]
 		switch {
 		case c >= 0x30 && c <= 0x3F, c >= 0x20 && c <= 0x2F:
+			// Parameter bytes (0-9 ; : < = > ?) and intermediate bytes
+			// (space through /).
 			i++
-		case (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'):
+		case c >= 0x40 && c <= 0x7E:
+			// Final byte per ECMA-48: '@' through '~', not just letters.
 			return i - start + 1
 		default:
-			// Not a valid CSI byte: treat the malformed prefix as consumed.
-			return i - start
+			// Not a valid CSI byte: give up on this sequence, consuming
+			// only the ESC so the rest (including the '[') is reprocessed
+			// as ordinary text.
+			return 1
 		}
 	}
 	return len(b) - start
@@ -76,9 +95,14 @@ func scanCSI(b []byte, start int) int {
 // scanUntilTerminator scans an OSC/DCS/PM/APC/SOS sequence, terminating on
 // ST (ESC \) or, when allowBEL is true, also on BEL (0x07); DCS/PM/APC/SOS
 // additionally accept a single-byte ST (0x9C). Returns the total byte count
-// from start, or the number of remaining bytes if unterminated.
+// from start, or the number of remaining bytes (capped at
+// maxUnterminatedScan) if unterminated.
 func scanUntilTerminator(b []byte, start int, allowBEL bool) int {
-	for i := start + 2; i < len(b); i++ {
+	limit := len(b)
+	if limit > start+maxUnterminatedScan {
+		limit = start + maxUnterminatedScan
+	}
+	for i := start + 2; i < limit; i++ {
 		if allowBEL && b[i] == 0x07 {
 			return i - start + 1
 		}
@@ -89,5 +113,5 @@ func scanUntilTerminator(b []byte, start int, allowBEL bool) int {
 			return i - start + 1
 		}
 	}
-	return len(b) - start
+	return limit - start
 }

--- a/server/terminal/escape_scan_test.go
+++ b/server/terminal/escape_scan_test.go
@@ -107,6 +107,46 @@ func TestScanEscapeSequence(t *testing.T) {
 			start:     0,
 			seqPrefix: "",
 		},
+		{
+			// '@' (0x40) is a valid CSI final byte (Insert Character, ICH)
+			// but is not a letter — regression guard for the terminator range.
+			name:      "csi_insert_character_at_sign",
+			input:     "\x1b[5@Hello",
+			start:     0,
+			seqPrefix: "\x1b[5@",
+		},
+		{
+			// '~' (0x7E) is a valid CSI final byte used by many real xterm
+			// sequences (Delete key, function keys, etc.) — regression
+			// guard for the terminator range extending past 'z' (0x7A).
+			name:      "csi_tilde_final_byte",
+			input:     "\x1b[3~Hello",
+			start:     0,
+			seqPrefix: "\x1b[3~",
+		},
+		{
+			// An invalid byte mid-CSI (not a param/intermediate/final byte)
+			// gives up on the sequence, consuming only the ESC so the rest
+			// (including '[') is reprocessed as ordinary text.
+			name:      "csi_invalid_byte_mid_sequence",
+			input:     "\x1b[3\x01mHello",
+			start:     0,
+			seqPrefix: "\x1b",
+		},
+		{
+			// scanEscapeSequence must work correctly when start > 0 (a real
+			// sequence mid-buffer), not just at start == 0.
+			name:      "csi_mid_buffer_not_at_start",
+			input:     "xy\x1b[31mRed",
+			start:     2,
+			seqPrefix: "\x1b[31m",
+		},
+		{
+			name:      "osc_mid_buffer_not_at_start",
+			input:     "xy\x1b]8;;https://example.com\x1b\\Link",
+			start:     2,
+			seqPrefix: "\x1b]8;;https://example.com\x1b\\",
+		},
 	}
 
 	for _, tt := range tests {
@@ -123,6 +163,24 @@ func TestScanEscapeSequence(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestScanUntilTerminator_SizeCap verifies an unterminated OSC/DCS payload
+// (e.g. truncated at a chunk boundary, or adversarial/untrusted PTY output)
+// doesn't force an unbounded scan — it gives up after maxUnterminatedScan
+// bytes rather than scanning to the end of an arbitrarily large buffer.
+func TestScanUntilTerminator_SizeCap(t *testing.T) {
+	payload := make([]byte, maxUnterminatedScan+1000)
+	payload[0] = '\x1b'
+	payload[1] = ']'
+	for i := 2; i < len(payload); i++ {
+		payload[i] = 'x' // never a BEL or ST terminator
+	}
+
+	got := scanEscapeSequence(payload, 0)
+	if got != maxUnterminatedScan {
+		t.Errorf("scanEscapeSequence on unterminated OSC longer than the cap = %d, want %d", got, maxUnterminatedScan)
 	}
 }
 

--- a/server/terminal/escape_scan_test.go
+++ b/server/terminal/escape_scan_test.go
@@ -1,0 +1,139 @@
+package terminal
+
+import "testing"
+
+func TestScanEscapeSequence(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		start int
+		// seqPrefix is the exact sequence bytes expected to be consumed,
+		// starting at input[start]. want = len(seqPrefix).
+		seqPrefix string
+	}{
+		{
+			name:      "csi_sgr",
+			input:     "\x1b[31mRed",
+			start:     0,
+			seqPrefix: "\x1b[31m",
+		},
+		{
+			name:      "csi_private_mode",
+			input:     "\x1b[?25hVisible",
+			start:     0,
+			seqPrefix: "\x1b[?25h",
+		},
+		{
+			name:      "csi_unterminated_drops_rest",
+			input:     "\x1b[31",
+			start:     0,
+			seqPrefix: "\x1b[31",
+		},
+		{
+			name:      "osc_terminated_by_bel_with_letter_in_payload",
+			input:     "\x1b]0;my title\x07Hello",
+			start:     0,
+			seqPrefix: "\x1b]0;my title\x07",
+		},
+		{
+			name:      "osc_terminated_by_st",
+			input:     "\x1b]8;;https://example.com\x1b\\Link",
+			start:     0,
+			seqPrefix: "\x1b]8;;https://example.com\x1b\\",
+		},
+		{
+			name:      "osc_unterminated_drops_rest",
+			input:     "\x1b]0;no terminator",
+			start:     0,
+			seqPrefix: "\x1b]0;no terminator",
+		},
+		{
+			name:      "dcs_terminated_by_st",
+			input:     "\x1bPq#0;2;0;0;0\x1b\\Sixel",
+			start:     0,
+			seqPrefix: "\x1bPq#0;2;0;0;0\x1b\\",
+		},
+		{
+			name:      "dcs_terminated_by_single_byte_st",
+			input:     "\x1bPq#0\x9cSixel",
+			start:     0,
+			seqPrefix: "\x1bPq#0\x9c",
+		},
+		{
+			name:      "charset_designation",
+			input:     "\x1b(BHello",
+			start:     0,
+			seqPrefix: "\x1b(B",
+		},
+		{
+			name:      "charset_designation_unterminated",
+			input:     "\x1b(",
+			start:     0,
+			seqPrefix: "\x1b(",
+		},
+		{
+			name:      "simple_save_cursor",
+			input:     "\x1b7Hello",
+			start:     0,
+			seqPrefix: "\x1b7",
+		},
+		{
+			name:      "simple_reverse_index",
+			input:     "\x1bMHello",
+			start:     0,
+			seqPrefix: "\x1bM",
+		},
+		{
+			name:      "c1_range_second_byte",
+			input:     "\x1b\x40Hello",
+			start:     0,
+			seqPrefix: "\x1b\x40",
+		},
+		{
+			name:      "unrecognized_second_byte_consumes_only_esc",
+			input:     "\x1b9Hello",
+			start:     0,
+			seqPrefix: "\x1b",
+		},
+		{
+			name:      "lone_esc_at_end_of_buffer",
+			input:     "text\x1b",
+			start:     4,
+			seqPrefix: "\x1b",
+		},
+		{
+			name:      "not_an_escape_byte",
+			input:     "Hello",
+			start:     0,
+			seqPrefix: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := len(tt.seqPrefix)
+			got := scanEscapeSequence([]byte(tt.input), tt.start)
+			if got != want {
+				if consumed, ok := boundedSlice(tt.input, tt.start, tt.start+got); ok {
+					t.Errorf("scanEscapeSequence(%q, %d) = %d, want %d (consumed %q, expected %q)",
+						tt.input, tt.start, got, want, consumed, tt.seqPrefix)
+				} else {
+					t.Errorf("scanEscapeSequence(%q, %d) = %d, want %d (result index out of range; expected %q)",
+						tt.input, tt.start, got, want, tt.seqPrefix)
+				}
+			}
+		})
+	}
+}
+
+// boundedSlice returns s[start:end] and true when the range is valid, or
+// ("", false) when it isn't. A bounds violation and a valid-but-empty slice
+// must never be conflated into the same string value (e.g. a sentinel like
+// "<out of range>"), since that string could coincidentally equal real
+// content being sliced — the ok bool is the only authoritative signal.
+func boundedSlice(s string, start, end int) (string, bool) {
+	if start < 0 || end > len(s) || start > end {
+		return "", false
+	}
+	return s[start:end], true
+}

--- a/server/terminal/state.go
+++ b/server/terminal/state.go
@@ -248,7 +248,7 @@ func (sg *StateGenerator) calculateCursorPosition(lines []*sessionv1.TerminalLin
 		if !lines[i].Attributes.IsEmpty {
 			cursorRow = uint32(i)
 			// Calculate visual character width (strip ANSI codes, handle multi-byte UTF-8)
-			visibleContent := sg.stripANSIBytes(lines[i].Content)
+			visibleContent := stripANSIBytes(lines[i].Content)
 			// Use runewidth to get visual column count instead of byte length
 			// This properly handles multi-byte UTF-8, wide characters (CJK/emoji), and zero-width chars
 			cursorCol = uint32(runewidth.StringWidth(string(visibleContent)))
@@ -263,11 +263,6 @@ func (sg *StateGenerator) calculateCursorPosition(lines []*sessionv1.TerminalLin
 	}
 }
 
-// stripANSIBytes removes ANSI escape sequences for visible character counting
-func (sg *StateGenerator) stripANSIBytes(b []byte) []byte {
-	return stripANSIBytes(b)
-}
-
 // sanitizeUTF8Bytes converts raw bytes to valid UTF-8, preserving ANSI escape sequences
 // This prevents xterm.js parsing errors from invalid byte sequences while maintaining
 // terminal formatting and color information
@@ -279,6 +274,7 @@ func (sg *StateGenerator) sanitizeUTF8Bytes(rawBytes []byte) []byte {
 
 	// Convert to valid UTF-8 by replacing invalid sequences
 	var result bytes.Buffer
+	result.Grow(len(rawBytes))
 
 	for i := 0; i < len(rawBytes); {
 		// Escape sequence: consume and preserve the whole sequence at once,

--- a/server/terminal/state.go
+++ b/server/terminal/state.go
@@ -265,27 +265,7 @@ func (sg *StateGenerator) calculateCursorPosition(lines []*sessionv1.TerminalLin
 
 // stripANSIBytes removes ANSI escape sequences for visible character counting
 func (sg *StateGenerator) stripANSIBytes(b []byte) []byte {
-	var result bytes.Buffer
-	inEscape := false
-
-	for i := 0; i < len(b); i++ {
-		if b[i] == '\x1b' {
-			inEscape = true
-			continue
-		}
-
-		if inEscape {
-			// End of escape sequence
-			if b[i] >= 'A' && b[i] <= 'Z' || b[i] >= 'a' && b[i] <= 'z' {
-				inEscape = false
-			}
-			continue
-		}
-
-		result.WriteByte(b[i])
-	}
-
-	return result.Bytes()
+	return stripANSIBytes(b)
 }
 
 // sanitizeUTF8Bytes converts raw bytes to valid UTF-8, preserving ANSI escape sequences
@@ -299,26 +279,15 @@ func (sg *StateGenerator) sanitizeUTF8Bytes(rawBytes []byte) []byte {
 
 	// Convert to valid UTF-8 by replacing invalid sequences
 	var result bytes.Buffer
-	inEscape := false
 
 	for i := 0; i < len(rawBytes); {
-		// Start of ANSI escape sequence
+		// Escape sequence: consume and preserve the whole sequence at once,
+		// so an OSC/DCS payload containing a letter (window titles,
+		// hyperlink URLs, etc.) doesn't get split mid-payload.
 		if rawBytes[i] == '\x1b' {
-			inEscape = true
-			result.WriteByte(rawBytes[i])
-			i++
-			continue
-		}
-
-		// Inside ANSI escape sequence - preserve all bytes
-		if inEscape {
-			b := rawBytes[i]
-			result.WriteByte(b)
-			// End of escape sequence (letter terminates most ANSI sequences)
-			if (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') {
-				inEscape = false
-			}
-			i++
+			n := scanEscapeSequence(rawBytes, i)
+			result.Write(rawBytes[i : i+n])
+			i += n
 			continue
 		}
 

--- a/server/terminal/state_test.go
+++ b/server/terminal/state_test.go
@@ -452,6 +452,12 @@ func TestStateGenerator_StripANSIBytes(t *testing.T) {
 			input:    "\x1b[38;5;208mOrange\x1b[0m",
 			expected: "Orange",
 		},
+		{
+			// OSC sequence with a letter in the payload before its BEL
+			// terminator must not be split mid-payload.
+			input:    "\x1b]0;my title\x07Hello",
+			expected: "Hello",
+		},
 	}
 
 	for i, tt := range tests {
@@ -596,6 +602,18 @@ func TestStateGenerator_SanitizeUTF8Bytes(t *testing.T) {
 			input:    []byte("Text\x07Bell\x08Backspace"),
 			expected: "Text\x07Bell\x08Backspace",
 			desc:     "Bell and backspace characters should be preserved",
+		},
+		{
+			name:     "osc_title_with_letter_in_payload",
+			input:    []byte("\x1b]0;my title\x07Hello"),
+			expected: "\x1b]0;my title\x07Hello",
+			desc:     "OSC title sequence must be preserved intact even though its payload contains a letter before the BEL terminator",
+		},
+		{
+			name:     "osc_hyperlink_terminated_by_st",
+			input:    []byte("\x1b]8;;https://example.com\x1b\\Link\x1b]8;;\x1b\\"),
+			expected: "\x1b]8;;https://example.com\x1b\\Link\x1b]8;;\x1b\\",
+			desc:     "OSC 8 hyperlink sequences terminated by ST (ESC \\\\) must be preserved intact",
 		},
 	}
 

--- a/server/terminal/state_test.go
+++ b/server/terminal/state_test.go
@@ -424,10 +424,9 @@ func TestStateGenerator_MonotonicSequencing(t *testing.T) {
 	}
 }
 
-// TestStateGenerator_StripANSIBytes tests ANSI escape sequence removal in StateGenerator
+// TestStateGenerator_StripANSIBytes tests ANSI escape sequence removal used by
+// StateGenerator (via the shared package-level stripANSIBytes).
 func TestStateGenerator_StripANSIBytes(t *testing.T) {
-	sg := NewStateGenerator(80, 24)
-
 	tests := []struct {
 		input    string
 		expected string
@@ -458,11 +457,26 @@ func TestStateGenerator_StripANSIBytes(t *testing.T) {
 			input:    "\x1b]0;my title\x07Hello",
 			expected: "Hello",
 		},
+		{
+			// OSC 8 hyperlink, terminated with ST (ESC \) instead of BEL.
+			input:    "\x1b]8;;https://example.com\x1b\\Link",
+			expected: "Link",
+		},
+		{
+			// DCS sequence terminated with ST.
+			input:    "\x1bPq#0;2;0;0;0\x1b\\Sixel",
+			expected: "Sixel",
+		},
+		{
+			// CSI final byte '@' (Insert Character) is not a letter.
+			input:    "\x1b[5@Hello",
+			expected: "Hello",
+		},
 	}
 
 	for i, tt := range tests {
 		t.Run("strip_test_"+string(rune('A'+i)), func(t *testing.T) {
-			result := sg.stripANSIBytes([]byte(tt.input))
+			result := stripANSIBytes([]byte(tt.input))
 			if string(result) != tt.expected {
 				t.Errorf("Expected %q, got %q", tt.expected, string(result))
 			}


### PR DESCRIPTION
## Summary

Since Claude Code's newer terminal renderer started emitting more OSC sequences (window title, hyperlinks, shell-integration marks), the web terminal pane started showing visual artifacts (garbled leftover text, misaligned cursor positioning).

Root cause: `stripANSIBytes` and `sanitizeUTF8Bytes` in `server/terminal/` treated **any ASCII letter** as the terminator of an escape sequence. That's only correct for CSI (`ESC[...letter`). OSC sequences terminate on BEL or `ESC\`, and DCS/PM/APC/SOS terminate on `ESC\` or a single `0x9C` byte — their payloads (titles, URLs, etc.) almost always contain a letter before the real terminator, so the scanner exited early and let the tail of the payload + terminator bleed through as literal visible text (and threw off cursor-column math used for the same purpose).

## Changes

- `server/terminal/escape_scan.go` (new): shared `scanEscapeSequence` helper implementing correct CSI/OSC/DCS/PM/APC/SOS/charset/simple-escape boundary detection, mirroring the already-correct logic in `pkg/analytics/escape_code_parser.go`.
- `server/terminal/delta.go`: `stripANSIBytes` rewired to use the shared scanner (was a byte-for-byte duplicate of the buggy state.go version).
- `server/terminal/state.go`: `stripANSIBytes` now delegates to the shared free function; `sanitizeUTF8Bytes` consumes whole escape sequences atomically instead of a letter-by-letter `inEscape` flag.
- Tests: regression cases for OSC (BEL- and ST-terminated) and DCS sequences with embedded letters in `delta_test.go`/`state_test.go`, plus a dedicated `escape_scan_test.go` table covering all sequence types and edge cases (unterminated, unrecognized second byte, buffer boundary).

Investigated and confirmed out of scope for this PR: `session/tmux/banner_filter.go` (matches tmux's own status-bar chrome, not Claude's output) and `session/framebuffer/diff.go` (dead code, not wired into the live capture path).

## Test plan

- [x] `go build ./server/terminal/...`
- [x] `go test ./server/terminal/...` — all existing + new cases pass
- [x] `make quick-check` — full build, all package tests, lint, registry validation all green
- [x] `make build` — Go + web UI build succeeds end-to-end