### PR TITLE
fix(terminal): cursor-sync post-resize snapshots so TUI repaints stop stacking

### DIFF
--- a/server/services/connectrpc_websocket.go
+++ b/server/services/connectrpc_websocket.go
@@ -251,6 +251,20 @@ func (h *ConnectRPCWebSocketHandler) markSnapshotDirty(sessionID string) {
 	})
 }
 
+// invalidateSnapshot drops a session's cached snapshot so the next getOrRefreshSnapshot
+// re-captures from tmux.
+//
+// This exists for callers that have just done something making the cached content stale
+// by construction, rather than merely suspecting new output — specifically the ±1 resize
+// nudge in streamViaControlMode, which repaints the TUI at the client's dimensions.
+// markSnapshotDirty cannot cover that case: its only call sites live in the
+// output-forwarding goroutine, which does not start until after the initial snapshot has
+// already been captured and sent, so a nudge-triggered repaint would otherwise leave the
+// cache "clean" and serve content captured at the pre-nudge dimensions.
+func (h *ConnectRPCWebSocketHandler) invalidateSnapshot(sessionID string) {
+	h.snapshotCache.Delete(sessionID)
+}
+
 // getOrRefreshSnapshot returns a cached snapshot if clean, otherwise calls captureFn to refresh.
 func (h *ConnectRPCWebSocketHandler) getOrRefreshSnapshot(
 	sessionID string,
@@ -624,6 +638,16 @@ func (h *ConnectRPCWebSocketHandler) streamViaControlMode(stream *connectWebSock
 
 		log.Info("[streamViaControlMode] handshake dimensions, forcing redraw via nudge", "cols", targetCols, "rows", targetRows)
 
+		// The nudge below repaints the TUI at targetCols x targetRows, so any snapshot
+		// cached from an earlier connection is stale by construction — it was captured at
+		// the previous dimensions. Drop it here so the capture at the end of this function
+		// re-reads the pane. Without this, getOrRefreshSnapshot sees a "clean" entry (the
+		// repaint cannot mark it dirty: markSnapshotDirty is only reachable from the
+		// output-forwarding goroutine, which starts later) and serves the old-dimension
+		// content, which xterm.js then paints live frames over — producing rows composited
+		// from two different wrap widths, duplicated table rows and stray glyphs.
+		h.invalidateSnapshot(sessionID)
+
 		// Nudge to (cols-1) so tmux always sends SIGWINCH regardless of current size
 		if targetCols > 1 {
 			if resizeErr := instance.ResizePTY(targetCols-1, targetRows); resizeErr != nil {
@@ -634,9 +658,19 @@ func (h *ConnectRPCWebSocketHandler) streamViaControlMode(stream *connectWebSock
 		if err := instance.ResizePTY(targetCols, targetRows); err != nil {
 			log.Error("[streamViaControlMode] failed to resize", "err", err)
 		} else {
-			// Wait for TUI to complete its full redraw using quiescence detection
+			// Wait for the TUI to complete its full redraw before capturing.
+			//
+			// NOTE: nothing signals quiescenceCh yet at this point — its only producer is
+			// the output-forwarding goroutine started further down — so this currently
+			// degenerates to a fixed quietFor settle rather than real quiescence
+			// detection, and the timeout warning below cannot fire. quietFor is therefore
+			// set to match the 200ms post-nudge settle that streamViaTmuxCapture uses, so
+			// a slow repaint is less likely to be captured half-drawn. Making this
+			// genuinely quiescence-driven requires subscribing a producer before the
+			// nudge (the previous subscription was removed for performance — see the
+			// quiescenceCh comment above).
 			quiescenceStart := time.Now()
-			waitForQuiescence(quiescenceCh, 500*time.Millisecond, 50*time.Millisecond)
+			waitForQuiescence(quiescenceCh, 500*time.Millisecond, 200*time.Millisecond)
 			if elapsed := time.Since(quiescenceStart); elapsed >= 500*time.Millisecond-5*time.Millisecond {
 				log.Warn("[streamViaControlMode] initial quiescence timed out; session may be stalled", "elapsed", elapsed.Round(time.Millisecond), "session", sessionID)
 			}
@@ -923,11 +957,21 @@ func (h *ConnectRPCWebSocketHandler) streamViaControlMode(stream *connectWebSock
 				// (R1.3 — post-resize snapshot).
 				if snapContent, snapErr := instance.CapturePaneContentRaw(); snapErr == nil && snapContent != "" {
 					h.markSnapshotDirty(sessionID)
+					// withCursorSync is required here for the same reason as every other
+					// snapshot send (see its doc comment): prepareSnapshotContent strips the
+					// absolute-cursor codes, so without a trailing CUP the xterm.js cursor is
+					// left wherever the last snapshot byte landed while tmux's cursor sits at
+					// the process's working position. Relative cursor-up redraws from an Ink
+					// TUI then rewind to the wrong row and each repaint stacks below the last
+					// instead of overwriting it. This was the one snapshot send of five that
+					// omitted it, so resizing — the very action users take to clear a garbled
+					// pane — left the cursor desynced and made interactive menus billow.
+					fullContent := withCursorSync(ansiSnapshotPrefix+prepareSnapshotContent(snapContent), instance)
 					snapMsg := &sessionv1.TerminalData{
 						SessionId: sessionID,
 						Data: &sessionv1.TerminalData_Output{
 							Output: &sessionv1.TerminalOutput{
-								Data: []byte(ansiSnapshotPrefix + prepareSnapshotContent(snapContent)),
+								Data: []byte(fullContent),
 							},
 						},
 					}
@@ -1306,12 +1350,15 @@ func (h *ConnectRPCWebSocketHandler) streamShellViaControlMode(stream *connectWe
 				}
 
 				if snapContent, snapErr := shellSess.CapturePaneContentRaw(); snapErr == nil && snapContent != "" {
+					// Same cursor-sync requirement as the session post-resize snapshot —
+					// see withCursorSync's doc comment.
+					fullContent := withCursorSync(ansiSnapshotPrefix+prepareSnapshotContent(snapContent), cursorTarget)
 					snapMsg := &sessionv1.TerminalData{
 						SessionId: sessionID,
 						ShellId:   shellID,
 						Data: &sessionv1.TerminalData_Output{
 							Output: &sessionv1.TerminalOutput{
-								Data: []byte(ansiSnapshotPrefix + prepareSnapshotContent(snapContent)),
+								Data: []byte(fullContent),
 							},
 						},
 					}

--- a/server/services/connectrpc_websocket_test.go
+++ b/server/services/connectrpc_websocket_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -756,5 +757,148 @@ func TestStripAnsiCodesHandlesNonLetterCSITerminators(t *testing.T) {
 				t.Errorf("stripAnsiCodes(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestInvalidateSnapshotForcesRecapture verifies that invalidateSnapshot causes the
+// next getOrRefreshSnapshot to re-run captureFn.
+//
+// Regression guard for garbled-terminal-on-connect: streamViaControlMode performs a
+// ±1 resize nudge to force the TUI to repaint, which makes any cached capture-pane
+// content stale by construction (it was captured at the pre-nudge dimensions). The
+// nudge cannot rely on markSnapshotDirty to invalidate it, because markSnapshotDirty
+// is only called from the output-forwarding goroutine, which does not start until
+// after the initial snapshot has already been captured and sent.
+func TestInvalidateSnapshotForcesRecapture(t *testing.T) {
+	h := NewConnectRPCWebSocketHandler(nil, nil, nil)
+	calls := 0
+	captureFn := func() (string, error) {
+		calls++
+		return fmt.Sprintf("content%d", calls), nil
+	}
+
+	// Populate the cache (simulates a snapshot captured at the previous dimensions).
+	if _, err := h.getOrRefreshSnapshot("sess1", captureFn); err != nil {
+		t.Fatalf("unexpected error priming cache: %v", err)
+	}
+
+	// A resize nudge just forced a repaint — the cached content is now stale.
+	h.invalidateSnapshot("sess1")
+
+	got, err := h.getOrRefreshSnapshot("sess1", captureFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("captureFn called %d times after invalidate, want 2 (stale snapshot was served)", calls)
+	}
+	if got != "content2" {
+		t.Errorf("got %q after invalidate, want %q", got, "content2")
+	}
+}
+
+// TestInvalidateSnapshotOnUnknownSessionIsNoOp verifies invalidating an absent
+// session neither panics nor creates a cache entry.
+func TestInvalidateSnapshotOnUnknownSessionIsNoOp(t *testing.T) {
+	h := NewConnectRPCWebSocketHandler(nil, nil, nil)
+
+	h.invalidateSnapshot("nonexistent-session")
+
+	if _, ok := h.snapshotCache.Load("nonexistent-session"); ok {
+		t.Error("invalidateSnapshot created a cache entry for an unknown session")
+	}
+}
+
+// TestWaitForQuiescenceReturnsAfterQuietForWhenNoProducer documents that
+// waitForQuiescence degenerates to a fixed quietFor sleep when nothing ever signals
+// the channel. streamViaControlMode's initial call is in exactly that situation: the
+// only producer (the output-forwarding goroutine) starts after the call site, so the
+// "wait for the TUI to finish redrawing" is really a short fixed delay and its
+// timeout warning can never fire.
+//
+// This test pins the current semantics so the trap is visible; making the initial
+// wait genuinely quiescence-driven requires subscribing a producer before the nudge.
+func TestWaitForQuiescenceReturnsAfterQuietForWhenNoProducer(t *testing.T) {
+	ch := make(chan struct{}, 16) // no producer, mirroring the initial-nudge call site
+
+	start := time.Now()
+	waitForQuiescence(ch, 500*time.Millisecond, 50*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if elapsed >= 400*time.Millisecond {
+		t.Errorf("waited %v — expected to return after quietFor (~50ms), not the 500ms timeout", elapsed)
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("returned after %v — expected to wait at least quietFor (~50ms)", elapsed)
+	}
+}
+
+// fakeCursorPositioner is a cursorPositioner stub for withCursorSync tests.
+type fakeCursorPositioner struct {
+	x, y int
+	err  error
+}
+
+func (f fakeCursorPositioner) GetPaneCursorPosition() (int, int, error) {
+	return f.x, f.y, f.err
+}
+
+// TestWithCursorSyncAppendsOneBasedCUP verifies the trailing CUP escape converts
+// tmux's 0-based cursor coords to CUP's 1-based row;col form.
+func TestWithCursorSyncAppendsOneBasedCUP(t *testing.T) {
+	got := withCursorSync("content", fakeCursorPositioner{x: 4, y: 9})
+	want := "content\x1b[10;5H"
+	if got != want {
+		t.Errorf("withCursorSync = %q, want %q", got, want)
+	}
+}
+
+// TestWithCursorSyncPassesThroughOnErrorOrNilTarget verifies content is returned
+// unchanged when the cursor position is unavailable.
+func TestWithCursorSyncPassesThroughOnErrorOrNilTarget(t *testing.T) {
+	if got := withCursorSync("content", nil); got != "content" {
+		t.Errorf("nil target: got %q, want unchanged", got)
+	}
+	failing := fakeCursorPositioner{x: 1, y: 1, err: fmt.Errorf("pane gone")}
+	if got := withCursorSync("content", failing); got != "content" {
+		t.Errorf("error target: got %q, want unchanged", got)
+	}
+}
+
+// TestAllSnapshotSendsUseCursorSync guards the invariant that every full-screen
+// snapshot send ends with a cursor-sync.
+//
+// prepareSnapshotContent deliberately strips absolute-cursor codes, so a snapshot
+// written without a trailing CUP leaves xterm.js's cursor desynced from the tmux pane
+// cursor; relative cursor-up redraws from an Ink TUI then rewind to the wrong row and
+// each repaint stacks below the previous one ("billowing"). The post-resize snapshot
+// omitted this call, which meant resizing to clear a garbled pane left interactive
+// menus stacking their previously highlighted option.
+//
+// This is a source-level guard because the snapshot sends live inside long-lived
+// streaming goroutines with no injectable seam. If those are ever refactored behind a
+// single snapshot-composition helper, replace this with a direct test of that helper.
+func TestAllSnapshotSendsUseCursorSync(t *testing.T) {
+	src, err := os.ReadFile("connectrpc_websocket.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+
+	for i, line := range strings.Split(string(src), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		// Snapshot frames are composed as <prefix> + prepareSnapshotContent(...).
+		if !strings.Contains(trimmed, "prepareSnapshotContent(") {
+			continue
+		}
+		// Skip the helper's own declaration.
+		if strings.HasPrefix(trimmed, "func prepareSnapshotContent") {
+			continue
+		}
+		if !strings.Contains(trimmed, "withCursorSync(") {
+			t.Errorf("connectrpc_websocket.go:%d composes a snapshot without withCursorSync:\n\t%s", i+1, trimmed)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Two of the five full-screen snapshot sends — the **post-resize** ones in `streamViaControlMode` and `streamShellViaControlMode` — omitted `withCursorSync`. `withCursorSync`'s own doc comment describes exactly what that produces:

> The mismatch causes subsequent cursor-up sequences emitted by the process to rewind to the wrong lines — producing the "billowing" effect where each animation frame stacks below the previous one instead of overwriting it.

`prepareSnapshotContent` deliberately strips absolute-cursor codes, so without a trailing CUP the xterm.js cursor is left wherever the last snapshot byte landed while tmux's cursor sits at the running process's working position.

**The nasty part:** a resize is exactly what users do to clear an already-garbled pane. So the recovery action itself desynced the cursor, and interactive menus then stranded every previously-highlighted option as the user arrowed through them.

Refs `tstapler/stapler-squad#253` (still open; the copies in this repo, #154/#164, were migrated with no fix commit).

## Evidence

From a 22s screen recording on v1.40.0 (macOS 26, Chrome), sampled every 2s — the ordering matches the causal chain above precisely:

| Frames | State |
|---|---|
| 1–4 | Stale-cell corruption: glyph-level interleaving of two wrap widths (`Letlmesverify beforefI claim anything:` over `Let me verify before I claim anything:`), a 5-row table painted 2–3× at different offsets, stray glyphs in the left gutter, rows overflowing the right edge |
| 4 | Cursor moves to the pane header controls — pane resized |
| 5–6 | **Completely clean.** No reconnect occurred; the stream read `Connected` throughout |
| 7–11 | Screen stays clean, but arrowing a numbered menu **accumulates** stale copies — 2 stranded lines growing to 4+, plus a duplicate `Esc to cancel` |

Corrupt → resize → clean → menus start billowing. Frames 5–11 are the post-resize snapshot path, i.e. the code this PR fixes.

## Changes

| Change | Confidence it was the user-visible cause |
|---|---|
| `withCursorSync` added to both post-resize snapshot sends | **High** — matches the documented symptom and the frame ordering |
| Initial post-nudge settle 50ms → 200ms, matching `streamViaTmuxCapture` | Medium — makes capturing a half-drawn repaint less likely |
| New `invalidateSnapshot()`, called after the ±1 resize nudge | **Low as a cause** — hardening; see below |

On the third item, being straight about it: `[SnapshotCache] serving cached snapshot` appears **zero** times across the reporter's entire log history, because any output between connects marks the entry dirty. The stale-serve window is real but narrow — it needs a reconnect with no intervening output, where the nudge has since reflowed the pane at different dimensions. The nudge can't rely on `markSnapshotDirty` to cover it: that function's only call sites live in the output-forwarding goroutine, which doesn't start until after the initial snapshot has already been captured and sent. Included as correctness, not as the headline fix.

## A latent trap this surfaced (not fixed here)

At the initial-nudge call site, **nothing has ever signalled `quiescenceCh`** — its only producer is that same output-forwarding goroutine, started further down. So:

```go
waitForQuiescence(quiescenceCh, 500*time.Millisecond, 50*time.Millisecond)
```

...silently degenerates to a fixed `quietFor` sleep, and the `elapsed >= 500ms-5ms` timeout warning below it can never fire. The comment above it claims it waits for the TUI to finish redrawing; it does not. Raising `quietFor` to 200ms is a mitigation, not a fix — genuine quiescence detection needs a subscriber established *before* the nudge. The inline-signalling comment suggests this was introduced when the separate subscription was removed for performance ("waking up 212K+ times per stream"). Flagged in a comment and pinned by a test rather than restructured, since that's a concurrency change I couldn't integration-test.

`TestWaitForQuiescenceReturnsAfterQuietForWhenNoProducer` documents the current semantics so the trap is visible instead of silent.

## Tests

- `withCursorSync` had **no test coverage at all**; added unit tests for the 1-based CUP conversion and the nil/error passthrough.
- `TestAllSnapshotSendsUseCursorSync` — a source-level guard asserting every `prepareSnapshotContent(...)` composition is wrapped in `withCursorSync`. **This guard is what surfaced the second missing call site** in the shell path, which I had otherwise missed. If the snapshot sends are ever refactored behind a single composition helper, replace it with a direct test of that helper.
- `invalidateSnapshot` recapture + unknown-session no-op.

Verified: `go build ./...`, `go vet ./server/services`, `gofmt` clean, and the full `server/services` suite green.

**Testing limitations, stated plainly:**
- `make ci` / `make lint` were not run — `golangci-lint` isn't installed in this environment.
- No e2e test added. `tests/e2e/terminal-resize.spec.ts` covers the resize path but asserts the *absence of duplicate lines*, not cursor position, so it wouldn't have caught this; asserting cursor sync needs a new harness.
- The corruption is intermittent and I could not reproduce it on demand, so this is verified by code reasoning + the recording, **not** by observing the bug disappear. Worth a second opinion on the confidence table.

## Not addressed — the deeper issue behind the garbling itself

Symptom A (the corruption in frames 1–4) has a root cause this PR does **not** fix: there is no full-screen resync on the live path at all.

- The only `terminal.clear()` reachable from the stream is `TerminalStreamManager.writeInitialContent()`, gated on a `ScrollbackResponse` that is never emitted — because **`ScrollbackManager.AppendOutput` is never called anywhere** in non-test code. So xterm.js is never cleared for the lifetime of a pane.
- `useTerminalFlowControl.requestFullResync` is implemented and throttled but **not re-exported from `useTerminalStream`** — no component can call it.
- The post-resize `CurrentPaneRequest` is ignored by the control-mode input loop.
- Client `cols` and tmux width can diverge, and the server detects it (`"CRITICAL: dimensions still mismatched after resize"`, `"CLAUDE CODE WIDTH BUG DETECTED"`) but only logs and captures anyway; `ResizeQuiescence.Cols/Rows` is discarded client-side.
- `RedrawThrottler` keeps only the last chunk in a 33ms window, so the erase half of a two-frame repaint can be dropped.
- The BUG-013 ED3 filter was removed (`EscapeSequenceParser.ts`: `// No sequence stripping - xterm.js v6 handles ED2+ED3 correctly`) and the tests inverted to assert passthrough, while `ADR-002-xterm-upgrade-6.0.md` still states the filter "remains necessary even with 6.0".

Happy to take any of those in a follow-up. Making resize the *only* full-resync path is what turns any single desync into a permanently broken pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
