### PR TITLE
Acceptance criteria disappear while editing a backlog item during triage (loading guard unmounts the edit form on every 5s poll)

### DIFF
--- a/server/dependencies.go
+++ b/server/dependencies.go
@@ -19,6 +19,7 @@ import (
 type ServerDependencies struct {
 	SessionService          *services.SessionService
 	Storage                 *session.Storage
+	Instances               []*session.Instance
 	EventBus                *events.EventBus
 	StatusManager           *session.InstanceStatusManager
 	ReviewQueue             *session.ReviewQueue
@@ -28,6 +29,7 @@ type ServerDependencies struct {
 	TmuxStreamerManager     *session.ExternalTmuxStreamerManager
 	ExternalDiscovery       *session.ExternalSessionDiscovery
 	ExternalApprovalMonitor *session.ExternalApprovalMonitor
+	HistoryLinker           *session.HistoryLinker
 }
 
 // BuildDependencies constructs and wires all server dependencies in the correct order.
@@ -62,6 +64,7 @@ func BuildDependencies() (*ServerDependencies, error) {
 	return &ServerDependencies{
 		SessionService:          rt.SessionService,
 		Storage:                 rt.Storage,
+		Instances:               rt.Instances,
 		EventBus:                rt.EventBus,
 		StatusManager:           rt.StatusManager,
 		ReviewQueue:             rt.ReviewQueue,
@@ -71,6 +74,7 @@ func BuildDependencies() (*ServerDependencies, error) {
 		TmuxStreamerManager:     rt.TmuxStreamerManager,
 		ExternalDiscovery:       rt.ExternalDiscovery,
 		ExternalApprovalMonitor: rt.ExternalApprovalMonitor,
+		HistoryLinker:           rt.HistoryLinker,
 	}, nil
 }
 
@@ -337,6 +341,7 @@ type RuntimeDeps struct {
 	TmuxStreamerManager     *session.ExternalTmuxStreamerManager
 	ExternalDiscovery       *session.ExternalSessionDiscovery
 	ExternalApprovalMonitor *session.ExternalApprovalMonitor
+	HistoryLinker           *session.HistoryLinker
 }
 
 // BuildRuntimeDeps constructs Phase 3 dependencies using Phase 2 outputs.
@@ -428,6 +433,12 @@ func BuildRuntimeDeps(svc *ServiceDeps) (*RuntimeDeps, error) {
 	sessionService.SetReactiveQueueManager(reactiveQueueMgr)
 	log.InfoLog.Printf("ReactiveQueueManager initialized")
 
+	// Step 8.5: HistoryLinker — detects Claude JSONL files and links conversation
+	// UUIDs to sessions so cold restore can use --resume on restart.
+	historyLinker := session.NewHistoryLinkerFromRealInspector()
+	historyLinker.SetInstances(instances)
+	log.InfoLog.Printf("HistoryLinker initialized with %d instances", len(instances))
+
 	// Step 9: ScrollbackManager (independent of above)
 	homeDir, _ := os.UserHomeDir()
 	scrollbackPath := filepath.Join(homeDir, ".stapler-squad", "sessions")
@@ -452,11 +463,13 @@ func BuildRuntimeDeps(svc *ServiceDeps) (*RuntimeDeps, error) {
 		instance.SetReviewQueue(reviewQueue)
 		instance.SetStatusManager(statusManager)
 		reviewQueuePoller.AddInstance(instance)
-		log.InfoLog.Printf("Added external session '%s' to review queue poller", instance.Title)
+		historyLinker.AddInstance(instance)
+		log.InfoLog.Printf("Added external session '%s' to review queue poller and history linker", instance.Title)
 	})
 	externalDiscovery.OnSessionRemoved(func(instance *session.Instance) {
 		reviewQueuePoller.RemoveInstance(instance.Title)
-		log.InfoLog.Printf("Removed external session '%s' from review queue poller", instance.Title)
+		historyLinker.RemoveInstance(instance.Title)
+		log.InfoLog.Printf("Removed external session '%s' from review queue poller and history linker", instance.Title)
 		reviewQueue.Remove(instance.Title)
 		if err := storage.DeleteInstance(instance.Title); err != nil {
 			log.WarningLog.Printf("Failed to remove external session '%s' from storage: %v", instance.Title, err)
@@ -519,5 +532,6 @@ func BuildRuntimeDeps(svc *ServiceDeps) (*RuntimeDeps, error) {
 		TmuxStreamerManager:     tmuxStreamerManager,
 		ExternalDiscovery:       externalDiscovery,
 		ExternalApprovalMonitor: externalApprovalMonitor,
+		HistoryLinker:           historyLinker,
 	}, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	httpsURL       string                          // set when remote access is enabled
 	hostnames      []string                        // detected LAN hostnames
 	origins        []string                        // allowed CORS origins
+	shutdownHooks  []func()                        // called before HTTP server stops
 }
 
 // NewServer creates a new HTTP server instance with SessionService registered.
@@ -84,6 +85,39 @@ func NewServer(addr string) *Server {
 		serverCtx := context.Background()
 		go deps.ReactiveQueueMgr.Start(serverCtx)
 		log.InfoLog.Printf("ReactiveQueueManager started")
+
+		// Start HistoryLinker: detects Claude JSONL files and links conversation
+		// UUIDs to sessions so cold restore can use --resume on restart.
+		go deps.HistoryLinker.Start(serverCtx)
+		log.InfoLog.Printf("HistoryLinker started")
+
+		// Register shutdown hook: capture pane working dirs and persist instance
+		// state so cold restore can find the right directory on next start.
+		// Uses HistoryLinker.Instances() (not the startup snapshot) so externally
+		// discovered sessions added after startup are also captured.
+		historyLinker := deps.HistoryLinker
+		storage := deps.Storage
+		srv.shutdownHooks = append(srv.shutdownHooks, func() {
+			instances := historyLinker.Instances()
+			deadline := time.Now().Add(4 * time.Second) // leave headroom for HTTP graceful shutdown
+			captured := 0
+			for _, inst := range instances {
+				if time.Now().After(deadline) {
+					log.WarningLog.Printf("[shutdown] Capture deadline exceeded; skipped %d of %d instances",
+						len(instances)-captured, len(instances))
+					break
+				}
+				if err := inst.CaptureCurrentState(); err != nil {
+					log.WarningLog.Printf("[shutdown] CaptureCurrentState '%s': %v", inst.Title, err)
+				}
+				captured++
+			}
+			if err := storage.SaveInstances(instances); err != nil {
+				log.WarningLog.Printf("[shutdown] SaveInstances: %v", err)
+			} else {
+				log.InfoLog.Printf("[shutdown] Persisted working dirs for %d instances", captured)
+			}
+		})
 
 		// Initialize notification history store and EventBus subscriber.
 		// notifStore is declared here so it can be wired into the approval handler below.
@@ -293,6 +327,12 @@ func (s *Server) Start(ctx context.Context) error {
 
 // Shutdown gracefully shuts down the HTTP server.
 func (s *Server) Shutdown() error {
+	// Run registered hooks (e.g. capture pane paths, persist instance state) before
+	// stopping the HTTP server so in-flight requests complete first.
+	for _, hook := range s.shutdownHooks {
+		hook()
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/server/services/workspace_service.go
+++ b/server/services/workspace_service.go
@@ -253,6 +253,14 @@ func (ws *WorkspaceService) SwitchWorkspace(
 		BaseRevision:    req.Msg.BaseRevision,
 	}
 
+	// Create a named checkpoint before switching so the state is recoverable.
+	if instance.Started() && !instance.Paused() {
+		label := "pre-switch: " + req.Msg.Target
+		if _, cpErr := instance.CreateCheckpoint(label, 0); cpErr != nil {
+			log.WarningLog.Printf("SwitchWorkspace: pre-switch checkpoint for '%s' failed (non-fatal): %v", instance.Title, cpErr)
+		}
+	}
+
 	result, err := instance.SwitchWorkspace(switchReq)
 	if err != nil {
 		return connect.NewResponse(&sessionv1.SwitchWorkspaceResponse{

--- a/session/capture_test.go
+++ b/session/capture_test.go
@@ -1,0 +1,45 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCaptureCurrentState_NotStarted_IsNoOp verifies that CaptureCurrentState
+// returns nil without modifying WorkingDir when the instance has not been started.
+func TestCaptureCurrentState_NotStarted_IsNoOp(t *testing.T) {
+	inst := &Instance{Title: "test-session"}
+	// inst.started == false by default
+
+	err := inst.CaptureCurrentState()
+
+	require.NoError(t, err)
+	assert.Empty(t, inst.WorkingDir, "WorkingDir should not be set for unstarted instance")
+}
+
+// TestCaptureCurrentState_Paused_IsNoOp verifies that CaptureCurrentState
+// returns nil without modifying WorkingDir when the instance is paused.
+func TestCaptureCurrentState_Paused_IsNoOp(t *testing.T) {
+	inst := &Instance{Title: "test-session", started: true}
+	inst.Status = Paused
+
+	err := inst.CaptureCurrentState()
+
+	require.NoError(t, err)
+	assert.Empty(t, inst.WorkingDir, "WorkingDir should not be set for paused instance")
+}
+
+// TestCaptureCurrentState_TmuxSessionDead_IsNoOp verifies that CaptureCurrentState
+// returns nil when the underlying tmux session does not exist (nil TmuxSession).
+// TmuxProcessManager.DoesSessionExist() returns false when its session field is nil.
+func TestCaptureCurrentState_TmuxSessionDead_IsNoOp(t *testing.T) {
+	inst := &Instance{Title: "test-session", started: true}
+	// tmuxManager is zero-value: session == nil → DoesSessionExist() returns false
+
+	err := inst.CaptureCurrentState()
+
+	require.NoError(t, err)
+	assert.Empty(t, inst.WorkingDir, "WorkingDir should not be set when tmux session is dead")
+}

--- a/session/capture_test.go
+++ b/session/capture_test.go
@@ -1,10 +1,12 @@
 package session
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tstapler/stapler-squad/session/tmux"
 )
 
 // TestCaptureCurrentState_NotStarted_IsNoOp verifies that CaptureCurrentState
@@ -42,4 +44,28 @@ func TestCaptureCurrentState_TmuxSessionDead_IsNoOp(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Empty(t, inst.WorkingDir, "WorkingDir should not be set when tmux session is dead")
+}
+
+// TestInstance_CaptureCurrentState_UpdatesWorkingDir verifies the happy path:
+// a started, running instance with a live tmux session has WorkingDir populated.
+func TestInstance_CaptureCurrentState_UpdatesWorkingDir(t *testing.T) {
+	const sessionName = "capture-happy"
+	mockExec := &tmux.MockCmdExec{
+		// list-sessions response: our session is alive
+		CombinedOutputFunc: func(_ *exec.Cmd) ([]byte, error) {
+			return []byte("staplersquad_capture-happy\n"), nil
+		},
+		// display-message response: current pane path
+		OutputFunc: func(_ *exec.Cmd) ([]byte, error) {
+			return []byte("/home/user/project\n"), nil
+		},
+	}
+	mockSession := tmux.NewTmuxSessionWithDeps(sessionName, "echo", nil, mockExec)
+	inst := &Instance{Title: sessionName, started: true}
+	inst.tmuxManager.SetSession(mockSession)
+
+	err := inst.CaptureCurrentState()
+
+	require.NoError(t, err)
+	assert.Equal(t, "/home/user/project", inst.WorkingDir)
 }

--- a/session/history_linker.go
+++ b/session/history_linker.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -25,6 +27,40 @@ type HistoryLinker struct {
 
 	mu        sync.RWMutex
 	instances []*Instance
+}
+
+// NewHistoryLinkerFromRealInspector creates a HistoryLinker backed by the real
+// gopsutil-based process inspector and an fsnotify watcher on ~/.claude/projects/.
+// This is the production constructor; use NewHistoryLinker in tests.
+func NewHistoryLinkerFromRealInspector() *HistoryLinker {
+	detector := NewHistoryFileDetectorWithRealInspector()
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.WarningLog.Printf("HistoryLinker: failed to get home dir, watcher disabled: %v", err)
+		homeDir = ""
+	}
+	watchDir := filepath.Join(homeDir, ".claude", "projects")
+
+	// Build the linker first so the watcher callback can close over it.
+	hl := &HistoryLinker{
+		detector:  detector,
+		instances: make([]*Instance, 0),
+	}
+	hl.watcher = NewHistoryFileWatcher(watchDir, func(_ string) {
+		hl.ScanAll()
+	})
+	return hl
+}
+
+// Instances returns a snapshot of the currently monitored instances.
+// Used by shutdown hooks that need the live set (including externally added sessions).
+func (hl *HistoryLinker) Instances() []*Instance {
+	hl.mu.RLock()
+	defer hl.mu.RUnlock()
+	snap := make([]*Instance, len(hl.instances))
+	copy(snap, hl.instances)
+	return snap
 }
 
 // NewHistoryLinker creates a HistoryLinker backed by the given detector and watcher.

--- a/session/history_linker_test.go
+++ b/session/history_linker_test.go
@@ -114,3 +114,50 @@ func TestHistoryLinker_StartAndStop(t *testing.T) {
 	// Verify it doesn't panic or block.
 	<-ctx.Done()
 }
+
+// TestNewHistoryLinkerFromRealInspector_ReturnsNonNil is a smoke test that verifies
+// the production constructor builds without panicking and returns a usable linker.
+func TestNewHistoryLinkerFromRealInspector_ReturnsNonNil(t *testing.T) {
+	linker := NewHistoryLinkerFromRealInspector()
+
+	require.NotNil(t, linker, "constructor should return a non-nil HistoryLinker")
+	require.NotNil(t, linker.detector, "detector should be initialized")
+	// watcher is created but not started yet — Start() is called separately.
+}
+
+// TestHistoryLinker_Instances_SnapshotIncludesAddedSessions verifies that Instances()
+// returns a consistent snapshot that reflects AddInstance calls.
+func TestHistoryLinker_Instances_SnapshotIncludesAddedSessions(t *testing.T) {
+	inspector := &mockProcessInspector{files: []string{}}
+	detector := NewHistoryFileDetector(inspector)
+	linker := NewHistoryLinker(detector, nil)
+
+	a := makeTestInstance("a")
+	b := makeTestInstance("b")
+	linker.AddInstance(a)
+	linker.AddInstance(b)
+
+	snap := linker.Instances()
+
+	require.Len(t, snap, 2)
+	titles := []string{snap[0].Title, snap[1].Title}
+	assert.Contains(t, titles, "a")
+	assert.Contains(t, titles, "b")
+}
+
+// TestHistoryLinker_Instances_SnapshotIsIndependent verifies that mutating the returned
+// snapshot does not affect the linker's internal state.
+func TestHistoryLinker_Instances_SnapshotIsIndependent(t *testing.T) {
+	inspector := &mockProcessInspector{files: []string{}}
+	detector := NewHistoryFileDetector(inspector)
+	linker := NewHistoryLinker(detector, nil)
+	linker.AddInstance(makeTestInstance("original"))
+
+	snap := linker.Instances()
+	snap[0] = makeTestInstance("mutated")
+
+	// Internal state should be unchanged.
+	internal := linker.Instances()
+	require.Len(t, internal, 1)
+	assert.Equal(t, "original", internal[0].Title)
+}

--- a/session/history_linker_test.go
+++ b/session/history_linker_test.go
@@ -3,12 +3,14 @@ package session
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tstapler/stapler-squad/session/tmux"
 )
 
 // makeTestInstance creates a minimal Instance for testing (no tmux, not started).
@@ -160,4 +162,69 @@ func TestHistoryLinker_Instances_SnapshotIsIndependent(t *testing.T) {
 	internal := linker.Instances()
 	require.Len(t, internal, 1)
 	assert.Equal(t, "original", internal[0].Title)
+}
+
+// TestHistoryLinker_LinksUUIDToSession verifies that ScanAll populates the session UUID
+// and history file path on a running instance when a matching JSONL file is open.
+func TestHistoryLinker_LinksUUIDToSession(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	uuid := "550e8400-e29b-41d4-a716-446655440002"
+	projectDir := "-Users-test-linker"
+	histPath := filepath.Join(homeDir, ".claude", "projects", projectDir, uuid+".jsonl")
+
+	const sessionName = "link-session"
+	mockExec := &tmux.MockCmdExec{
+		// list-sessions: our session is alive
+		CombinedOutputFunc: func(_ *exec.Cmd) ([]byte, error) {
+			return []byte("staplersquad_link-session\n"), nil
+		},
+		// display-message #{pane_pid}: return a fake PID
+		OutputFunc: func(_ *exec.Cmd) ([]byte, error) {
+			return []byte("12345\n"), nil
+		},
+	}
+	mockSession := tmux.NewTmuxSessionWithDeps(sessionName, "echo", nil, mockExec)
+
+	inspector := &mockProcessInspector{files: []string{histPath}}
+	detector := NewHistoryFileDetector(inspector)
+	linker := NewHistoryLinker(detector, nil)
+
+	inst := makeTestInstance(sessionName)
+	inst.started = true
+	inst.tmuxManager.SetSession(mockSession)
+	linker.AddInstance(inst)
+
+	linker.ScanAll()
+
+	assert.True(t, inst.HasClaudeSession())
+	assert.Equal(t, uuid, inst.claudeSession.SessionID)
+	assert.Equal(t, histPath, inst.HistoryFilePath)
+}
+
+// TestHistoryLinker_IdempotentRelink verifies that correlateSession is a no-op
+// when the instance already has a UUID linked — avoiding spurious proc_pidinfo calls.
+func TestHistoryLinker_IdempotentRelink(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	existingUUID := "550e8400-e29b-41d4-a716-446655440003"
+	histPath := filepath.Join(homeDir, ".claude", "projects", "-test", existingUUID+".jsonl")
+
+	// Inspector returns a different UUID — it must not be called.
+	differentUUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	differentPath := filepath.Join(homeDir, ".claude", "projects", "-test", differentUUID+".jsonl")
+	inspector := &mockProcessInspector{files: []string{differentPath}}
+	detector := NewHistoryFileDetector(inspector)
+	linker := NewHistoryLinker(detector, nil)
+
+	inst := makeTestInstance("already-linked")
+	inst.SetHistoryInfo(existingUUID, histPath)
+	linker.AddInstance(inst)
+
+	linker.ScanAll() // correlateSession should return early (HasClaudeSession == true)
+
+	assert.Equal(t, existingUUID, inst.claudeSession.SessionID, "UUID must not change on re-scan")
+	assert.Equal(t, histPath, inst.HistoryFilePath, "HistoryFilePath must not change on re-scan")
 }

--- a/session/instance.go
+++ b/session/instance.go
@@ -1894,6 +1894,33 @@ func (i *Instance) SetHistoryInfo(conversationUUID, historyFilePath string) {
 	i.HistoryFilePath = historyFilePath
 }
 
+// CaptureCurrentState records the pane's current working directory into WorkingDir.
+// Called during graceful shutdown so cold restore can restart in the right directory.
+// No-op if the session is not started, paused, or the tmux session is dead.
+func (i *Instance) CaptureCurrentState() error {
+	if !i.started || i.Paused() {
+		return nil
+	}
+	if !i.tmuxManager.DoesSessionExist() {
+		return nil
+	}
+	tmuxSession := i.tmuxManager.Session()
+	if tmuxSession == nil {
+		return nil
+	}
+	path, err := tmuxSession.GetPaneCurrentPath()
+	if err != nil {
+		return fmt.Errorf("CaptureCurrentState '%s': %w", i.Title, err)
+	}
+	if path == "" {
+		return nil
+	}
+	i.stateMutex.Lock()
+	defer i.stateMutex.Unlock()
+	i.WorkingDir = path
+	return nil
+}
+
 // CreateCheckpoint captures a named state bookmark for this session.
 // scrollbackSeq should be the current scrollback high-water mark (from ScrollbackManager);
 // pass 0 if the caller does not have access to scrollback state.

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -1633,6 +1633,20 @@ func sanitizeUTF8String(rawBytes []byte) string {
 	return result.String()
 }
 
+// GetPaneCurrentPath returns the current working directory of the tmux pane.
+// This is used by CaptureCurrentState to persist cwd before shutdown for cold restore.
+func (t *TmuxSession) GetPaneCurrentPath() (string, error) {
+	cmd := t.buildTmuxCommand("display-message", "-p", "-t", t.sanitizedName,
+		"#{pane_current_path}")
+
+	output, err := t.cmdExec.Output(cmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pane path for session '%s': %w", t.sanitizedName, err)
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
 // GetPanePID returns the PID of the foreground process in the pane.
 // This is used by HistoryLinker to correlate open files with session records.
 func (t *TmuxSession) GetPanePID() (int32, error) {

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -540,3 +540,42 @@ func TestRegistryKeyUnregisteredOnClose(t *testing.T) {
 			"registry should not contain executor key %q after Close()", key)
 	}
 }
+
+// --- GetPaneCurrentPath tests ---
+
+func TestGetPaneCurrentPath_ReturnsTrimmedPath(t *testing.T) {
+	cmdExec := MockCmdExec{
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			if strings.Contains(cmd.String(), "pane_current_path") {
+				return []byte("/home/user/project\n"), nil
+			}
+			return []byte(""), nil
+		},
+		RunFunc:            func(cmd *exec.Cmd) error { return nil },
+		CombinedOutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte(""), nil },
+	}
+	session := newTmuxSession("capture-test", "echo", NewMockPtyFactory(t), cmdExec, TmuxPrefix)
+
+	path, err := session.GetPaneCurrentPath()
+
+	require.NoError(t, err)
+	// Trailing newline is trimmed.
+	require.Equal(t, "/home/user/project", path)
+}
+
+func TestGetPaneCurrentPath_ReturnsError(t *testing.T) {
+	cmdExec := MockCmdExec{
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("tmux server not running")
+		},
+		RunFunc:            func(cmd *exec.Cmd) error { return nil },
+		CombinedOutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte(""), nil },
+	}
+	session := newTmuxSession("capture-err-test", "echo", NewMockPtyFactory(t), cmdExec, TmuxPrefix)
+
+	path, err := session.GetPaneCurrentPath()
+
+	require.Error(t, err)
+	require.Empty(t, path)
+	require.Contains(t, err.Error(), "failed to get pane path")
+}

--- a/web-app/src/app/page.tsx
+++ b/web-app/src/app/page.tsx
@@ -48,6 +48,9 @@ function HomeContent() {
     resumeSession,
     renameSession,
     restartSession,
+    createCheckpoint,
+    listCheckpoints,
+    forkSession,
     listSessions,
     updateSession,
   } = useSessionService({
@@ -258,6 +261,9 @@ function HomeContent() {
             onRenameSession={renameSession}
             onRestartSession={restartSession}
             onUpdateTags={handleUpdateTags}
+            onCreateCheckpoint={createCheckpoint}
+            onListCheckpoints={listCheckpoints}
+            onForkFromCheckpoint={forkSession}
           />
         )}
       </main>

--- a/web-app/src/components/sessions/SessionCard.module.css
+++ b/web-app/src/components/sessions/SessionCard.module.css
@@ -493,6 +493,57 @@
   cursor: not-allowed;
 }
 
+/* Fork-from-checkpoint dialog */
+.forkEmptyMessage {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  text-align: center;
+  padding: 12px 0;
+}
+
+.forkCheckpointList {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+}
+
+.forkCheckpointItem {
+  padding: 0;
+  border-bottom: 1px solid var(--card-border);
+}
+
+.forkCheckpointItem:last-child {
+  border-bottom: none;
+}
+
+.forkCheckpointLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background 0.15s ease;
+}
+
+.forkCheckpointLabel:hover {
+  background: var(--button-bg-hover);
+}
+
+.forkGitSha {
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  background: var(--button-bg);
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--card-border);
+}
+
 /* Actions toggle button — hidden on desktop, shown on mobile */
 .actionsToggle {
   display: none;

--- a/web-app/src/components/sessions/SessionCard.tsx
+++ b/web-app/src/components/sessions/SessionCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Session, SessionStatus, ReviewItem, InstanceType } from "@/gen/session/v1/types_pb";
+import { Session, SessionStatus, ReviewItem, InstanceType, CheckpointProto } from "@/gen/session/v1/types_pb";
 import { ReviewQueueBadge } from "./ReviewQueueBadge";
 import { GitHubBadge } from "./GitHubBadge";
 import { TagEditor } from "./TagEditor";
@@ -17,6 +17,9 @@ interface SessionCardProps {
   onRename?: (sessionId: string, newTitle: string) => Promise<boolean>;
   onRestart?: (sessionId: string) => Promise<boolean>;
   onUpdateTags?: (sessionId: string, tags: string[]) => void;
+  onCreateCheckpoint?: (sessionId: string, label: string) => Promise<boolean>;
+  onListCheckpoints?: (sessionId: string) => Promise<CheckpointProto[]>;
+  onForkFromCheckpoint?: (sessionId: string, checkpointId: string, newTitle: string) => Promise<Session | null>;
   selectMode?: boolean;
   isSelected?: boolean;
   onToggleSelect?: () => void;
@@ -33,6 +36,9 @@ export function SessionCard({
   onRename,
   onRestart,
   onUpdateTags,
+  onCreateCheckpoint,
+  onListCheckpoints,
+  onForkFromCheckpoint,
   selectMode = false,
   isSelected = false,
   onToggleSelect,
@@ -43,10 +49,20 @@ export function SessionCard({
   const [showActions, setShowActions] = useState(false);
   const [newTitle, setNewTitle] = useState(session.title);
   const [isRestartConfirmOpen, setIsRestartConfirmOpen] = useState(false);
+  const [isCheckpointOpen, setIsCheckpointOpen] = useState(false);
+  const [checkpointLabel, setCheckpointLabel] = useState("");
+  const [isCreatingCheckpoint, setIsCreatingCheckpoint] = useState(false);
+  const [isForkOpen, setIsForkOpen] = useState(false);
+  const [forkCheckpoints, setForkCheckpoints] = useState<CheckpointProto[]>([]);
+  const [forkTitle, setForkTitle] = useState("");
+  const [activeForkCheckpointId, setActiveForkCheckpointId] = useState("");
+  const [isForking, setIsForking] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [renameError, setRenameError] = useState("");
+  const [checkpointError, setCheckpointError] = useState("");
+  const [forkError, setForkError] = useState("");
   const getStatusColor = (status: SessionStatus): string => {
     switch (status) {
       case SessionStatus.RUNNING:
@@ -217,6 +233,70 @@ export function SessionCard({
     setIsRestartConfirmOpen(false);
   };
 
+  const handleCheckpointClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setCheckpointLabel("");
+    setIsCheckpointOpen(true);
+  };
+
+  const handleCheckpointSubmit = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!checkpointLabel.trim()) return;
+    setIsCreatingCheckpoint(true);
+    setCheckpointError("");
+    try {
+      const success = await onCreateCheckpoint?.(session.id, checkpointLabel.trim());
+      if (success) {
+        setIsCheckpointOpen(false);
+      } else {
+        setCheckpointError("Failed to create checkpoint");
+      }
+    } catch (error) {
+      setCheckpointError(error instanceof Error ? error.message : "Failed to create checkpoint");
+    } finally {
+      setIsCreatingCheckpoint(false);
+    }
+  };
+
+  const handleCheckpointCancel = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsCheckpointOpen(false);
+    setCheckpointError("");
+  };
+
+  const handleForkClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const cps = await onListCheckpoints?.(session.id) ?? [];
+    setForkCheckpoints(cps);
+    setForkTitle(`${session.title}-fork`);
+    setActiveForkCheckpointId(cps.length > 0 ? cps[cps.length - 1].id : "");
+    setIsForkOpen(true);
+  };
+
+  const handleForkSubmit = async (checkpointId: string) => {
+    if (!forkTitle.trim() || !checkpointId) return;
+    setIsForking(true);
+    setForkError("");
+    try {
+      const result = await onForkFromCheckpoint?.(session.id, checkpointId, forkTitle.trim());
+      if (result) {
+        setIsForkOpen(false);
+      } else {
+        setForkError("Failed to fork session");
+      }
+    } catch (error) {
+      setForkError(error instanceof Error ? error.message : "Failed to fork session");
+    } finally {
+      setIsForking(false);
+    }
+  };
+
+  const handleForkCancel = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsForkOpen(false);
+    setForkError("");
+  };
+
   return (
     <>
       {isTagEditorOpen && (
@@ -281,6 +361,118 @@ export function SessionCard({
                 onClick={handleRestartCancel}
                 disabled={isRestarting}
                 className={styles.cancelButton}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {isCheckpointOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="checkpointDialogTitle"
+          className={styles.renameDialog}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className={styles.dialogContent}>
+            <h3 id="checkpointDialogTitle">Create Checkpoint</h3>
+            <p>Enter a label for this checkpoint of &quot;{session.title}&quot;:</p>
+            <input
+              type="text"
+              value={checkpointLabel}
+              onChange={(e) => setCheckpointLabel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleCheckpointSubmit(e as unknown as React.MouseEvent);
+                if (e.key === "Escape") handleCheckpointCancel(e as unknown as React.MouseEvent);
+              }}
+              placeholder="e.g. before refactor, working state"
+              className={styles.renameInput}
+              autoFocus
+            />
+            {checkpointError && <span className={styles.errorMessage}>{checkpointError}</span>}
+            <div className={styles.dialogActions}>
+              <button
+                onClick={handleCheckpointSubmit}
+                disabled={isCreatingCheckpoint || !checkpointLabel.trim()}
+                className={styles.submitButton}
+              >
+                {isCreatingCheckpoint ? "Saving..." : "📍 Save Checkpoint"}
+              </button>
+              <button
+                onClick={handleCheckpointCancel}
+                disabled={isCreatingCheckpoint}
+                className={styles.cancelButton}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {isForkOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="forkDialogTitle"
+          className={styles.renameDialog}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className={styles.dialogContent}>
+            <h3 id="forkDialogTitle">Fork Session</h3>
+            <p>Fork &quot;{session.title}&quot; from a checkpoint into a new independent session.</p>
+            <label className={styles.renameLabel}>New session title:</label>
+            <input
+              type="text"
+              value={forkTitle}
+              onChange={(e) => setForkTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") handleForkCancel(e as unknown as React.MouseEvent);
+              }}
+              placeholder="e.g. my-session-fork"
+              className={styles.renameInput}
+              autoFocus
+            />
+            {forkCheckpoints.length === 0 ? (
+              <p className={styles.forkEmptyMessage}>
+                No checkpoints found. Create a checkpoint first.
+              </p>
+            ) : (
+              <ul className={styles.forkCheckpointList}>
+                {forkCheckpoints.map((cp) => (
+                  <li key={cp.id} className={styles.forkCheckpointItem}>
+                    <input
+                      type="radio"
+                      name="forkCheckpoint"
+                      value={cp.id}
+                      checked={activeForkCheckpointId === cp.id}
+                      onChange={() => setActiveForkCheckpointId(cp.id)}
+                      id={`cp-${cp.id}`}
+                    />
+                    <label htmlFor={`cp-${cp.id}`} className={styles.forkCheckpointLabel}>
+                      <strong>{cp.label}</strong>
+                      {cp.gitCommitSha && <span className={styles.forkGitSha}>{cp.gitCommitSha.slice(0, 7)}</span>}
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {forkError && <span className={styles.errorMessage}>{forkError}</span>}
+            <div className={styles.dialogActions}>
+              {forkCheckpoints.length > 0 && (
+                <button
+                  className={styles.submitButton}
+                  onClick={() => handleForkSubmit(activeForkCheckpointId)}
+                  disabled={isForking || !forkTitle.trim() || !activeForkCheckpointId}
+                >
+                  {isForking ? "Forking..." : "Fork from checkpoint"}
+                </button>
+              )}
+              <button
+                onClick={handleForkCancel}
+                className={styles.cancelButton}
+                disabled={isForking}
               >
                 Cancel
               </button>
@@ -527,6 +719,26 @@ export function SessionCard({
           >
             🔄 Restart
           </button>
+          {onCreateCheckpoint && (
+            <button
+              className={styles.actionButton}
+              onClick={handleCheckpointClick}
+              title="Save a named checkpoint of the current session state"
+              aria-label={`Create checkpoint for session ${session.title}`}
+            >
+              📍 Checkpoint
+            </button>
+          )}
+          {onForkFromCheckpoint && (
+            <button
+              className={styles.actionButton}
+              onClick={handleForkClick}
+              title="Fork this session from a checkpoint"
+              aria-label={`Fork session ${session.title} from checkpoint`}
+            >
+              🍴 Fork
+            </button>
+          )}
           <button
             className={styles.actionButton}
             onClick={(e) => {

--- a/web-app/src/components/sessions/SessionList.tsx
+++ b/web-app/src/components/sessions/SessionList.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { AppLink } from "@/components/ui/AppLink";
-import { Session, SessionStatus } from "@/gen/session/v1/types_pb";
+import { Session, SessionStatus, CheckpointProto } from "@/gen/session/v1/types_pb";
 import { SessionCard } from "./SessionCard";
 import { BulkActions } from "./BulkActions";
 import { GroupingStrategy, GroupingStrategyLabels, groupSessions, cycleGroupingStrategy } from "@/lib/grouping/strategies";
@@ -18,6 +18,9 @@ interface SessionListProps {
   onRenameSession?: (sessionId: string, newTitle: string) => Promise<boolean>;
   onRestartSession?: (sessionId: string) => Promise<boolean>;
   onUpdateTags?: (sessionId: string, tags: string[]) => void;
+  onCreateCheckpoint?: (sessionId: string, label: string) => Promise<boolean>;
+  onListCheckpoints?: (sessionId: string) => Promise<CheckpointProto[]>;
+  onForkFromCheckpoint?: (sessionId: string, checkpointId: string, newTitle: string) => Promise<Session | null>;
 }
 
 type SortField = 'lastActivity' | 'name' | 'createdAt' | 'updatedAt';
@@ -71,6 +74,9 @@ export function SessionList({
   onRenameSession,
   onRestartSession,
   onUpdateTags,
+  onCreateCheckpoint,
+  onListCheckpoints,
+  onForkFromCheckpoint,
 }: SessionListProps) {
   // Initialize state from local storage
   const [searchQuery, setSearchQuery] = useState(() => loadFromStorage(STORAGE_KEYS.SEARCH_QUERY, ""));
@@ -510,6 +516,9 @@ export function SessionList({
                       onRename={onRenameSession}
                       onRestart={onRestartSession}
                       onUpdateTags={onUpdateTags}
+                      onCreateCheckpoint={onCreateCheckpoint}
+                      onListCheckpoints={onListCheckpoints}
+                      onForkFromCheckpoint={onForkFromCheckpoint}
                       selectMode={selectMode}
                       isSelected={selectedSessions.has(session.id)}
                       onToggleSelect={() => handleToggleSession(session.id)}

--- a/web-app/src/lib/hooks/useSessionService.ts
+++ b/web-app/src/lib/hooks/useSessionService.ts
@@ -49,6 +49,9 @@ interface UseSessionServiceReturn {
   renameSession: (id: string, newTitle: string) => Promise<boolean>;
   restartSession: (id: string) => Promise<boolean>;
   acknowledgeSession: (id: string) => Promise<boolean>;
+  createCheckpoint: (sessionId: string, label: string) => Promise<boolean>;
+  listCheckpoints: (sessionId: string) => Promise<import("@/gen/session/v1/types_pb").CheckpointProto[]>;
+  forkSession: (sessionId: string, checkpointId: string, newTitle: string) => Promise<Session | null>;
 
   // Real-time updates
   watchSessions: (options?: { categoryFilter?: string; statusFilter?: SessionStatus }) => void;
@@ -287,6 +290,59 @@ export function useSessionService(
     [dispatch]
   );
 
+  // Create checkpoint for a session
+  const createCheckpoint = useCallback(
+    async (sessionId: string, label: string): Promise<boolean> => {
+      if (!clientRef.current) return false;
+
+      dispatch(setError(null));
+
+      try {
+        await clientRef.current.createCheckpoint({ sessionId, label });
+        return true;
+      } catch (err) {
+        dispatch(setError(err instanceof Error ? err.message : "Failed to create checkpoint"));
+        return false;
+      }
+    },
+    [dispatch]
+  );
+
+  // List checkpoints for a session
+  const listCheckpoints = useCallback(
+    async (sessionId: string) => {
+      if (!clientRef.current) return [];
+      try {
+        const response = await clientRef.current.listCheckpoints({ sessionId });
+        return response.checkpoints;
+      } catch {
+        return [];
+      }
+    },
+    []
+  );
+
+  // Fork a session from a checkpoint
+  const forkSession = useCallback(
+    async (sessionId: string, checkpointId: string, newTitle: string): Promise<Session | null> => {
+      if (!clientRef.current) return null;
+
+      dispatch(setError(null));
+
+      try {
+        const response = await clientRef.current.forkSession({ sessionId, checkpointId, newTitle });
+        if (response.session) {
+          dispatch(upsertSession(response.session));
+        }
+        return response.session ?? null;
+      } catch (err) {
+        dispatch(setError(err instanceof Error ? err.message : "Failed to fork session"));
+        return null;
+      }
+    },
+    [dispatch]
+  );
+
   // Acknowledge session (skip from review queue)
   const acknowledgeSession = useCallback(
     async (id: string): Promise<boolean> => {
@@ -424,6 +480,9 @@ export function useSessionService(
     renameSession,
     restartSession,
     acknowledgeSession,
+    createCheckpoint,
+    listCheckpoints,
+    forkSession,
     watchSessions,
     stopWatching,
   };


### PR DESCRIPTION
## Summary
## Summary

While editing a backlog item **whose triage is still running**, acceptance criteria you add in the edit form disappear every ~5 seconds. You can add a criterion and type into it, but a moment later the form snaps back to only the already-saved criteria and your unsaved rows are gone.

Observed on `v1.31.1` (built from source), macOS, Chrome. Reproduced from a screen recording; timeline of the edit form:

- 2 rows: `Define the watermelon signal` (saved) + one being typed
- 3 rows: typed `Encode Fix Version = …` and clicked **+ Add criterion**
- ~4s later: **snaps back to just the 1 saved row** — the typed row and the new row are gone
- start re-adding → happens again on the next poll tick

## Root cause

`BacklogItemDetail` polls the server every 5s while triage is running, and `load()` toggles a `loading` flag on every fetch:

```ts
// BacklogItemDetail.tsx
const load = useCallback(async () => {
  setLoading(true);                              // ← flips on every po [truncated]

(Backlog item: 12601982-3bf4-4207-b59e-a2ffbc7aeeeb)

## Test plan
- [x] BacklogItemDetail's full-screen loading placeholder (if (loading && !item)) only renders on the initial load — background polls with an existing item must not unmount the view or any child form [Confirmed on origin/main tip (2e26666f): guard is `if (loading && !item)` in BacklogItemDetail.tsx:353]
- [x] The triage background poll (setInterval every 5s while triageStatus === 'running') is suspended while editMode === true [Confirmed poll guard `if (item?.triageStatus !== "running" || editMode) return;` at BacklogItemDetail.tsx:103]
- [x] A user can add acceptance-criteria rows in the edit form during an active triage poll and still see the unsaved rows after a 5s poll tick [Verified via regression test: unsaved AC row text survives 10s of poll ticks during editMode]
- [x] Regression test web-app/src/components/backlog/BacklogItemDetail.regression.test.tsx exists and passes via `cd web-app && npx jest --testPathPatterns BacklogItemDetail.regression` [npx jest --testPathPatterns BacklogItemDetail.regression -> Tests: 2 passed, 2 total]
- [x] No regression to existing BacklogItemDetail/BacklogItemForm/BacklogItemPanel test suites (`npx jest --testPathPatterns "BacklogItem"`) [npx jest --testPathPatterns "BacklogItem" -> Tests: 9 passed, 9 total (incl. new clientKey tests)]
- [x] (Optional/nit) BacklogItemForm's acceptance-criteria rows use a stable client-side clientKey (crypto.randomUUID()) instead of array index i as the React key, verified by a new test asserting DOM node and focus identity survive row removal, with clientKey stripped before the onSubmit payload [Impleme [truncated]
- [x] The stapler-squad service instance relevant to the original bug reporter is confirmed to be running a build containing commit 6ef8164b (or is updated via make install-service) before the backlog item is treated as resolved for the reporter [Running service reports `stapler-squad version 1.37.0-16-g6 [truncated]
- [x] The BacklogItemDetail.regression.test.tsx / BacklogItem* suite is wired into an existing CI workflow, or an explicit immediate follow-up backlog item is filed to do so, closing the 'verified once, never guarded again' gap (CI currently runs zero Jest tests) [CI confirmed to run zero Jest invocations [truncated]
