### PR TITLE
fix(backlog): stable client-side keys for acceptance-criteria rows

### DIFF
--- a/web-app/src/components/backlog/BacklogItemForm.test.tsx
+++ b/web-app/src/components/backlog/BacklogItemForm.test.tsx
@@ -90,3 +90,51 @@ describe("BacklogItemForm — cloning busy state", () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
   });
 });
+
+describe("BacklogItemForm — acceptance criteria row identity", () => {
+  it("BacklogItemForm_should_PreserveRowIdentity_When_EarlierRowRemoved", () => {
+    render(
+      <BacklogItemForm
+        initialValues={{
+          acCriteria: [
+            { index: 0, text: "First criterion", status: "pending" },
+            { index: 1, text: "Second criterion", status: "pending" },
+          ],
+        }}
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+
+    const secondRowInput = screen.getByTestId("backlog-criterion-text-1");
+    secondRowInput.focus();
+
+    fireEvent.click(screen.getByTestId("backlog-remove-criterion-0"));
+
+    const survivingInput = screen.getByTestId("backlog-criterion-text-0");
+    expect(survivingInput).toBe(secondRowInput);
+    expect(survivingInput).toHaveValue("Second criterion");
+    expect(document.activeElement).toBe(survivingInput);
+  });
+
+  it("strips clientKey from the acCriteria payload on submit", async () => {
+    const onSubmit = jest.fn(() => Promise.resolve());
+    render(
+      <BacklogItemForm
+        initialValues={{
+          id: "item-1",
+          title: "Existing item",
+          acCriteria: [{ index: 0, text: "A criterion", status: "pending" }],
+        }}
+        onSubmit={onSubmit}
+        onCancel={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("backlog-form-submit"));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const { acCriteria } = onSubmit.mock.calls[0][0];
+    expect(acCriteria).toEqual([{ index: 0, text: "A criterion", status: "pending" }]);
+  });
+});

--- a/web-app/src/components/backlog/BacklogItemForm.tsx
+++ b/web-app/src/components/backlog/BacklogItemForm.tsx
@@ -26,6 +26,8 @@ const AC_STATUS_OPTIONS: { value: AcCriterionStatus; label: string }[] = [
   { value: "done", label: "Done" },
 ];
 
+type AcCriterionRow = AcCriterion & { clientKey: string };
+
 export function BacklogItemForm({
   initialValues,
   onSubmit,
@@ -38,8 +40,10 @@ export function BacklogItemForm({
   const [priority, setPriority] = useState<number>(initialValues?.priority ?? 3);
   const [skipPlanning, setSkipPlanning] = useState(initialValues?.skipPlanning ?? false);
   const [skipReviewGate, setSkipReviewGate] = useState(initialValues?.skipReviewGate ?? false);
-  const [acCriteria, setAcCriteria] = useState<AcCriterion[]>(
-    initialValues?.acCriteria ?? []
+  // Lazy initializer: crypto.randomUUID() must only run once per row at mount,
+  // not on every re-render.
+  const [acCriteria, setAcCriteria] = useState<AcCriterionRow[]>(
+    () => (initialValues?.acCriteria ?? []).map((c) => ({ ...c, clientKey: crypto.randomUUID() }))
   );
   const [errors, setErrors] = useState<FormErrors>({});
   const [submitting, setSubmitting] = useState(false);
@@ -76,7 +80,7 @@ export function BacklogItemForm({
           priority,
           skipPlanning,
           skipReviewGate,
-          acCriteria: acCriteria.map((c, i) => ({ ...c, index: i })),
+          acCriteria: acCriteria.map(({ clientKey, ...rest }, i) => ({ ...rest, index: i })),
           skipTriage: isVague,
         });
       } finally {
@@ -89,7 +93,7 @@ export function BacklogItemForm({
   const addCriterion = useCallback(() => {
     setAcCriteria((prev) => [
       ...prev,
-      { index: prev.length, text: "", status: "pending" as AcCriterionStatus },
+      { index: prev.length, text: "", status: "pending" as AcCriterionStatus, clientKey: crypto.randomUUID() },
     ]);
   }, []);
 
@@ -266,7 +270,7 @@ export function BacklogItemForm({
         {acCriteria.length > 0 && (
           <div className={styles.acList} role="list" aria-label="Acceptance criteria list">
             {acCriteria.map((criterion, i) => (
-              <div key={i} className={styles.acRow} role="listitem">
+              <div key={criterion.clientKey} className={styles.acRow} role="listitem">
                 <input
                   type="text"
                   className={styles.acInput}


### PR DESCRIPTION
## Summary
- Closes out backlog item #146 ("acceptance criteria disappear while editing during triage"). The core fix (loading-guard `if (loading && !item)` + poll suspend `|| editMode`) was already merged and verified passing (`BacklogItemDetail.regression.test.tsx`, 2/2 green).
- This PR adds the item's optional nit (AC #6): `BacklogItemForm`'s acceptance-criteria rows now key off a stable client-only `clientKey` (`crypto.randomUUID()`) instead of array index, so removing an earlier row no longer causes React to misattribute DOM/focus state to the wrong row. `clientKey` is stripped before the `onSubmit` payload — wire shape unchanged.

## Test plan
- [x] `cd web-app && npx jest --testPathPatterns BacklogItemDetail.regression` → 2 passed, 2 total
- [x] `cd web-app && npx jest --testPathPatterns "BacklogItem"` → 9 passed, 9 total (incl. 2 new tests: DOM/focus identity survives row removal, `clientKey` excluded from submit payload)
- [x] Confirmed running local stapler-squad service (`1.37.0-16-g618c859a-dirty`) already has fix commit 6ef8164b as an ancestor — no restart required.
- [x] Filed follow-up #185 for the separately-scoped "wire Jest into CI" gap (CI currently runs zero Jest tests; out of proportion to bundle into this nit PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)